### PR TITLE
Fix Cleric Disapproval Table Dropdown

### DIFF
--- a/module/dcc.js
+++ b/module/dcc.js
@@ -191,7 +191,7 @@ function registerTables () {
               name: value.name,
               path: `${packName}.${value.name}`
             }
-          })
+          }
         }
       }
     }

--- a/module/dcc.js
+++ b/module/dcc.js
@@ -186,7 +186,7 @@ function registerTables () {
         const pack = game.packs.get(packName)
         if (pack) {
           await pack.getIndex()
-          pack.index.forEach(function (value, key, map) {
+          for (const [key, value] of pack.index.entries()) {
             CONFIG.DCC.disapprovalTables[key] = {
               name: value.name,
               path: `${packName}.${value.name}`


### PR DESCRIPTION
Fixed issue #253 because iterating over a map in this manner resulted in the variable `key` being `undefined`. Now the variable `key` will be set to the `_id` that was generated for the compendium entry.