### PR TITLE
Fix Font Size for AC and HP values

### DIFF
--- a/styles/dcc.scss
+++ b/styles/dcc.scss
@@ -337,7 +337,7 @@ $duvall: 'DuvallSmallCaps', 'Palatino Linotype', serif;
 }
 
 .dcc .ac .ac-value {
-  font-size: 1.6rem;
+  font-size: 1.3rem;
   height: 25px;
   margin: 21px auto 0;
   width: 35px;
@@ -490,7 +490,7 @@ $duvall: 'DuvallSmallCaps', 'Palatino Linotype', serif;
 }
 
 .dcc .hp .current {
-  font-size: 1.6rem;
+  font-size: 1.3rem;
   height: 25px;
   margin: 31px auto 0 23px;
   width: 35px;


### PR DESCRIPTION
I noticed that the font size for the current HP and AC inputs is too big to fit. (atleast for me)
If this only occurs on resolutions > 1080p you can ignore this fix (as I already changed it on my side^^)
In comparison:

## Before (1.6rem)
![image](https://user-images.githubusercontent.com/31926457/124380424-d1fe5300-dcbc-11eb-8ed4-53ea99c920ae.png)

## After (1.3rem)
![image](https://user-images.githubusercontent.com/31926457/124380471-01ad5b00-dcbd-11eb-9574-d6347654de53.png)
