### PR TITLE
Change speaker to work with modules like Chat Portrait

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -463,14 +463,14 @@ class DCCActor extends Actor {
     const damageRollResult = await this.rollDamage(weapon, options)
 
     // Speaker object for the chat cards
-    const speaker = { alias: this.name, id: this.id }
+    const speaker = ChatMessage.getSpeaker({ actor: this })
 
     // Output the results
     if (options.displayStandardCards) {
       // Attack roll card
       if (attackRollResult.rolled) {
         attackRollResult.roll.toMessage({
-          speaker: ChatMessage.getSpeaker({ actor: this }),
+          speaker: speaker,
           flavor: game.i18n.format(options.backstab ? 'DCC.BackstabRoll' : 'DCC.AttackRoll', { weapon: weapon.name })
         })
       } else {
@@ -490,7 +490,7 @@ class DCCActor extends Actor {
       // Damage roll card
       if (damageRollResult.rolled) {
         damageRollResult.roll.toMessage({
-          speaker: ChatMessage.getSpeaker({ actor: this }),
+          speaker: speaker,
           flavor: game.i18n.format('DCC.DamageRoll', { weapon: weapon.name })
         })
       } else {
@@ -807,7 +807,7 @@ class DCCActor extends Actor {
    * @param {Number} multiplier     Damage multiplier
    */
   async applyDamage (damageAmount, multiplier) {
-    const speaker = { alias: this.name, id: this.id }
+    const speaker = ChatMessage.getSpeaker({ actor: this })
 
     // Calculate damage amount and current hit points
     const amount = damageAmount * multiplier


### PR DESCRIPTION
**Disclaimer**: I'm not aware why there was decision to create custom speaker for chat messages.

Creating custom speaker object makes modules like Chat Portrait fail to find tokens/portraits for speaker used. As far as I've seen in code it is mixed bag already. This is attempt to unify it and fix cooperation with Chat Portrait. (keep in mind disclaimer, I have no idea why it was done this way)