### PR TITLE
Fix automatic deletion of empty items.

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -134,7 +134,7 @@ class DCCActorSheet extends ActorSheet {
     for (const i of inventory) {
       // Remove physical items with zero quantity
       if (removeEmptyItems && i.data.quantity !== undefined && i.data.quantity <= 0) {
-        this.actor.deleteOwnedItem(i.id, {})
+        this.actor.deleteOwnedItem(i._id, {})
         continue
       }
 


### PR DESCRIPTION
Automatic deletion of empty items fails, as the ID of the item in the data-table is '_id' (and not 'id').