### PR TITLE
New Setting: Automatically adds warrior's level to the initiative value

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -551,6 +551,8 @@
   "DCC.SettingAutomateClericDisapprovalHint": "Automatically apply disapproval range increases and roll disapproval results for Clerics. Applies to the Cleric's spell-like abilities and to spells with Casting Mode set to 'Cleric'.",
   "DCC.SettingAutomateFleetingLuck": "Automate Fleeting Luck",
   "DCC.SettingAutomateFleetingLuckHint": "Automatically track Fleeting Luck based on roll results",
+  "DCC.SettingAutomateWarriorInitiative": "Automate Warrior's Initiative",
+  "DCC.SettingAutomateWarriorInitiativeHint": "Automatically add warrior's level to the initiative value",
   "DCC.SettingAutomateWizardSpellLoss": "Automate Wizard/Elf Spell Loss",
   "DCC.SettingAutomateWizardSpellLossHint": "Automatically mark spells as lost when a casting fails. Applies to the Wizard/Elf Spell Check button and spells with Casting Mode set to 'Wizard'.",
   "DCC.SettingCriticalHitsCompendium": "Critical Hits Compendium",

--- a/lang/en.json
+++ b/lang/en.json
@@ -547,6 +547,8 @@
   "DCC.SenseIV": "Infravision",
   "DCC.SenseUS": "Underground Skills",
   "DCC.Senses": "Senses",
+  "DCC.SettingAutomateCombatModifier": "Automate Combat Modifiers",
+  "DCC.SettingAutomateCombatModifierHint": "Automatically add Strength/Agility modifier to attack and hit rolls",
   "DCC.SettingAutomateClericDisapproval": "Automate Cleric Disapproval",
   "DCC.SettingAutomateClericDisapprovalHint": "Automatically apply disapproval range increases and roll disapproval results for Clerics. Applies to the Cleric's spell-like abilities and to spells with Casting Mode set to 'Cleric'.",
   "DCC.SettingAutomateFleetingLuck": "Automate Fleeting Luck",

--- a/module/actor.js
+++ b/module/actor.js
@@ -362,6 +362,11 @@ class DCCActor extends Actor {
       }
     ]
 
+    // Initiative: A warrior adds his class level to his initiative rolls.
+    if ((token._actor.system.class.className == "Warrior") && (game.settings.get('dcc', 'automateWarriorInititative'))) {
+      terms[1].formula = terms[1].formula + " + " + token._actor.system.details.level.value;
+    }
+
     const roll = await game.dcc.DCCRoll.createRoll(terms, this.getRollData(), options)
 
     // evaluate roll, otherwise roll.total is undefined

--- a/module/actor.js
+++ b/module/actor.js
@@ -1019,6 +1019,24 @@ class DCCActor extends Actor {
       })
     }
 
+    // Add Strength or Agility modifier to attack rolls
+    let modifier;
+    let modifierLabel;
+    if ((this.system.class.className) && (game.settings.get('dcc', 'automateCombatModifier'))) {
+      if (weapon.system.melee) {
+          modifier = " + " + this.system.abilities.str.mod;
+          modifierLabel = "DCC.AbilityStr";
+      } else {
+          modifier = " + " + this.system.abilities.agl.mod;
+          modifierLabel = "DCC.AbilityAgl";
+      }
+      terms.push({
+              type: 'Modifier',
+              label: game.i18n.localize(modifierLabel),
+              formula: modifier
+      })
+  }    
+
     /* Roll the Attack */
     const rollOptions = Object.assign(
       {
@@ -1084,6 +1102,24 @@ class DCCActor extends Actor {
         formula
       }
     ]
+
+    // Add Strength or Agility modifier to damage rolls
+    let modifier;
+    let modifierLabel;
+    if ((this.system.class.className) && (game.settings.get('dcc', 'automateCombatModifier'))) {
+      if (weapon.system.melee) {
+          modifier = " + " + this.system.abilities.str.mod;
+          modifierLabel = "DCC.AbilityStr";
+      } else {
+          modifier = " + " + this.system.abilities.agl.mod;
+          modifierLabel = "DCC.AbilityAgl";
+      }
+      terms.push({
+              type: 'Modifier',
+              label: game.i18n.localize(modifierLabel),
+              formula: modifier
+      })
+  }
 
     /* Roll the damage */
     const rollOptions = Object.assign(

--- a/module/settings.js
+++ b/module/settings.js
@@ -234,4 +234,16 @@ export const registerSystemSettings = async function () {
     default: true,
     config: true
   })
+
+    /**
+   * Automatically adds warrior's level to the initiative value
+   */
+    game.settings.register('dcc', 'automateWarriorInititative', {
+      name: 'DCC.SettingAutomateWarriorInitiative',
+      hint: 'DCC.SettingAutomateWarriorInitiativeHint',
+      scope: 'world',
+      type: Boolean,
+      default: false,
+      config: true
+    })
 }

--- a/module/settings.js
+++ b/module/settings.js
@@ -246,4 +246,16 @@ export const registerSystemSettings = async function () {
       default: false,
       config: true
     })
+
+  /**
+   * Automatically add Strength/Agility modifier to attack and hit rolls
+   */
+  game.settings.register('dcc', 'automateCombatModifier', {
+    name: 'DCC.SettingAutomateCombatModifier',
+    hint: 'DCC.SettingAutomateCombatModifierHint',
+    scope: 'world',
+    type: Boolean,
+    default: false,
+    config: true
+  })
 }


### PR DESCRIPTION
As written in the quick start rules on page 13: "Initiative: A warrior adds his class level to his initiative rolls."