### PR TITLE
Allow for import of Puprle Sorcerer character sheet with no weapons

### DIFF
--- a/module/pc-parser.js
+++ b/module/pc-parser.js
@@ -334,7 +334,7 @@ function _parsePlainPCToJSON (pcString) {
   pcObject.hitPoints = _firstMatch(pcString.match(/HP:\s+(\d+)[;\n$]/))
 
   const weaponString = pcString.match(/Weapon:\s+(.*)[;\n$]/)
-  const weapon = weaponString.length > 0 ? _parseWeapon(weaponString[1]) : null
+  const weapon = (weaponString && weaponString.length > 0) ? _parseWeapon(weaponString[1]) : null
   if (weapon) {
     pcObject.weapon = weapon.name
     pcObject.attackMod = weapon.attackMod


### PR DESCRIPTION
This PR allows for 0-level, plain-text character sheets generated by Purple Sorcerer with **no weapons** to be imported.