### PR TITLE
Add extra dice to Foundry's Dice Configuration menu

### DIFF
--- a/module/dcc.js
+++ b/module/dcc.js
@@ -53,6 +53,24 @@ Hooks.once('init', async function () {
   CONFIG.Item.documentClass = DCCItem
   CONFIG.Combatant.documentClass = DCCCombatant
 
+  CONFIG.Dice.fulfillment.dice = {
+    d2: { label: "d3", icon: '<i class="fas fa-dice-two"></i>'},
+    d3: { label: "d3", icon: '<i class="fas fa-dice-three"></i>'},
+    d4: { label: "d4", icon: '<i class="fas fa-dice-d4"></i>' },
+    d5: { label: "d5", icon: '<i class="fas fa-dice-five"></i>'},
+    d6: { label: "d6", icon: '<i class="fas fa-dice-d6"></i>' },
+    d7: { label: "d7", icon: '<i class="fas fa-dice-d6"></i>'},
+    d8: { label: "d8", icon: '<i class="fas fa-dice-d8"></i>' },
+    d10: { label: "d10", icon: '<i class="fas fa-dice-d10"></i>' },
+    d12: { label: "d12", icon: '<i class="fas fa-dice-d12"></i>' },
+    d14: { label: "d14", icon: '<i class="fas fa-dice-d20"></i>'},
+    d16: { label: "d16", icon: '<i class="fas fa-dice-d20"></i>'},
+    d20: { label: "d20", icon: '<i class="fas fa-dice-d20"></i>' },
+    d24: { label: "d24", icon: '<i class="fas fa-dice-d20"></i>'},
+    d30: { label: "d30", icon: '<i class="fas fa-dice-d20"></i>'},
+    d100: { label: "d100", icon: '<i class="fas fa-percent"></i>' }
+  }
+
   // Register sheet application classes
   Actors.unregisterSheet('core', ActorSheet)
   Actors.registerSheet('dcc', DCCActorSheet, {

--- a/module/dcc.js
+++ b/module/dcc.js
@@ -54,7 +54,7 @@ Hooks.once('init', async function () {
   CONFIG.Combatant.documentClass = DCCCombatant
 
   CONFIG.Dice.fulfillment.dice = {
-    d2: { label: "d3", icon: '<i class="fas fa-dice-two"></i>'},
+    d2: { label: "d2", icon: '<i class="fas fa-dice-two"></i>'},
     d3: { label: "d3", icon: '<i class="fas fa-dice-three"></i>'},
     d4: { label: "d4", icon: '<i class="fas fa-dice-d4"></i>' },
     d5: { label: "d5", icon: '<i class="fas fa-dice-five"></i>'},


### PR DESCRIPTION
This PR adds the extra dice used on DCC to the Dice Configuration menu, which should allows users to choose their preferred rolling method.

It overwrites the original `CONFIG.Dice.fulfillment.dice` to make sure the dice are displayed in order. Otherwise, d2, d3, d5, etc would show up after d100.

Caveat: Font Awesome has no icons for d7, d14, d16, d24, d30.

![image](https://github.com/user-attachments/assets/54e5255d-6daa-410c-89dc-98cdf1df84c8)
