### PR TITLE
fix: Apply damage/healing chat card bug

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -1405,14 +1405,12 @@ class DCCActor extends Actor {
       const messageData = {
         user: game.user.id,
         speaker,
-        flavor: game.i18n.format(locString),
-        isRoll: true,
-        rolls: [await new Roll(deltaHp.toString()).evaluate()],
+        // flavor: game.i18n.format(locString, { damage: Math.abs(deltaHp) }),
         flags: {
           'dcc.isApplyDamage': true
         },
+        content: game.i18n.format(locString, { damage: Math.abs(deltaHp) }),
         type: CONST.CHAT_MESSAGE_STYLES.EMOTE,
-        content: game.i18n.format(locString, { target: this.name, damage: Math.abs(deltaHp) }),
         sound: CONFIG.sounds.notification
       }
       ChatMessage.applyRollMode(messageData, game.settings.get('core', 'rollMode'))


### PR DESCRIPTION
Apply damage/healing chat card had unnecessary roll HTML, and 'undefined' deltaHP amount in flavor text. I simplified the message and fixed the 'undefined' error.

pre-fix:
<img width="292" alt="Screenshot 2025-05-10 at 1 54 34 PM" src="https://github.com/user-attachments/assets/bccae44d-230e-4899-8520-a4f0817f9553" />

post-fix:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/80a40d19-d179-4c65-bba7-66d983546216" />
