### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-foundry-manifest-after-release.yml
+++ b/.github/workflows/update-foundry-manifest-after-release.yml
@@ -5,6 +5,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: write
+
 jobs:
   update_manifest_post_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/foundryvtt-dcc/dcc/security/code-scanning/4](https://github.com/foundryvtt-dcc/dcc/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the workflow's purpose and the actions used, the `contents: write` permission is necessary for updating the Foundry manifest file. Other permissions will be set to `read` or omitted entirely if not needed.

The `permissions` block will be added at the root level of the workflow, ensuring it applies to all jobs within the workflow. This change will limit the `GITHUB_TOKEN` permissions to only what is required for the workflow to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
