### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,6 +3,9 @@
 
 name: Run Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/foundryvtt-dcc/dcc/security/code-scanning/3](https://github.com/foundryvtt-dcc/dcc/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to the minimum required for the workflow. Since the workflow only performs basic CI tasks (checking out code, setting up Node.js, installing dependencies, building, and running tests), it only needs `contents: read` permissions. This change ensures that no unnecessary write permissions are granted, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
