### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   create_github_release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     name: Foundry Release
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/foundryvtt-dcc/dcc/security/code-scanning/2](https://github.com/foundryvtt-dcc/dcc/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow creates a GitHub release, it requires `contents: write` permission. We will set this permission explicitly at the job level to limit its scope. All other permissions will default to `none`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
