### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/foundry-website-update.yml
+++ b/.github/workflows/foundry-website-update.yml
@@ -5,6 +5,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: write
+
 jobs:
   update_foundry_website_post_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/foundryvtt-dcc/dcc/security/code-scanning/1](https://github.com/foundryvtt-dcc/dcc/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, the following permissions are necessary:
- `contents: read` to allow the workflow to read repository contents.
- `contents: write` to allow the workflow to update the Foundry website post-release.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
