### PR TITLE
Fix: Finds correct crit table names when using non-english localizations

### DIFF
--- a/module/chat.js
+++ b/module/chat.js
@@ -365,7 +365,8 @@ export const emoteSkillCheckRoll = function (message, html, data) {
  */
 export const lookupCriticalRoll = async function (message, html) {
   if (!message.rolls || !message.isContentVisible || !message.flavor.includes(game.i18n.localize('DCC.Critical'))) return
-  const tableName = message.flavor.replace('Critical (', '').replace(')', '')
+  const criticalText = game.i18n.localize('DCC.Critical')
+  const tableName = message.flavor.replace(`${criticalText} (`, '').replace(')', '')
 
   const critResult = await getCritTableResult(message.rolls[0], tableName)
   


### PR DESCRIPTION
Use Tantan on the Foundry/#DCC discord channel reported crit table lookups not working when his French localization was on. Turns out there were some instances of string matching that assumed english text. This fix makes that more robust by using localization strings for matching, and extracting the suffix (e.g. "III" from "Crit Table III") to form a canonical (english) name to search the compendium for. (Since the compendium table names are always English.) 

Tested and appears to work well across various scenarios. 