### PR TITLE
Use `FilePicker.implementation` when creating a new FilePicker

### DIFF
--- a/docs/V13_APP_V2_HOW_TO.md
+++ b/docs/V13_APP_V2_HOW_TO.md
@@ -61,7 +61,7 @@ renderTemplate('template.html', data)
 
 // V13 Pattern (Required)
 foundry.applications.ux.TextEditor.implementation.enrichHTML(content)
-foundry.applications.apps.FilePicker.browse()
+foundry.applications.apps.FilePicker.implementation.browse()
 foundry.applications.handlebars.renderTemplate('template.html', data)
 ```
 
@@ -586,7 +586,7 @@ static async #onEditImage(event, target) {
   const field = target.dataset.field || "img"
   const current = foundry.utils.getProperty(this.document, field)
 
-  const fp = new foundry.applications.apps.FilePicker({
+  const fp = new foundry.applications.apps.FilePicker.implementation({
     type: "image",
     current: current,
     callback: (path) => this.document.update({ [field]: path })

--- a/module/__mocks__/foundry.js
+++ b/module/__mocks__/foundry.js
@@ -1483,6 +1483,9 @@ global.foundry = {
       FilePicker: class FilePickerMock {
         constructor (options = {}) { this.options = options }
         async browse () { return this }
+        static implementation (...args) {
+          return new global.foundry.applications.apps.FilePicker(...args)
+        }
       },
       // ImagePopout - image viewer dialog
       ImagePopout: class ImagePopoutMock {

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -755,8 +755,9 @@ class DCCActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
   static async #editImage (event, target) {
     const field = target.dataset.field || 'img'
     const current = foundry.utils.getProperty(this.options.document, field)
+    const FilePicker = foundry.applications.apps.FilePicker.implementation
 
-    const fp = new foundry.applications.apps.FilePicker({
+    const fp = new FilePicker({
       type: 'image',
       current,
       callback: (path) => {

--- a/module/item-sheet.js
+++ b/module/item-sheet.js
@@ -400,8 +400,9 @@ class DCCItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
   static async #editImage (event, target) {
     const field = target.dataset.field || 'img'
     const current = foundry.utils.getProperty(this.document, field)
+    const FilePicker = foundry.applications.apps.FilePicker.implementation
 
-    const fp = new foundry.applications.apps.FilePicker({
+    const fp = new FilePicker({
       type: 'image',
       current,
       callback: (path) => {

--- a/module/party-sheet.js
+++ b/module/party-sheet.js
@@ -395,8 +395,9 @@ class DCCPartySheet extends DCCActorSheet {
   static async #editImage (event, target) {
     const field = target.dataset.field || 'img'
     const current = foundry.utils.getProperty(this.document, field)
+    const FilePicker = foundry.applications.apps.FilePicker.implementation
 
-    const fp = new foundry.applications.apps.FilePicker({
+    const fp = new FilePicker({
       type: 'image',
       current,
       callback: (path) => {


### PR DESCRIPTION
## Intent

This changeset updates the actor, item, and party sheet to use `foundry.applications.apps.FilePicker.implementation`. This is how Foundry accesses the `FilePicker` class under the hood.

### Why?

I'm a member of the dev team over at [The Forge](https://forgevtt.com/). One of our users reported running into an issue where our V13-specific customizations to the `FilePicker` class (which come from `CONFIG.ux.FilePicker`) weren't being applied. This change gets them working, while also making use of the pattern Foundry uses internally when creating a `FilePicker`.

This is my first PR in this repo; please let me know if there's anything you'd like to see changed!