### PR TITLE
fixed bug #539 - concatenation of damage override and backstab damage fields

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -1086,7 +1086,13 @@ class DCCActor extends Actor {
       }
     }
     if (options.backstab && weapon.system?.backstabDamage) {
-      damageRollFormula = damageRollFormula.replace(weapon.system?.damageWeapon, weapon.system?.backstabDamage)
+      if (!weapon.system?.damageWeapon || weapon.system.damageWeapon.trim() === '') {
+        // No weapon damage component to replace, use backstab damage directly
+        damageRollFormula = weapon.system.backstabDamage
+      } else {
+        // Replace the weapon damage component with backstab damage
+        damageRollFormula = damageRollFormula.replace(weapon.system.damageWeapon, weapon.system.backstabDamage)
+      }
     }
     let damageRoll, damageInlineRoll, damagePrompt
     if (automateDamageFumblesCrits) {


### PR DESCRIPTION
fixed bug #539 ( https://github.com/foundryvtt-dcc/dcc/issues/539 )
On a backstab, when weapon damage is empty, and damage override is set,  use backstab damage field instead of concatting override and backstab damage fields