### PR TITLE
Register all language files in system.json

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,8 +16,11 @@
       "Bash(chmod:*)",
       "Bash(node:*)",
       "Bash(git add:*)",
+      "Bash(git checkout:*)",
+      "Bash(git commit:*)",
+      "Bash(npm run scss:*)",
+      "Bash(git add:*)",
       "Bash(git commit:*)"
-      "Bash(npm run scss:*)"
     ],
     "deny": []
   }

--- a/system.json
+++ b/system.json
@@ -60,9 +60,29 @@
       "path": "lang/en.json"
     },
     {
+      "lang": "de",
+      "name": "Deutsch",
+      "path": "lang/de.json"
+    },
+    {
       "lang": "es",
       "name": "Español",
       "path": "lang/es.json"
+    },
+    {
+      "lang": "fr",
+      "name": "Français",
+      "path": "lang/fr.json"
+    },
+    {
+      "lang": "it",
+      "name": "Italiano",
+      "path": "lang/it.json"
+    },
+    {
+      "lang": "pl",
+      "name": "Polski",
+      "path": "lang/pl.json"
     }
   ],
   "packs": [


### PR DESCRIPTION
## Summary
- Added missing language registrations for German, French, Italian, and Polish
- These translation files were already present in the lang/ directory but not registered in system.json
- Now all 6 language files (en, de, es, fr, it, pl) are properly registered