### PR TITLE
Fix data path for finding original item when dragging an item between actors

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -1126,11 +1126,7 @@ class DCCActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
     let sourceItemId = null
     if (isItemTransfer) {
       sourceActor = game.actors.get(data.actorId)
-      // Get the item ID from the data - it should be in the uuid
-      if (data.uuid) {
-        const parts = data.uuid.split('.')
-        sourceItemId = parts[parts.length - 1]
-      }
+      sourceItemId = data.data._id
     }
 
     // Handle different drop types - delegate to base class


### PR DESCRIPTION
This is my first post here, let me know if anything's amiss! The data structure for the `Item` being moved has no `uuid` field, but it does have `data.data._id`, which gets the field we're looking for.