### PR TITLE
fix: Add Effects tab to generic actor sheet

### DIFF
--- a/module/actor-sheets-dcc.js
+++ b/module/actor-sheets-dcc.js
@@ -555,6 +555,10 @@ class DCCActorSheetGeneric extends DCCActorSheet {
       id: 'wizardSpells',
       template: 'systems/dcc/templates/actor-partial-wizard-spells.html'
     },
+    effects: {
+      id: 'effects',
+      template: 'systems/dcc/templates/partial-effects.html'
+    },
     notes: {
       id: 'notes',
       template: 'systems/dcc/templates/actor-partial-pc-notes.html'


### PR DESCRIPTION
## Summary
- Add the 'effects' part to DCCActorSheetGeneric.PARTS so the Effects tab appears on the generic actor sheet
- This brings feature parity with class-specific sheets and NPC sheets that already have the Effects tab
- Completes Active Effects support across all actor sheet types

## Changes
Added the `effects` entry to the static PARTS object in `DCCActorSheetGeneric` class, pointing to the existing `partial-effects.html` template.

## Test plan
- [ ] Create a generic actor and verify the Effects tab appears
- [ ] Verify effects can be added, edited, and removed from generic actors
- [ ] Confirm existing functionality on class and NPC sheets is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)