### PR TITLE
fix: NPC parser 'and' separator and actor import ID validation

### DIFF
--- a/module/__tests__/npc-parser-comprehensive.test.js
+++ b/module/__tests__/npc-parser-comprehensive.test.js
@@ -262,6 +262,23 @@ describe('NPC Parser Comprehensive Tests', () => {
       expect(result[0].items[1].system.damage).toBe('1d6+1')
     })
 
+    it('should parse multiple attacks with "and"', async () => {
+      const result = await parseNPCs('Test: Init +0; Atk claw +3 melee (1d4) and bite +5 melee (1d6+1); AC 10; HP 5; Act 1d20; SV Fort +0, Ref +0, Will +0; AL N.')
+      expect(result[0].items).toHaveLength(2)
+      expect(result[0].items[0].name).toBe('claw')
+      expect(result[0].items[0].system.damage).toBe('1d4')
+      expect(result[0].items[1].name).toBe('bite')
+      expect(result[0].items[1].system.damage).toBe('1d6+1')
+    })
+
+    it('should parse multiple attacks with mixed "and" and "or"', async () => {
+      const result = await parseNPCs('Test: Init +0; Atk claw +3 melee (1d4) and bite +5 melee (1d6+1) or tail +2 melee (1d8); AC 10; HP 5; Act 1d20; SV Fort +0, Ref +0, Will +0; AL N.')
+      expect(result[0].items).toHaveLength(3)
+      expect(result[0].items[0].name).toBe('claw')
+      expect(result[0].items[1].name).toBe('bite')
+      expect(result[0].items[2].name).toBe('tail')
+    })
+
     it('should parse ranged attacks', async () => {
       const result = await parseNPCs('Test: Init +0; Atk bow +4 ranged (1d6); AC 10; HP 5; Act 1d20; SV Fort +0, Ref +0, Will +0; AL N.')
       expect(result[0].items[0].system.melee).toBe(false)

--- a/module/actor.js
+++ b/module/actor.js
@@ -1928,6 +1928,33 @@ class DCCActor extends Actor {
       }
     }
   }
+
+  /**
+   * Override fromImport to fix legacy item IDs that are not 16 characters
+   * Foundry v13 requires exactly 16-character alphanumeric IDs
+   * @param {object} json - The JSON data to import
+   * @returns {Promise<Document>} The created document
+   */
+  static async fromImport (json) {
+    // Fix any item IDs that are not exactly 16 characters
+    if (json.items && Array.isArray(json.items)) {
+      for (const item of json.items) {
+        if (item._id && (item._id.length !== 16 || !/^[a-zA-Z0-9]+$/.test(item._id))) {
+          // Truncate or pad the ID to 16 characters while keeping it alphanumeric
+          if (item._id.length > 16) {
+            item._id = item._id.substring(0, 16)
+          } else {
+            // Pad with random alphanumeric characters
+            const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+            while (item._id.length < 16) {
+              item._id += chars.charAt(Math.floor(Math.random() * chars.length))
+            }
+          }
+        }
+      }
+    }
+    return super.fromImport(json)
+  }
 }
 
 export default DCCActor

--- a/module/npc-parser.js
+++ b/module/npc-parser.js
@@ -150,7 +150,7 @@ async function parseNPC (npcString) {
   npc.items = []
 
   /* Attacks */
-  const attackRegex = /(?:^|or )([^]+?)(?= or |$)/gm
+  const attackRegex = /(?:^|(?:or|and) )([^]+?)(?= (?:or|and) |$)/gm
   const matches = npc.attacks.matchAll(attackRegex)
   for (const match of matches) {
     const parsedAttack = _parseAttack(match[1], npc.damage)


### PR DESCRIPTION
## Summary
- Fixed NPC parser to recognize "and" as a separator between multiple attacks (previously only "or" was recognized)
- Added `fromImport` static method to DCCActor to fix legacy item IDs that don't meet Foundry v13's 16-character requirement

## Test plan
- [x] Existing NPC parser tests pass
- [x] New tests added for "and" separator parsing
- [x] New tests added for mixed "and"/"or" attack separators
- [x] Manual test: Import an NPC with attacks separated by "and" (e.g., "claw +3 melee (1d4) and bite +5 melee (1d6)")
- [x] Manual test: Import an actor exported from an older Foundry version with legacy item IDs

Fixes #615
