### PR TITLE
Add schema extension hooks for modules

### DIFF
--- a/module/data/actor/base-actor.mjs
+++ b/module/data/actor/base-actor.mjs
@@ -1,4 +1,4 @@
-/* global foundry */
+/* global foundry, Hooks */
 /**
  * Base data model for all DCC actors
  * Contains the common template fields shared by all actor types
@@ -108,7 +108,7 @@ export class BaseActorData extends foundry.abstract.TypeDataModel {
   }
 
   static defineSchema () {
-    return {
+    const schema = {
       // Abilities
       abilities: new SchemaField({
         str: new AbilityField({ label: 'DCC.AbilityStr' }),
@@ -255,5 +255,20 @@ export class BaseActorData extends foundry.abstract.TypeDataModel {
       // Currency
       currency: new CurrencyField()
     }
+
+    /**
+     * Allow modules to extend the base actor schema by adding fields to existing SchemaFields
+     * or adding entirely new top-level fields. This hook runs for all actor types.
+     *
+     * @example
+     * // In your module's init hook:
+     * Hooks.on('dcc.defineBaseActorSchema', (schema) => {
+     *   // Add a new field to details
+     *   schema.details.fields.sheetClass = new foundry.data.fields.StringField({ initial: '' })
+     * })
+     */
+    Hooks.callAll('dcc.defineBaseActorSchema', schema)
+
+    return schema
   }
 }

--- a/module/data/actor/player-data.mjs
+++ b/module/data/actor/player-data.mjs
@@ -1,4 +1,4 @@
-/* global foundry */
+/* global foundry, Hooks */
 /**
  * Data model for Player actors
  * Players use all class templates merged together:
@@ -60,7 +60,7 @@ export class PlayerData extends BaseActorData {
   }
 
   static defineSchema () {
-    return {
+    const schema = {
       ...super.defineSchema(),
 
       // Class information
@@ -227,5 +227,29 @@ export class PlayerData extends BaseActorData {
         showSwimFlySpeed: new BooleanField({ initial: false })
       })
     }
+
+    /**
+     * Allow modules to extend the Player schema by adding fields to existing SchemaFields
+     * or adding entirely new top-level fields.
+     *
+     * @example
+     * // In your module's init hook:
+     * Hooks.on('dcc.definePlayerSchema', (schema) => {
+     *   // Add a new field to the class SchemaField
+     *   schema.class.fields.myCustomField = new foundry.data.fields.StringField({ initial: '' })
+     *
+     *   // Add a new field to details
+     *   schema.details.fields.sheetClass = new foundry.data.fields.StringField({ initial: '' })
+     *
+     *   // Add an entirely new top-level SchemaField
+     *   schema.rewards = new foundry.data.fields.SchemaField({
+     *     fame: new foundry.data.fields.NumberField({ initial: 0 }),
+     *     wealth: new foundry.data.fields.NumberField({ initial: 0 })
+     *   })
+     * })
+     */
+    Hooks.callAll('dcc.definePlayerSchema', schema)
+
+    return schema
   }
 }


### PR DESCRIPTION
Add hooks that allow modules to extend the actor data schemas:
- `dcc.defineBaseActorSchema` - Extend fields shared by all actor types
- `dcc.definePlayerSchema` - Extend Player-specific fields

Modules can use these hooks to add custom fields to existing SchemaFields (like `class`, `details`, `skills`) or add entirely new top-level fields.

This enables proper DataModel integration for modules like XCC that need to store additional actor data.