### PR TITLE
Add npc special field to data types

### DIFF
--- a/module/data/actor/base-actor.mjs
+++ b/module/data/actor/base-actor.mjs
@@ -199,6 +199,9 @@ export class BaseActorData extends foundry.abstract.TypeDataModel {
           special: new StringField({ initial: '' }),
           swim: new StringField({ initial: '' }), // Can include units
           fly: new StringField({ initial: '' }) // Can include units
+        }),
+        special: new SchemaField({
+          value: new StringField({ initial: '' })
         })
       }),
 


### PR DESCRIPTION
Add the npc 'special' field to the datatypes to restore it's use. Data should not be lost.  Fixes #642.