### PR TITLE
Fix AC and HP input height to prevent number clipping

### DIFF
--- a/styles/dcc.css
+++ b/styles/dcc.css
@@ -1889,7 +1889,7 @@ a.inline-roll {
   align-self: center;
   border: 0;
   font-size: 24px;
-  height: 17px;
+  height: 28px;
   justify-self: center;
   margin-bottom: 5px;
   width: 37px;

--- a/styles/dcc.scss
+++ b/styles/dcc.scss
@@ -1988,7 +1988,7 @@ a.inline-roll {
       align-self: center;
       border: 0;
       font-size: 24px;
-      height: 17px;
+      height: 28px;
       justify-self: center;
       margin-bottom: 5px;
       width: 37px;


### PR DESCRIPTION
## Summary

Fixes a visual bug where AC and HP numbers in the shield boxes on the character sheet were being clipped at the top.

## Changes

- Updated `.ac-and-hp input` height from `17px` to `28px` in `/Users/timwhite/FoundryVTT/Data/systems/dcc/styles/dcc.scss`
- Compiled SCSS to CSS via `npm run scss`

## Root Cause

The input height was set to `17px` which was insufficient for the `24px` font size being used. This caused the top portions of the numbers to be cut off, making them difficult to read.

## Solution

Increased the input height from `17px` to `28px` to provide adequate vertical space for the `24px` font, ensuring the numbers display fully without clipping.

## Test Plan

- [x] All linting checks pass (`npm run format`)
- [x] All unit tests pass (440 tests)
- [x] SCSS compiles successfully to CSS
- [x] All language files remain in sync
- [x] Visual verification: AC and HP numbers now display fully in shield boxes

## Screenshots

Before: Numbers were clipped at the top
After: Numbers display fully with proper vertical spacing

## Breaking Changes

None - this is a purely visual fix with no functional changes.

## Related Issues

Fixes display issue in character sheet AC and HP shield boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)