### PR TITLE
Fix: Prevent critRange reset when regenerating classLink

### DIFF
--- a/module/actor-sheets-dcc.js
+++ b/module/actor-sheets-dcc.js
@@ -57,7 +57,8 @@ class DCCActorSheetCleric extends DCCActorSheet {
   async _prepareContext (options) {
     const context = await super._prepareContext(options)
 
-    if (this.options.document.system.details.sheetClass !== 'Cleric' || !this.options.document.system.class.classLink) {
+    // Only set class defaults on initial setup (when sheetClass doesn't match)
+    if (this.options.document.system.details.sheetClass !== 'Cleric') {
       await this.options.document.update({
         'system.class.className': game.i18n.localize('DCC.Cleric'),
         'system.class.classLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.ClericClassLink')),
@@ -69,6 +70,11 @@ class DCCActorSheetCleric extends DCCActorSheet {
         'system.config.showBackstab': false,
         'system.config.showSpells': false,
         'system.skills.shieldBash.useDeed': false
+      })
+    } else if (!this.options.document.system.class.classLink) {
+      // Regenerate classLink if missing (e.g., core book wasn't installed initially)
+      await this.options.document.update({
+        'system.class.classLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.ClericClassLink'))
       })
     }
 
@@ -119,7 +125,8 @@ class DCCActorSheetThief extends DCCActorSheet {
   async _prepareContext (options) {
     const context = await super._prepareContext(options)
 
-    if (this.options.document.system.details.sheetClass !== 'Thief' || !this.options.document.system.class.classLink) {
+    // Only set class defaults on initial setup (when sheetClass doesn't match)
+    if (this.options.document.system.details.sheetClass !== 'Thief') {
       await this.options.document.update({
         'system.class.className': game.i18n.localize('DCC.Thief'),
         'system.class.classLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.ThiefClassLink')),
@@ -132,6 +139,11 @@ class DCCActorSheetThief extends DCCActorSheet {
         'system.class.spellCheckAbility': null,
         'system.config.showSpells': false,
         'system.skills.shieldBash.useDeed': false
+      })
+    } else if (!this.options.document.system.class.classLink) {
+      // Regenerate classLink if missing (e.g., core book wasn't installed initially)
+      await this.options.document.update({
+        'system.class.classLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.ThiefClassLink'))
       })
     }
 
@@ -186,7 +198,8 @@ class DCCActorSheetHalfling extends DCCActorSheet {
   async _prepareContext (options) {
     const context = await super._prepareContext(options)
 
-    if (this.options.document.system.details.sheetClass !== 'Halfling' || !this.options.document.system.class.classLink) {
+    // Only set class defaults on initial setup (when sheetClass doesn't match)
+    if (this.options.document.system.details.sheetClass !== 'Halfling') {
       await this.options.document.update({
         'system.class.className': game.i18n.localize('DCC.Halfling'),
         'system.class.classLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.HalflingClassLink')),
@@ -198,6 +211,11 @@ class DCCActorSheetHalfling extends DCCActorSheet {
         'system.class.spellCheckAbility': null,
         'system.config.showBackstab': false,
         'system.skills.shieldBash.useDeed': false
+      })
+    } else if (!this.options.document.system.class.classLink) {
+      // Regenerate classLink if missing (e.g., core book wasn't installed initially)
+      await this.options.document.update({
+        'system.class.classLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.HalflingClassLink'))
       })
     }
 
@@ -248,7 +266,8 @@ class DCCActorSheetWarrior extends DCCActorSheet {
   async _prepareContext (options) {
     const context = await super._prepareContext(options)
 
-    if (this.options.document.system.details.sheetClass !== 'Warrior' || !this.options.document.system.class.classLink) {
+    // Only set class defaults on initial setup (when sheetClass doesn't match)
+    if (this.options.document.system.details.sheetClass !== 'Warrior') {
       await this.options.document.update({
         'system.class.className': game.i18n.localize('DCC.Warrior'),
         'system.class.classLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.WarriorClassLink')),
@@ -261,6 +280,12 @@ class DCCActorSheetWarrior extends DCCActorSheet {
         'system.class.spellCheckAbility': null,
         'system.config.showBackstab': false,
         'system.skills.shieldBash.useDeed': false
+      })
+    } else if (!this.options.document.system.class.classLink) {
+      // Regenerate classLink if missing (e.g., core book wasn't installed initially)
+      await this.options.document.update({
+        'system.class.classLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.WarriorClassLink')),
+        'system.class.mightyDeedsLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.MightyDeedsLink'))
       })
     }
 
@@ -316,7 +341,8 @@ class DCCActorSheetWizard extends DCCActorSheet {
   async _prepareContext (options) {
     const context = await super._prepareContext(options)
 
-    if (this.options.document.system.details.sheetClass !== 'Wizard' || !this.options.document.system.class.classLink) {
+    // Only set class defaults on initial setup (when sheetClass doesn't match)
+    if (this.options.document.system.details.sheetClass !== 'Wizard') {
       await this.options.document.update({
         'system.class.className': game.i18n.localize('DCC.Wizard'),
         'system.class.classLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.WizardClassLink')),
@@ -331,6 +357,13 @@ class DCCActorSheetWizard extends DCCActorSheet {
         'system.config.showSpells': true,
         'system.config.showBackstab': false,
         'system.skills.shieldBash.useDeed': false
+      })
+    } else if (!this.options.document.system.class.classLink) {
+      // Regenerate classLink if missing (e.g., core book wasn't installed initially)
+      await this.options.document.update({
+        'system.class.classLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.WizardClassLink')),
+        'system.class.spellcastingLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.SpellcastingLink')),
+        'system.class.spellburnLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.SpellburnLink'))
       })
     }
 
@@ -381,7 +414,8 @@ class DCCActorSheetDwarf extends DCCActorSheet {
   async _prepareContext (options) {
     const context = await super._prepareContext(options)
 
-    if (this.options.document.system.details.sheetClass !== 'Dwarf' || !this.options.document.system.class.classLink) {
+    // Only set class defaults on initial setup (when sheetClass doesn't match)
+    if (this.options.document.system.details.sheetClass !== 'Dwarf') {
       await this.options.document.update({
         'system.class.className': game.i18n.localize('DCC.Dwarf'),
         'system.class.classLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.DwarfClassLink')),
@@ -421,6 +455,12 @@ class DCCActorSheetDwarf extends DCCActorSheet {
         // Explicitly trigger a re-render to show the new item
         this.render(false)
       }
+    } else if (!this.options.document.system.class.classLink) {
+      // Regenerate classLink if missing (e.g., core book wasn't installed initially)
+      await this.options.document.update({
+        'system.class.classLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.DwarfClassLink')),
+        'system.class.mightyDeedsLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.MightyDeedsLink'))
+      })
     }
 
     return context
@@ -475,7 +515,8 @@ class DCCActorSheetElf extends DCCActorSheet {
   async _prepareContext (options) {
     const context = await super._prepareContext(options)
 
-    if (this.options.document.system.details.sheetClass !== 'Elf' || !this.options.document.system.class.classLink) {
+    // Only set class defaults on initial setup (when sheetClass doesn't match)
+    if (this.options.document.system.details.sheetClass !== 'Elf') {
       await this.options.document.update({
         'system.class.className': game.i18n.localize('DCC.Elf'),
         'system.class.classLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.ElfClassLink')),
@@ -488,6 +529,11 @@ class DCCActorSheetElf extends DCCActorSheet {
         'system.config.showSpells': true,
         'system.config.showBackstab': false,
         'system.skills.shieldBash.useDeed': false
+      })
+    } else if (!this.options.document.system.class.classLink) {
+      // Regenerate classLink if missing (e.g., core book wasn't installed initially)
+      await this.options.document.update({
+        'system.class.classLink': await TextEditor.enrichHTML(game.i18n.localize('DCC.ElfClassLink'))
       })
     }
 


### PR DESCRIPTION
## Summary

Fixes a bug where changing the Critical Threat Range dropdown would immediately revert to its default value. This occurred because the class sheet initialization logic was resetting all class defaults (including critRange) whenever the classLink was missing, even if the character's sheetClass was already correctly set.

### Root Cause
The original condition `sheetClass !== 'ClassName' || !classLink` used OR logic, which meant:
- When classLink was missing (e.g., core book not initially installed), the entire defaults block would execute
- This would reset critRange and other user-customized values back to defaults
- Users would change critRange, but on the next render it would reset

### Solution
Changed to `else if` pattern:
1. **First block**: Only executes when `sheetClass !== 'ClassName'` (initial setup)
   - Sets ALL defaults including critRange, className, classLink, etc.
2. **Second block**: Only executes when sheetClass matches but classLink is missing
   - Regenerates ONLY the classLink (and related links like mightyDeedsLink, spellcastingLink)
   - Preserves user-customized values like critRange

### Changes
- Updated 7 class sheets: Cleric, Thief, Halfling, Warrior, Wizard, Dwarf, Elf
- Added inline comments explaining the logic
- Generic class sheet unaffected (doesn't use classLink logic)

## Test Plan

- [x] All 440 unit tests pass
- [x] Pre-commit hooks (format + test) pass
- [ ] Manual verification: Change critRange dropdown and confirm it persists
- [ ] Manual verification: Verify classLink regeneration still works when core book is added
- [ ] Verify no regression in initial character sheet setup

## Breaking Changes

None - this is a bug fix that preserves user intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)