### PR TITLE
fix: add backward compatibility for crit/fumble property names

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -1552,6 +1552,7 @@ class DCCActor extends Actor {
         critRoll,
         critRollFormula,
         critResult,
+        critText: critResult, // Legacy name for dcc-qol compatibility
         critRollTotal,
         ...(attackRollResult.crit ? { critTableName } : {}),
         critDieOverride: weapon.system?.config?.critDieOverride,
@@ -1565,6 +1566,7 @@ class DCCActor extends Actor {
         fumbleRoll,
         fumbleRollFormula,
         fumbleResult,
+        fumbleText: fumbleResult, // Legacy name for dcc-qol compatibility
         fumbleRollTotal,
         fumbleTableName,
         originalFumbleTableName,


### PR DESCRIPTION
## Summary

Adds backward compatibility aliases for the property names that were changed in the recent crit/fumble navigation feature (#654). This maintains compatibility with external modules like dcc-qol that still expect the legacy property names.

### What Changed

The crit/fumble navigation feature (#654) renamed:
- `critText` → `critResult`
- `fumbleText` → `fumbleResult`

This breaking change affected the dcc-qol module, which still looks for the old property names.

### Solution

Added backward compatibility aliases in `module/actor.js`:
- In `rollAttackMacro()`: Added `critText: critResult` alias
- In `rollDamageMacro()`: Added `fumbleText: fumbleResult` alias

Both the new property names and legacy names are now available in the template data, ensuring:
- New navigation features work correctly with `critResult`/`fumbleResult`
- External modules using `critText`/`fumbleText` continue to function

### Test Plan

- [x] All existing unit tests pass (440 tests)
- [x] Code formatting passes (StandardJS + StyleLint)
- [x] SCSS compilation succeeds
- [x] Translation coverage verified
- [ ] Manual testing: Verify crit/fumble navigation still works
- [ ] Manual testing: Verify dcc-qol module compatibility

### Breaking Changes

None - this is a backward compatibility fix that restores functionality.

### Related Issues

Fixes compatibility issue with dcc-qol module after #654

Generated with [Claude Code](https://claude.com/claude-code)