### PR TITLE
fix: convert string values to numbers in Active Effects Add/Multiply modes

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -308,7 +308,11 @@ class DCCActor extends Actor {
     const delta = Number(value)
     if (isNaN(delta)) return
 
-    const newValue = current + delta
+    // Convert current to number to ensure numeric addition (not string concatenation)
+    const currentNumber = Number(current)
+    if (isNaN(currentNumber)) return
+
+    const newValue = currentNumber + delta
     foundry.utils.setProperty(this, key, newValue)
     overrides[key] = newValue
   }
@@ -324,7 +328,11 @@ class DCCActor extends Actor {
     const multiplier = Number(value)
     if (isNaN(multiplier)) return
 
-    const newValue = current * multiplier
+    // Convert current to number for consistency with other effect methods
+    const currentNumber = Number(current)
+    if (isNaN(currentNumber)) return
+
+    const newValue = currentNumber * multiplier
     foundry.utils.setProperty(this, key, newValue)
     overrides[key] = newValue
   }


### PR DESCRIPTION
## Summary

Fixes Active Effects not being applied correctly to melee attack rolls and other numeric fields that are stored as strings.

## Problem

The `_applyAddEffect` and `_applyMultiplyEffect` methods in `module/actor.js` were performing arithmetic operations directly on string values, resulting in string concatenation instead of numeric operations.

**Example of the bug:**
- Field: `system.details.attackHitBonus.melee.adjustment` (StringField with initial value `'+0'`)
- Active Effect: Add mode with value `-20`
- **Expected result**: `-20`
- **Actual result**: `'+0-20'` (string concatenation)
- When parsed with `parseInt()`: incorrectly became `0`

This broke Active Effects that used Add or Multiply modes on fields defined as StringFields but containing numeric values.

## Solution

Updated `_applyAddEffect` and `_applyMultiplyEffect` to explicitly convert the current value to a number before performing arithmetic operations. This matches the pattern already used by `_applyUpgradeEffect` and `_applyDowngradeEffect` in the same class.

**Changes:**
1. Convert `current` value to number using `Number(current)`
2. Validate with `isNaN()` check before proceeding
3. Perform arithmetic on numeric values only

## Testing

- ✅ All 456 unit tests pass
- ✅ Code formatting passes (StandardJS + StyleLint)
- ✅ SCSS compilation passes
- ✅ Language file validation passes

## Breaking Changes

None. This is a bug fix that makes Active Effects work as intended.

## Related Issues

Fixes #663

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)