### PR TITLE
fix: prevent attack roll from being applied as damage (#669)

### DIFF
--- a/lang/cn.json
+++ b/lang/cn.json
@@ -58,6 +58,7 @@
   "DCC.AlreadyHasInitiative": "指示物已在战斗记录器中获得先攻值；而不重骰。",
   "DCC.Ammunition": "弹药",
   "DCC.ApplyDamageEmote": "{targetName} {damageInline}",
+  "DCC.ApplyDamageNoRoll": "未找到伤害骰。请先投掷伤害。",
   "DCC.ApplyDisapprovalMacroName": "提升不悦范围",
   "DCC.ApplyLevelChanges": "应用等级改变",
   "DCC.AdjustHitPoints": "调整生命值",

--- a/lang/de.json
+++ b/lang/de.json
@@ -58,6 +58,7 @@
   "DCC.AlreadyHasInitiative": "Token hat bereits einen Initiativewert im Kampftracker; würfele nicht erneut",
   "DCC.Ammunition": "Munition",
   "DCC.ApplyDamageEmote": "{targetName} {damageInline}",
+  "DCC.ApplyDamageNoRoll": "Kein Schadenswurf gefunden. Würfle zuerst den Schaden.",
   "DCC.ApplyDisapprovalMacroName": "Ungnadebereich erhöhen",
   "DCC.ApplyLevelChanges": "Stufenänderungen anwenden",
   "DCC.AdjustHitPoints": "Trefferpunkte anpassen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -58,6 +58,7 @@
   "DCC.AlreadyHasInitiative": "Token already has initiative score in the Combat Tracker; not re-rolling",
   "DCC.Ammunition": "Ammunition",
   "DCC.ApplyDamageEmote": "{targetName} {damageInline}",
+  "DCC.ApplyDamageNoRoll": "No damage roll found. Roll damage first before applying it.",
   "DCC.ApplyDisapprovalMacroName": "Increase Disapproval Range",
   "DCC.ApplyLevelChanges": "Apply Level Changes",
   "DCC.AdjustHitPoints": "Adjust Hit Points",

--- a/lang/es.json
+++ b/lang/es.json
@@ -58,6 +58,7 @@
   "DCC.AlreadyHasInitiative": "El token ya tiene puntuación de iniciativa en el rastreador de combate; no se vuelve a tirar",
   "DCC.Ammunition": "Munición",
   "DCC.ApplyDamageEmote": "{targetName} {damageInline}",
+  "DCC.ApplyDamageNoRoll": "No se encontró tirada de daño. Tira el daño primero.",
   "DCC.ApplyDisapprovalMacroName": "Incrementar rango de desaprobación",
   "DCC.ApplyLevelChanges": "Aplicar cambios de nivel",
   "DCC.AdjustHitPoints": "Ajustar puntos de golpe",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -47,6 +47,7 @@
   "DCC.AlreadyHasInitiative": "Le token a déjà un score d'initiative dans le Tracker de Combat ; pas de relance",
   "DCC.Ammunition": "Munitions",
   "DCC.ApplyDamageEmote": "{targetName} {damageInline}",
+  "DCC.ApplyDamageNoRoll": "Aucun jet de dégâts trouvé. Lancez d'abord les dégâts.",
   "DCC.ApplyDisapprovalMacroName": "Augmentation du risque de défaveur",
   "DCC.ApplyLevelChanges": "Appliquer les Changements de Niveau",
   "DCC.Armor": "Armure",

--- a/lang/it.json
+++ b/lang/it.json
@@ -58,6 +58,7 @@
   "DCC.AlreadyHasInitiative": "Il Segnalino ha già un punteggio di iniziativa nel Combat Tracker; non verrà rilanciato",
   "DCC.Ammunition": "Munizione",
   "DCC.ApplyDamageEmote": "{targetName} {damageInline}",
+  "DCC.ApplyDamageNoRoll": "Nessun tiro per i danni trovato. Tira prima per i danni.",
   "DCC.ApplyDisapprovalMacroName": "Aumenta l'Intervallo di Disapprovazione",
   "DCC.ApplyLevelChanges": "Applica Modifiche di Livello",
   "DCC.AdjustHitPoints": "Modifica i Punti Ferita",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -58,6 +58,7 @@
   "DCC.AlreadyHasInitiative": "Żeton ma już wynik inicjatywy w Trackerze Walki; nie przerzucam",
   "DCC.Ammunition": "Amunicja",
   "DCC.ApplyDamageEmote": "{targetName} {damageInline}",
+  "DCC.ApplyDamageNoRoll": "Nie znaleziono rzutu na obrażenia. Najpierw rzuć na obrażenia.",
   "DCC.ApplyDisapprovalMacroName": "Zwiększ Zakres Dezaprobaty",
   "DCC.ApplyLevelChanges": "Zastosuj Zmiany Poziomu",
   "DCC.AdjustHitPoints": "Dostosuj Punkty Wytrzymałości",


### PR DESCRIPTION
## Summary
- Fixes #669: "Apply damage" was incorrectly using the attack roll value instead of the damage roll
- Modified `applyChatCardDamage()` to check for the `isToHit` flag before falling back to `.dice-total`
- Added warning notification when no damage roll is found
- Added translations for the warning message in all 7 language files

## Test plan
- [x] All 473 unit tests pass
- [x] `npm run check` passes (format, scss, test, compare-lang)
- [ ] Manual testing: Roll attack, right-click message, select "Apply Damage" - should show warning instead of applying attack roll as damage
- [ ] Manual testing: Roll damage separately, right-click, "Apply Damage" - should work correctly
