### PR TITLE
Fix spellCheckOtherMod not working for clerics

### DIFF
--- a/module/__tests__/active-effects.test.js
+++ b/module/__tests__/active-effects.test.js
@@ -192,16 +192,15 @@ describe('Active Effect Methods - String to Number Conversion', () => {
     expect(overrides['system.attributes.hp.value']).toEqual(5)
   })
 
-  test('_applyAddEffect returns early for null current values', () => {
+  test('_applyAddEffect treats null current values as zero', () => {
     const actor = new DCCActor()
 
     const overrides = {}
 
-    // Try to add to a non-existent property
+    // Add to a non-existent (null) property — should treat null as 0
     actor._applyAddEffect('system.nonexistent.property', '5', overrides)
 
-    // Should not throw or add to overrides
-    expect(overrides).toEqual({})
+    expect(overrides['system.nonexistent.property']).toEqual(5)
   })
 
   test('_applyAddEffect returns early for non-numeric delta values', () => {

--- a/module/__tests__/actor.test.js
+++ b/module/__tests__/actor.test.js
@@ -1783,3 +1783,41 @@ test('roll skill check without useLevel config', async () => {
     }
   )
 })
+
+test('computeSpellCheck propagates spellCheckOtherMod to cleric abilities', () => {
+  // Set up cleric-like skills
+  actor.system.skills.divineAid = { label: 'Divine Aid', value: '', ability: '' }
+  actor.system.skills.turnUnholy = { label: 'Turn Unholy', value: '', ability: '' }
+  actor.system.skills.layOnHands = { label: 'Lay on Hands', value: '', ability: '' }
+
+  // Reset to personality-based (cleric)
+  actor.system.class.spellCheckAbility = 'per'
+  actor.system.class.spellCheckOverride = ''
+  actor.system.class.spellCheckOtherMod = '+3'
+  actor.system.details.level.value = 1
+
+  actor.computeSpellCheck()
+
+  // spellCheck = level(1) + per mod(+2) + other(+3) = +1+2+3
+  expect(actor.system.class.spellCheck).toEqual('+1+2+3')
+  // divineAid and layOnHands mirror spellCheck
+  expect(actor.system.skills.divineAid.value).toEqual('+1+2+3')
+  expect(actor.system.skills.layOnHands.value).toEqual('+1+2+3')
+  // turnUnholy adds luck mod
+  expect(actor.system.skills.turnUnholy.value).toEqual(`+1+2+3+${actor.system.abilities.lck.mod}`)
+})
+
+test('_applyAddEffect treats null initial values as zero', () => {
+  const overrides = {}
+
+  // Set a property to null to simulate cleric's spellCheckOtherMod
+  actor.system.class.spellCheckOtherMod = null
+  expect(actor.system.class.spellCheckOtherMod).toBeNull()
+
+  // Apply an ADD effect of +2
+  actor._applyAddEffect('system.class.spellCheckOtherMod', '2', overrides)
+
+  // Should treat null as 0 and add 2
+  expect(actor.system.class.spellCheckOtherMod).toEqual(2)
+  expect(overrides['system.class.spellCheckOtherMod']).toEqual(2)
+})

--- a/module/actor.js
+++ b/module/actor.js
@@ -321,13 +321,12 @@ class DCCActor extends Actor {
    */
   _applyAddEffect (key, value, overrides) {
     const current = foundry.utils.getProperty(this, key)
-    if (current == null) return
 
     const delta = Number(value)
     if (isNaN(delta)) return
 
-    // Convert current to number to ensure numeric addition (not string concatenation)
-    const currentNumber = Number(current)
+    // Treat null as 0 for ADD operations (e.g. cleric spellCheckOtherMod starts as null)
+    const currentNumber = Number(current ?? 0)
     if (isNaN(currentNumber)) return
 
     const newValue = currentNumber + delta

--- a/templates/actor-partial-cleric.html
+++ b/templates/actor-partial-cleric.html
@@ -32,6 +32,12 @@
           <div class="mr-3 group-indent label-font" title="{{localize 'DCC.DisplayValueHint'}}">{{localize "DCC.AbilityPerShort"}} {{localize
             "DCC.Modifier"}}</div>
           <div class="value-display center" title="{{localize 'DCC.DisplayValueHint'}}">{{system.abilities.per.mod}}</div>
+          <label class="group-indent" for="system.class.spellCheckOtherMod" title="{{localize 'DCC.OtherModHint'}}">
+            {{localize "DCC.SpellCheckOtherMod"}}
+          </label>
+          <input id="system.class.spellCheckOtherMod" name="system.class.spellCheckOtherMod"
+                 value="{{system.class.spellCheckOtherMod}}"
+                 data-dtype="String"/>
           <label class="group-indent" for="system.class.spellCheckOverride" title="{{localize 'DCC.OverrideHint'}}">
             {{localize "DCC.Override"}}
           </label>


### PR DESCRIPTION
## Summary
- Fix `_applyAddEffect` to treat `null` initial values as `0` instead of silently skipping ADD active effects — this was preventing `spellCheckOtherMod` from working on clerics since the field starts as `null` (no input on the sheet)
- Add the missing "Spell Check Bonus" input field to the cleric template, matching wizard/elf templates
- Add tests for cleric spell check propagation to Divine Aid, Turn Unholy, and Lay on Hands

Closes #679

## Test plan
- [x] All 500 tests pass (`npm test`)
- [x] Code passes linting (`npm run format`)
- [x] Manual: Create a cleric, add Active Effect with `system.class.spellCheckOtherMod` ADD `2`, verify spell check bonus increases and cleric abilities reflect the change