### PR TITLE
fix: clean up damage formula display for negative adjustments

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -1507,9 +1507,6 @@ class DCCActor extends Actor {
 
       damagePrompt = game.i18n.localize('DCC.Damage')
     } else if (damageRollFormula) {
-      if (damageRollFormula.includes('-')) {
-        damageRollFormula = `max(${damageRollFormula}, 1)`
-      }
       damageInlineRoll = await TextEditor.enrichHTML(`[[/r ${damageRollFormula} # Damage]]`)
       damagePrompt = game.i18n.localize('DCC.RollDamage')
     }

--- a/module/chat.js
+++ b/module/chat.js
@@ -142,6 +142,33 @@ function applyChatCardDamage (roll, multiplier) {
 }
 
 /**
+ * Enforce minimum 1 damage on damage rolls rendered in chat
+ * Handles inline rolls (e.g. [[/r 1d4-2 # Damage]]) that can't use post-roll clamping
+ * @param message
+ * @param html
+ */
+export const enforceMinimumDamage = function (message, html) {
+  if (!message.rolls?.length || !message.isContentVisible) return
+  if (!message.flavor?.includes(game.i18n.localize('DCC.Damage'))) return
+
+  const roll = message.rolls[0]
+  if (roll.total < 1) {
+    roll._total = 1
+    // Update the rendered roll display in the chat HTML
+    const rollTotal = html.querySelector('.dice-total')
+    if (rollTotal) {
+      rollTotal.textContent = '1'
+    }
+    // Update damage-applyable elements
+    html.querySelectorAll('.damage-applyable').forEach(el => {
+      if (el.dataset.damage !== undefined) {
+        el.dataset.damage = '1'
+      }
+    })
+  }
+}
+
+/**
  * Change attack rolls into emotes
  * @param message
  * @param html

--- a/module/dcc.js
+++ b/module/dcc.js
@@ -790,6 +790,7 @@ Hooks.on('renderChatMessageHTML', async (message, html, data) => {
     message.setFlag('core', 'canPopout', true)
   }
   chat.highlightCriticalSuccessFailure(message, html, data)
+  chat.enforceMinimumDamage(message, html)
   SpellResult.processChatMessage(message, html, data)
 
   // Add data-item-id for modules that want to use it


### PR DESCRIPTION
## Summary
- Remove `max()` wrapper from `damageRollFormula` so damage buttons show clean formulas (e.g., `1d4-2` instead of `max(1d4-2, 1)`)
- Add `enforceMinimumDamage()` chat hook to clamp damage roll totals to minimum 1 post-render, matching the existing auto-roll behavior
- Fixes the display issue reported in #713 where Active Effects with negative damage adjustments caused ugly `max()` formulas in Roll Damage buttons

## Test plan
- [ ] Create NPC with weapon, add Active Effect with negative `attackDamageBonus.melee.adjustment`
- [ ] Attack with weapon (non-auto-roll mode) — verify Roll Damage button shows clean formula like `(1d4-2)`
- [ ] Click Roll Damage — if roll result would be < 1, verify it displays as 1
- [ ] Right-click the damage chat card and Apply Damage — verify correct value (minimum 1) is applied
- [ ] Test with auto-roll damage enabled — verify damage is still clamped to minimum 1
- [ ] Test with dcc-qol module active — verify damage button shows clean formula

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)