### PR TITLE
chore: add SessionStart hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+npm install --no-audit --no-fund

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,18 @@
   "enabledPlugins": {
     "foundryvtt-dev@cyface": true
   },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "allow": [
       "Bash(cat:*)",


### PR DESCRIPTION
## Summary
- Adds `.claude/hooks/session-start.sh` that runs `npm install` when `CLAUDE_CODE_REMOTE=true`, so remote Claude Code on the web sessions have dependencies ready for tests and linters.
- Registers the hook under `SessionStart` in `.claude/settings.json`.
- Hook is a no-op on local machines (gated on `CLAUDE_CODE_REMOTE`) and idempotent.

## Test plan
- [x] Hook runs cleanly: `CLAUDE_CODE_REMOTE=true .claude/hooks/session-start.sh` installs 448 packages, exits 0.
- [x] Linter works after hook: `npx standard module/dcc.js` and `npx stylelint styles/dcc.scss` both pass.
- [x] Tests work after hook: `npx vitest run --project unit module/__tests__/dice-chain.test.js` passes (7/7).
- [x] Full pre-commit hook ran `npm run format` + `npm run test` — 599/599 passing.

https://claude.ai/code/session_0125ZKjDREzJKFMWaxZASoMW