### PR TITLE
fix: halfling two-weapon rule works across locales

### DIFF
--- a/module/__tests__/two-weapon-fighting.test.js
+++ b/module/__tests__/two-weapon-fighting.test.js
@@ -34,7 +34,8 @@ describe('Two-Weapon Fighting', () => {
             melee: { value: '+0', adjustment: '+0' },
             missile: { value: '+0', adjustment: '+0' }
           },
-          level: { value: 1 }
+          level: { value: 1 },
+          sheetClass: className
         },
         class: { className },
         config: {}

--- a/module/actor.js
+++ b/module/actor.js
@@ -1722,7 +1722,7 @@ class DCCActor extends Actor {
     let twoWeaponNote = ''
     if (attackRollResult.fumble &&
       (weapon.system?.twoWeaponPrimary || weapon.system?.twoWeaponSecondary) &&
-      this.system?.class?.className === game.i18n.localize('DCC.Halfling')) {
+      this.system?.details?.sheetClass === 'Halfling') {
       twoWeaponNote = game.i18n.localize('DCC.HalflingTwoWeaponFumbleNote')
     }
 

--- a/module/item.js
+++ b/module/item.js
@@ -67,8 +67,7 @@ class DCCItem extends Item {
       // Two-Weapon Fighting Dice Modifications
       if (this.system.twoWeaponPrimary || this.system.twoWeaponSecondary) {
         const agilityScore = this.actor?.system?.abilities?.agl?.value || 0
-        const className = this.actor?.system?.class?.className || ''
-        const isHalfling = className === game.i18n.localize('DCC.Halfling')
+        const isHalfling = this.actor?.system?.details?.sheetClass === 'Halfling'
 
         // Calculate dice penalty based on agility and weapon hand
         let dicePenalty = 0


### PR DESCRIPTION
## Summary

- The two-weapon fighting rule and fumble note in `actor.js:1725` and `item.js:71` compared `className` to `game.i18n.localize('DCC.Halfling')`. In non-English locales this fails whenever a character's `className` was stored in a different locale than the current session (e.g., created in English, opened in German where `DCC.Halfling` → `Halbling`) — silently dropping the halfling two-weapon rules.
- Fixed by comparing `details.sheetClass === 'Halfling'`. `sheetClass` is the canonical English key that `migrations.js` guarantees, and this is already the pattern used for Elf (`actor.js:134`) and Cleric (`actor.js:1393`) class checks.
- Test helper updated to populate `details.sheetClass` so tests exercise the new path.

## Test plan

- [x] `npm test` — all 704 tests pass (including 22 two-weapon-fighting tests)
- [x] `npm run format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)