### PR TITLE
fix: preserve judge description when adding item to container (#722)

### DIFF
--- a/module/__integration__/data-models.test.js
+++ b/module/__integration__/data-models.test.js
@@ -315,6 +315,33 @@ describe('Data Migration (real Foundry migration pipeline)', () => {
     expect(typeof migrated.weight).toBe('number')
     expect(migrated.weight).toBe(3.5)
   })
+
+  // Regression for #722: dropping an item into a container would wipe the
+  // judge-only description. The cause was migrateData adding an empty
+  // description.judge to the partial update diff Foundry persists.
+  test('BaseItemData migrateData does not add description on partial updates', () => {
+    const source = { container: 'abc' }
+    const migrated = BaseItemData.migrateData(source)
+    expect(migrated.description).toBeUndefined()
+  })
+
+  test('PhysicalItemData migrateData does not add description on partial updates', () => {
+    const source = { container: 'abc' }
+    const migrated = PhysicalItemData.migrateData(source)
+    expect(migrated.description).toBeUndefined()
+  })
+
+  test('BaseItemData migrateData backfills judge for legacy descriptions missing it', () => {
+    const source = { description: { value: '<p>visible</p>' } }
+    const migrated = BaseItemData.migrateData(source)
+    expect(migrated.description.judge).toEqual({ value: '' })
+  })
+
+  test('BaseItemData migrateData preserves an existing judge description', () => {
+    const source = { description: { judge: { value: '<p>secret</p>' } } }
+    const migrated = BaseItemData.migrateData(source)
+    expect(migrated.description.judge).toEqual({ value: '<p>secret</p>' })
+  })
 })
 
 // ============================================================================

--- a/module/data/item/base-item.mjs
+++ b/module/data/item/base-item.mjs
@@ -18,13 +18,12 @@ export class BaseItemData extends foundry.abstract.TypeDataModel {
    * @returns {object} - Migrated data
    */
   static migrateData (source) {
-    // Ensure description structure exists
-    if (!source.description) {
-      source.description = {}
-    }
-
-    // Ensure judge sub-object exists
-    if (!source.description.judge) {
+    // Backfill the judge sub-object on legacy items that already have a
+    // description but pre-date the judge field. Guarded so partial-update
+    // diffs (e.g. `{ container: 'abc' }`) are not mutated to add an empty
+    // description.judge — Foundry persists the cleaned diff, which would
+    // otherwise wipe the existing judge text on disk (see #722).
+    if (source.description && typeof source.description === 'object' && !source.description.judge) {
       source.description.judge = { value: '' }
     }
 


### PR DESCRIPTION
## Summary

- Fixes #722. The judge-only description was being wiped whenever an item was dragged into a container (or any partial item update was issued).
- Root cause: `BaseItemData.migrateData` unconditionally injected `description.judge = { value: '' }` into its source. Foundry runs `migrateData` against partial update diffs too, so a one-field write like `item.update({ 'system.container': containerId })` ended up persisting an empty judge value over the existing one.
- Guard the backfill so it only runs when `description` is already present on the source — full-data loads of legacy items still get the judge sub-object initialized; partial-update diffs are no longer mutated.

## Test plan

- [x] All 614 unit tests pass (`npm run test:unit`)
- [x] Added 4 regression tests in `module/__integration__/data-models.test.js` covering: partial update without description, partial update on `PhysicalItemData`, legacy backfill of missing judge, preservation of an existing judge value
- [ ] Manual repro in Foundry v14: drag an item with a populated judge-only description into a container, confirm the judge text survives; pull it back out, confirm it's still there

https://claude.ai/code/session_014KGzn5u3pRTUiedWSLohyP

---
_Generated by [Claude Code](https://claude.ai/code/session_014KGzn5u3pRTUiedWSLohyP)_