### PR TITLE
fix: use foundry.utils.getProperty in item-piles ITEM_COST_TRANSFORMER

### DIFF
--- a/module/item-piles-support.js
+++ b/module/item-piles-support.js
@@ -1,4 +1,4 @@
-/* global game, getProperty, Item */
+/* global foundry, game, Item */
 export async function setupItemPilesForDCC () {
   const baseConfig = {
     VERSION: '1.2.0',
@@ -39,7 +39,7 @@ export async function setupItemPilesForDCC () {
     ITEM_COST_TRANSFORMER: (item, currencies) => {
       let overallCost = 0
       currencies.forEach((currency, index) => {
-        const denominationCost = Number(getProperty(item, currency.data.path.replace('system.currency.', 'system.value.')))
+        const denominationCost = Number(foundry.utils.getProperty(item, currency.data.path.replace('system.currency.', 'system.value.')))
         if (!isNaN(denominationCost)) {
           overallCost += denominationCost * currency.exchangeRate
         }


### PR DESCRIPTION
## Summary
- `module/item-piles-support.js:42` still called the bare global `getProperty`, which Foundry V14 removed. The rest of the codebase already moved to `foundry.utils.getProperty`; this file was missed when it was extracted in commit `bf3b10c`.
- Fix swaps in `foundry.utils.getProperty` and updates the file's globals comment.

Fixes https://github.com/fantasycalendar/FoundryVTT-ItemPiles/issues/836 — without this, dragging items onto an Item Piles merchant throws `"getProperty is not defined"` during `ITEM_COST_TRANSFORMER` and corrupts the sheet state.

## Test plan
- [x] `npm run test:unit` — 614 tests pass
- [ ] Manual: drag an item onto an Item Piles merchant in a V14 world and confirm it adds to inventory without error

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNySc8YBVyGf2auRaxVYtf)_