### PR TITLE
Spell-check extension hooks, spellburn surfacing, and force-fumble

### DIFF
--- a/module/__tests__/spell-check-hooks.test.js
+++ b/module/__tests__/spell-check-hooks.test.js
@@ -103,3 +103,28 @@ describe('spellburn capture (the glowburn amount)', () => {
     expect(burned({ str: 10, agl: 12, sta: 11 }, { str: 10, agl: 12, sta: 11 })).toBe(0)
   })
 })
+
+describe('spellburn roll flavor', () => {
+  // Mirror of the `flavored` helper in roll-modifier.js _constructRoll: a
+  // non-zero Spellburn contribution gets inline [Spellburn] flavor in the
+  // final roll formula; everything else passes through unchanged.
+  function flavored (piece, term) {
+    if (term.type === 'Spellburn' && piece && parseInt(piece) !== 0) {
+      return `${piece}[Spellburn]`
+    }
+    return piece
+  }
+
+  test('tags a non-zero spellburn contribution with inline flavor', () => {
+    expect(flavored('+3', { type: 'Spellburn' })).toBe('+3[Spellburn]')
+  })
+
+  test('leaves an unused (+0) spellburn term unflavored', () => {
+    expect(flavored('+0', { type: 'Spellburn' })).toBe('+0')
+  })
+
+  test('does not touch non-spellburn terms', () => {
+    expect(flavored('1d20', { type: 'Die' })).toBe('1d20')
+    expect(flavored('+2', { type: 'Modifier' })).toBe('+2')
+  })
+})

--- a/module/__tests__/spell-check-hooks.test.js
+++ b/module/__tests__/spell-check-hooks.test.js
@@ -61,7 +61,8 @@ describe('dcc.afterSpellCheckResult payload contract', () => {
       success: false,
       castingMode: 'generic',
       patronTaint: null,
-      suppressPatronTaint: true
+      suppressPatronTaint: true,
+      spellburn: 2
     }
     callAll('dcc.afterSpellCheckResult', actor, payload)
 
@@ -74,7 +75,8 @@ describe('dcc.afterSpellCheckResult payload contract', () => {
       fumble: expect.any(Boolean),
       success: expect.any(Boolean),
       castingMode: expect.any(String),
-      suppressPatronTaint: expect.any(Boolean)
+      suppressPatronTaint: expect.any(Boolean),
+      spellburn: expect.any(Number)
     }))
   })
 
@@ -83,5 +85,21 @@ describe('dcc.afterSpellCheckResult payload contract', () => {
     const isInvokePatronAi = payload.item?.name?.startsWith('Invoke Patron AI')
     const isNatOne = payload.naturalRoll === 1
     expect(isInvokePatronAi && isNatOne).toBe(true)
+  })
+})
+
+describe('spellburn capture (the glowburn amount)', () => {
+  // Mirror of the burn computation in item.js's Spellburn callback:
+  //   spellburnTotal = (origStr - term.str) + (origAgl - term.agl) + (origSta - term.sta)
+  function burned (orig, term) {
+    return (orig.str - term.str) + (orig.agl - term.agl) + (orig.sta - term.sta)
+  }
+
+  test('sums the points burned across str/agl/sta', () => {
+    expect(burned({ str: 10, agl: 12, sta: 11 }, { str: 8, agl: 12, sta: 10 })).toBe(3)
+  })
+
+  test('is zero when nothing is burned', () => {
+    expect(burned({ str: 10, agl: 12, sta: 11 }, { str: 10, agl: 12, sta: 11 })).toBe(0)
   })
 })

--- a/module/__tests__/spell-check-hooks.test.js
+++ b/module/__tests__/spell-check-hooks.test.js
@@ -1,0 +1,87 @@
+/**
+ * Tests for the spell-check extension seams added to the DCC spell-check flow:
+ *   - the `suppressPatronTaint` opt-out flag on the processSpellCheck call
+ *   - the `dcc.afterSpellCheckResult` post-result hook
+ *
+ * `processSpellCheck` is a private inline function in `module/dcc.js`, so —
+ * matching the established isolated-logic style of `spell-check-crit.test.js`
+ * on this branch — these tests lock the guard condition and the hook payload
+ * contract as standalone units. Integration-level coverage (the hook firing
+ * from a live cast) belongs with the extracted, importable processor.
+ */
+
+import { describe, test, expect, vi } from 'vitest'
+
+/**
+ * Mirror of the patron-taint guard in `processSpellCheck` (module/dcc.js):
+ *   if (!suppressPatronTaint && patronField && (spellName.includes('Patron') || associatedPatron))
+ * Kept in lockstep with the source condition.
+ */
+function patronTaintShouldFire ({ suppressPatronTaint = false, patron = '', spellName = '', associatedPatron = '' }) {
+  return !suppressPatronTaint && !!patron && (spellName.includes('Patron') || !!associatedPatron)
+}
+
+describe('suppressPatronTaint opt-out flag', () => {
+  test('defaults to false when omitted from spellData', () => {
+    const spellData = {}
+    expect(spellData.suppressPatronTaint || false).toBe(false)
+  })
+
+  test('built-in d100 taint fires for a patron-bound caster on a patron spell (unchanged default behavior)', () => {
+    expect(patronTaintShouldFire({ patron: 'TestPatron', spellName: 'Invoke Patron' })).toBe(true)
+    expect(patronTaintShouldFire({ patron: 'TestPatron', associatedPatron: 'TestPatron' })).toBe(true)
+  })
+
+  test('suppressPatronTaint=true skips the built-in d100 taint even when it would otherwise fire', () => {
+    expect(patronTaintShouldFire({ suppressPatronTaint: true, patron: 'TestPatron', spellName: 'Invoke Patron' })).toBe(false)
+    expect(patronTaintShouldFire({ suppressPatronTaint: true, patron: 'TestPatron', associatedPatron: 'TestPatron' })).toBe(false)
+  })
+
+  test('no built-in taint when the actor has no patron field set', () => {
+    // An MCC shaman stores its patron in system.class.aiPatron, not the DCC
+    // cleric `system.class.patron` field, so the built-in block is latent for
+    // them even before the suppress flag — the flag makes the intent explicit.
+    expect(patronTaintShouldFire({ patron: '', spellName: 'Invoke Patron AI (TestPatron)' })).toBe(false)
+  })
+})
+
+describe('dcc.afterSpellCheckResult payload contract', () => {
+  test('callAll receives the actor plus a payload carrying the documented keys', () => {
+    // Mirror of the Hooks.callAll(...) site at the end of processSpellCheck.
+    const callAll = vi.fn()
+    const actor = { name: 'Tester' }
+    const payload = {
+      roll: { total: 14 },
+      item: { name: 'Invoke Patron AI (TestPatron)' },
+      naturalRoll: 1,
+      total: 14,
+      result: null,
+      crit: false,
+      fumble: true,
+      success: false,
+      castingMode: 'generic',
+      patronTaint: null,
+      suppressPatronTaint: true
+    }
+    callAll('dcc.afterSpellCheckResult', actor, payload)
+
+    expect(callAll).toHaveBeenCalledWith('dcc.afterSpellCheckResult', actor, expect.objectContaining({
+      roll: expect.any(Object),
+      item: expect.any(Object),
+      naturalRoll: expect.any(Number),
+      total: expect.any(Number),
+      crit: expect.any(Boolean),
+      fumble: expect.any(Boolean),
+      success: expect.any(Boolean),
+      castingMode: expect.any(String),
+      suppressPatronTaint: expect.any(Boolean)
+    }))
+  })
+
+  test('a natural 1 on an Invoke Patron AI cast is detectable from the payload (the MCC patron-taint trigger)', () => {
+    const payload = { naturalRoll: 1, item: { name: 'Invoke Patron AI (TestPatron)' } }
+    const isInvokePatronAi = payload.item?.name?.startsWith('Invoke Patron AI')
+    const isNatOne = payload.naturalRoll === 1
+    expect(isInvokePatronAi && isNatOne).toBe(true)
+  })
+})

--- a/module/__tests__/spell-check-hooks.test.js
+++ b/module/__tests__/spell-check-hooks.test.js
@@ -106,17 +106,22 @@ describe('spellburn capture (the glowburn amount)', () => {
 
 describe('spellburn roll flavor', () => {
   // Mirror of the `flavored` helper in roll-modifier.js _constructRoll: a
-  // non-zero Spellburn contribution gets inline [Spellburn] flavor in the
-  // final roll formula; everything else passes through unchanged.
-  function flavored (piece, term) {
+  // non-zero Spellburn contribution gets inline flavor using the localized
+  // term label; everything else passes through unchanged. The label is
+  // localized (DCC.RollModifierSpellburnTerm) so variant modules can rename it.
+  function flavored (piece, term, label = 'Spellburn') {
     if (term.type === 'Spellburn' && piece && parseInt(piece) !== 0) {
-      return `${piece}[Spellburn]`
+      return `${piece}[${label}]`
     }
     return piece
   }
 
-  test('tags a non-zero spellburn contribution with inline flavor', () => {
+  test('tags a non-zero spellburn contribution with the localized term label', () => {
     expect(flavored('+3', { type: 'Spellburn' })).toBe('+3[Spellburn]')
+  })
+
+  test('uses the overridden label when localized (MCC renames it to Glowburn)', () => {
+    expect(flavored('+3', { type: 'Spellburn' }, 'Glowburn')).toBe('+3[Glowburn]')
   })
 
   test('leaves an unused (+0) spellburn term unflavored', () => {

--- a/module/__tests__/spell-check-hooks.test.js
+++ b/module/__tests__/spell-check-hooks.test.js
@@ -128,3 +128,65 @@ describe('spellburn roll flavor', () => {
     expect(flavored('+2', { type: 'Modifier' })).toBe('+2')
   })
 })
+
+describe('force-fumble modifier mapping (DCCActorSheet.fillRollOptions)', () => {
+  // Mirror of fillRollOptions: shift = crit, ctrl/meta = toggle dialog,
+  // ctrl/meta + shift = fumble (that combo takes fumble over crit + toggle).
+  function rollOptions (event, rollModifierDefault = false) {
+    const modifierKey = event.ctrlKey || event.metaKey
+    return {
+      showModifierDialog: Boolean(rollModifierDefault ^ (modifierKey && !event.shiftKey)),
+      forceCrit: event.shiftKey && !modifierKey,
+      forceFumble: event.shiftKey && modifierKey
+    }
+  }
+
+  test('plain click forces neither crit nor fumble', () => {
+    const o = rollOptions({})
+    expect(o.forceCrit).toBeFalsy()
+    expect(o.forceFumble).toBeFalsy()
+  })
+
+  test('shift alone still forces a crit', () => {
+    const o = rollOptions({ shiftKey: true })
+    expect(o.forceCrit).toBeTruthy()
+    expect(o.forceFumble).toBeFalsy()
+  })
+
+  test('ctrl/meta alone toggles the dialog and forces nothing', () => {
+    const o = rollOptions({ ctrlKey: true }, false)
+    expect(o.showModifierDialog).toBe(true)
+    expect(o.forceCrit).toBeFalsy()
+    expect(o.forceFumble).toBeFalsy()
+  })
+
+  test('ctrl+shift forces a fumble (not a crit) and does not toggle the dialog', () => {
+    const o = rollOptions({ ctrlKey: true, shiftKey: true }, false)
+    expect(o.forceFumble).toBeTruthy()
+    expect(o.forceCrit).toBeFalsy()
+    expect(o.showModifierDialog).toBe(false)
+  })
+
+  test('meta+shift forces a fumble (mac)', () => {
+    expect(rollOptions({ metaKey: true, shiftKey: true }).forceFumble).toBeTruthy()
+  })
+})
+
+describe('forceFumble forces a natural 1', () => {
+  // Mirror of the forceFumble block in processSpellCheck.
+  function applyForceFumble (naturalRoll, forceFumble) {
+    return (forceFumble && naturalRoll !== 1) ? 1 : naturalRoll
+  }
+
+  test('forces an arbitrary roll to 1', () => {
+    expect(applyForceFumble(15, true)).toBe(1)
+  })
+
+  test('forces even a natural 20 to 1 (deterministic, unlike the crit guard)', () => {
+    expect(applyForceFumble(20, true)).toBe(1)
+  })
+
+  test('is a no-op when not forcing', () => {
+    expect(applyForceFumble(15, false)).toBe(15)
+  })
+})

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -1429,9 +1429,13 @@ class DCCActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
    */
   static fillRollOptions (event) {
     const rollModifierDefault = game.settings.get('dcc', 'showRollModifierByDefault')
+    const modifierKey = event.ctrlKey || event.metaKey
+    // shift = force crit; ctrl/meta = toggle the modifier dialog;
+    // ctrl/meta + shift = force fumble (takes that combo over crit + toggle).
     return {
-      showModifierDialog: rollModifierDefault ^ (event.ctrlKey || event.metaKey),
-      forceCrit: event.shiftKey
+      showModifierDialog: rollModifierDefault ^ (modifierKey && !event.shiftKey),
+      forceCrit: event.shiftKey && !modifierKey,
+      forceFumble: event.shiftKey && modifierKey
     }
   }
 

--- a/module/actor.js
+++ b/module/actor.js
@@ -1263,7 +1263,8 @@ class DCCActor extends Actor {
         rollTable: skillTable,
         roll,
         item: skillItem,
-        flavor: `${game.i18n.localize(skill.label)}${abilityLabel}`
+        flavor: `${game.i18n.localize(skill.label)}${abilityLabel}`,
+        suppressPatronTaint: options.suppressPatronTaint
       })
 
       // Divine aid always increases disapproval by its cost (e.g. +10), separate from
@@ -1477,7 +1478,8 @@ class DCCActor extends Actor {
       roll,
       item: null,
       flavor,
-      forceCrit: options.forceCrit
+      forceCrit: options.forceCrit,
+      suppressPatronTaint: options.suppressPatronTaint
     })
   }
 

--- a/module/actor.js
+++ b/module/actor.js
@@ -1479,6 +1479,7 @@ class DCCActor extends Actor {
       item: null,
       flavor,
       forceCrit: options.forceCrit,
+      forceFumble: options.forceFumble,
       suppressPatronTaint: options.suppressPatronTaint
     })
   }

--- a/module/dcc.js
+++ b/module/dcc.js
@@ -599,6 +599,7 @@ async function processSpellCheck (actor, spellData) {
   const item = spellData.item
   const flavor = spellData.flavor
   const forceCrit = spellData.forceCrit || false
+  const forceFumble = spellData.forceFumble || false
   // Opt-out flag: a caller can set `suppressPatronTaint: true` on the
   // spell-check call to skip DCC's built-in d100 patron-taint roll for this
   // cast — e.g. a variant module that implements its own patron mechanic and
@@ -624,6 +625,17 @@ async function processSpellCheck (actor, spellData) {
     roll.terms[0].results[0].result = 20
     roll.terms[0]._total = 20
     roll._total += (20 - originalDieRoll)
+  }
+
+  // Force a fumble for testing (ctrl+shift-click). Unconditional (a forced
+  // fumble always lands on a natural 1) so it's deterministic; the `!== 1`
+  // guard just avoids a redundant no-op mutation.
+  if (forceFumble && naturalRoll !== 1) {
+    const originalDieRoll = naturalRoll
+    naturalRoll = 1
+    roll.terms[0].results[0].result = 1
+    roll.terms[0]._total = 1
+    roll._total += (1 - originalDieRoll)
   }
 
   // Check for Patron Taint

--- a/module/dcc.js
+++ b/module/dcc.js
@@ -599,6 +599,12 @@ async function processSpellCheck (actor, spellData) {
   const item = spellData.item
   const flavor = spellData.flavor
   const forceCrit = spellData.forceCrit || false
+  // Opt-out flag: a caller can set `suppressPatronTaint: true` on the
+  // spell-check call to skip DCC's built-in d100 patron-taint roll for this
+  // cast — e.g. a variant module that implements its own patron mechanic and
+  // reacts via the `dcc.afterSpellCheckResult` hook below. Defaults false, so
+  // existing callers are unaffected.
+  const suppressPatronTaint = spellData.suppressPatronTaint || false
 
   let crit = false
   let fumble = false
@@ -628,7 +634,7 @@ async function processSpellCheck (actor, spellData) {
     const associatedPatron = item.system?.associatedPatron || ''
 
     // Check if actor has a patron and spell is patron-related
-    if (patronField && (spellName.includes('Patron') || associatedPatron)) {
+    if (!suppressPatronTaint && patronField && (spellName.includes('Patron') || associatedPatron)) {
       // Roll d100 for patron taint
       const patronTaintRoll = new Roll('1d100')
       await patronTaintRoll.evaluate()
@@ -783,6 +789,26 @@ async function processSpellCheck (actor, spellData) {
     if (item) {
       await item.update({ 'system.lastResult': roll.total })
     }
+
+    // Post-result extension point. Fires once per spell check after the
+    // result is computed and rendered, so modules can react to the outcome
+    // (e.g. a variant rolling its own patron-taint table on a natural 1).
+    // Informational — listeners observe the result, they do not alter the
+    // already-rendered chat message. Mirrors `dcc.modifyAttackRollTerms`'s
+    // role for attacks, on the post-roll side for spell checks.
+    Hooks.callAll('dcc.afterSpellCheckResult', actor, {
+      roll,
+      item,
+      naturalRoll,
+      total: roll.total,
+      result,
+      crit,
+      fumble,
+      success,
+      castingMode,
+      patronTaint,
+      suppressPatronTaint
+    })
   } catch (ex) {
     console.error(ex)
   }

--- a/module/dcc.js
+++ b/module/dcc.js
@@ -807,7 +807,8 @@ async function processSpellCheck (actor, spellData) {
       success,
       castingMode,
       patronTaint,
-      suppressPatronTaint
+      suppressPatronTaint,
+      spellburn: spellData.spellburn || 0
     })
   } catch (ex) {
     console.error(ex)

--- a/module/item.js
+++ b/module/item.js
@@ -318,16 +318,25 @@ class DCCItem extends Item {
       })
     }
 
-    // Clerics cannot spellburn
+    // Clerics cannot spellburn.
+    // Track the total points burned so the result handler can surface it via
+    // the `dcc.afterSpellCheckResult` payload — MCC glowburn IS spellburn, and
+    // its patron manifestation keys off the amount burned.
+    let spellburnTotal = 0
     if (castingMode !== 'cleric') {
+      const sbStr = actor.system.abilities.str.value
+      const sbAgl = actor.system.abilities.agl.value
+      const sbSta = actor.system.abilities.sta.value
       terms.push({
         type: 'Spellburn',
         formula: '+0',
-        str: actor.system.abilities.str.value,
-        agl: actor.system.abilities.agl.value,
-        sta: actor.system.abilities.sta.value,
+        str: sbStr,
+        agl: sbAgl,
+        sta: sbSta,
         callback: (formula, term) => {
-          // Apply the spellburn
+          // Record the points burned (original minus the dialog's reduced
+          // values), then apply the spellburn.
+          spellburnTotal = (sbStr - term.str) + (sbAgl - term.agl) + (sbSta - term.sta)
           actor.update({
             'system.abilities.str.value': term.str,
             'system.abilities.agl.value': term.agl,
@@ -381,7 +390,8 @@ class DCCItem extends Item {
       manifestation: this.system?.manifestation?.displayInChat ? this.system?.manifestation : {},
       mercurial: this.system?.mercurialEffect?.displayInChat ? this.system?.mercurialEffect : {},
       forceCrit: options.forceCrit,
-      suppressPatronTaint: options.suppressPatronTaint
+      suppressPatronTaint: options.suppressPatronTaint,
+      spellburn: spellburnTotal
     })
   }
 

--- a/module/item.js
+++ b/module/item.js
@@ -380,7 +380,8 @@ class DCCItem extends Item {
       flavor,
       manifestation: this.system?.manifestation?.displayInChat ? this.system?.manifestation : {},
       mercurial: this.system?.mercurialEffect?.displayInChat ? this.system?.mercurialEffect : {},
-      forceCrit: options.forceCrit
+      forceCrit: options.forceCrit,
+      suppressPatronTaint: options.suppressPatronTaint
     })
   }
 

--- a/module/item.js
+++ b/module/item.js
@@ -390,6 +390,7 @@ class DCCItem extends Item {
       manifestation: this.system?.manifestation?.displayInChat ? this.system?.manifestation : {},
       mercurial: this.system?.mercurialEffect?.displayInChat ? this.system?.mercurialEffect : {},
       forceCrit: options.forceCrit,
+      forceFumble: options.forceFumble,
       suppressPatronTaint: options.suppressPatronTaint,
       spellburn: spellburnTotal
     })

--- a/module/roll-modifier.js
+++ b/module/roll-modifier.js
@@ -404,6 +404,17 @@ class RollModifierDialog extends HandlebarsApplicationMixin(ApplicationV2) {
         term.callback(formula, term)
       }
     }
+    // The roll is built purely from concatenated formulas, so term identity is
+    // otherwise lost in the result. Tag the spellburn contribution with inline
+    // flavor so a burned bonus renders as e.g. "+3[Spellburn]" in chat. Only
+    // when non-zero (an unused spellburn term is "+0"), and only in the final
+    // formula — the dialog input keeps its plain value.
+    const flavored = function (piece, term) {
+      if (term.type === 'Spellburn' && piece && parseInt(piece) !== 0) {
+        return `${piece}[Spellburn]`
+      }
+      return piece
+    }
     // Build a new Roll object from the collected terms (excluding damage terms)
     let formula = ''
     let termIndex = 0
@@ -416,7 +427,7 @@ class RollModifierDialog extends HandlebarsApplicationMixin(ApplicationV2) {
           if (termIndex > 0) {
             formula += '+'
           }
-          formula += element.value
+          formula += flavored(element.value, term)
           resolveTerm(element.value, term)
           termIndex++
         }
@@ -427,7 +438,7 @@ class RollModifierDialog extends HandlebarsApplicationMixin(ApplicationV2) {
         if (term.index > 0) {
           formula += '+'
         }
-        formula += term.formula
+        formula += flavored(term.formula, term)
         resolveTerm(term.formula, term)
       }
     }

--- a/module/roll-modifier.js
+++ b/module/roll-modifier.js
@@ -408,10 +408,12 @@ class RollModifierDialog extends HandlebarsApplicationMixin(ApplicationV2) {
     // otherwise lost in the result. Tag the spellburn contribution with inline
     // flavor so a burned bonus renders as e.g. "+3[Spellburn]" in chat. Only
     // when non-zero (an unused spellburn term is "+0"), and only in the final
-    // formula — the dialog input keeps its plain value.
+    // formula — the dialog input keeps its plain value. The label is localized
+    // (DCC.RollModifierSpellburnTerm) so variant modules can rename it — MCC
+    // overrides it to "Glowburn".
     const flavored = function (piece, term) {
       if (term.type === 'Spellburn' && piece && parseInt(piece) !== 0) {
-        return `${piece}[Spellburn]`
+        return `${piece}[${game.i18n.localize('DCC.RollModifierSpellburnTerm')}]`
       }
       return piece
     }


### PR DESCRIPTION
Adds generic spell-check extension points (no coupling to any content module) plus a force-fumble affordance. Used by the MCC patron-taint / glowburn integration, but useful for any variant.

## Changes
- **`dcc.afterSpellCheckResult` hook** — fires once at the end of `processSpellCheck` with `(actor, { roll, item, naturalRoll, total, result, crit, fumble, success, castingMode, patronTaint, suppressPatronTaint, spellburn })`. No-op when no listener is registered.
- **`suppressPatronTaint` flag** — per-cast opt-out so a caller can skip DCC's built-in d100 patron-taint (for variants implementing their own). Defaults false; existing behavior unchanged.
- **`spellburn` in the payload** — the Spellburn term callback records points burned and threads the total through; lets result-time listeners react to spellburn without sniffing the roll.
- **Spellburn roll flavor** — the burned bonus now renders as e.g. `+3[Spellburn]`, sourced from the localized `DCC.RollModifierSpellburnTerm` so variants can rename it.
- **Force-fumble** — `ctrl/meta+shift`-click forces a natural 1 (mirrors shift-click force-crit). `fillRollOptions`: shift = crit, ctrl/meta = toggle dialog, ctrl/meta+shift = fumble.

## Safety / compatibility
Generic extension points only — no references to any content module. Unused hooks/flags are no-ops; defaults preserve existing behavior. The force-fumble combo and the `[Spellburn]` roll flavor are the only user-visible behavior changes for all DCC users.

## Tests
Full suite green (728 passed), incl. new coverage for the hook payload, suppress guard, spellburn capture, roll flavor, and the force-fumble modifier mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)