### PR TITLE
fix(actor): support native V14 token.* active-effect overrides (#736)

### DIFF
--- a/module/__tests__/active-effects.test.js
+++ b/module/__tests__/active-effects.test.js
@@ -954,3 +954,59 @@ describe('Active Effects - Custom mode fires applyActiveEffect hook (#736)', () 
     expect(actor.overrides['system.attributes.init.value']).toEqual(99)
   })
 })
+
+describe('Active Effects - native token overrides route to the token (#736)', () => {
+  test('token.* changes are stripped and stashed on tokenActiveEffectChanges, not applied to the actor', () => {
+    // Core Foundry v14 routes `token.*` changes (e.g. token.light.dim) to the
+    // TokenDocument by stripping the prefix and stashing them on the actor's
+    // tokenActiveEffectChanges; TokenDocument#applyActiveEffects applies them. Our
+    // replacement must reproduce that, or these changes crash writing a `token` field
+    // the actor data model doesn't own. This is the module-free, core way (vs ATL).
+    const actor = createPC()
+    const mockEffect = {
+      disabled: false,
+      isSuppressed: false,
+      changes: [
+        { key: 'token.light.dim', mode: 5, type: 'override', value: '60' },
+        { key: 'token.light.bright', mode: 5, type: 'override', value: '30' }
+      ]
+    }
+    actor.effects = new global.Collection([['torch-effect', mockEffect]])
+
+    expect(() => actor.applyActiveEffects()).not.toThrow()
+
+    const stashed = actor.tokenActiveEffectChanges.initial
+    expect(stashed).toHaveLength(2)
+    expect(stashed[0].key).toEqual('light.dim')
+    expect(stashed[0].value).toEqual('60')
+    expect(stashed[1].key).toEqual('light.bright')
+    expect(stashed[1].value).toEqual('30')
+    // Each routed change keeps an effect reference for core's downstream pipeline.
+    expect(stashed[0].effect).toBe(mockEffect)
+    // Token changes are NOT written to the actor (no phantom `token` field).
+    expect(actor.overrides['token.light.dim']).toBeUndefined()
+    expect(actor.overrides['light.dim']).toBeUndefined()
+  })
+
+  test('actor-targeting changes still apply alongside token.* changes', () => {
+    // A mixed effect: one token override + one real actor change. The actor change
+    // must still land while the token change is routed away.
+    const actor = createPC()
+    actor.system.attributes.init = { value: 0 }
+    const mockEffect = {
+      disabled: false,
+      isSuppressed: false,
+      changes: [
+        { key: 'token.light.dim', mode: 5, type: 'override', value: '40' },
+        { key: 'system.attributes.init.value', type: 'add', value: '2' }
+      ]
+    }
+    actor.effects = new global.Collection([['mixed-effect', mockEffect]])
+
+    actor.applyActiveEffects()
+
+    expect(actor.tokenActiveEffectChanges.initial).toHaveLength(1)
+    expect(actor.tokenActiveEffectChanges.initial[0].key).toEqual('light.dim')
+    expect(actor.overrides['system.attributes.init.value']).toEqual(2)
+  })
+})

--- a/module/actor.js
+++ b/module/actor.js
@@ -275,6 +275,15 @@ class DCCActor extends Actor {
     const overrides = this.overrides
     const effects = []
 
+    // Native V14 token overrides (#736): changes keyed `token.*` (e.g. token.light.dim)
+    // target the TokenDocument, not the actor. Core's Actor#applyActiveEffects strips
+    // the `token.` prefix and stashes them on tokenActiveEffectChanges[phase] so
+    // TokenDocument#applyActiveEffects can apply them to each token. Because our
+    // implementation replaces core's, we must reproduce that routing — otherwise these
+    // changes fall through to the actor and crash writing a non-existent `token` field.
+    this.tokenActiveEffectChanges = {}
+    const tokenChanges = []
+
     // Collect active effects from the actor
     for (const effect of this.effects) {
       if (!effect.disabled && !effect.isSuppressed) {
@@ -310,6 +319,15 @@ class DCCActor extends Actor {
 
       for (const change of effect.changes) {
         const key = change.key
+
+        // Route native token-override changes to the token (core Foundry v14 path).
+        // Strip the `token.` prefix and stash for TokenDocument#applyActiveEffects;
+        // never apply them to the actor data model (#736).
+        if (typeof key === 'string' && key.startsWith('token.')) {
+          tokenChanges.push({ ...change, key: key.slice(6), effect })
+          continue
+        }
+
         const type = change.type || 'add'
 
         // Handle different change types
@@ -361,6 +379,11 @@ class DCCActor extends Actor {
         }
       }
     }
+
+    // Hand the routed token-override changes off to core's TokenDocument pipeline.
+    // We only run the "initial" phase (see the early return above), so the "final"
+    // batch stays empty — matching how we apply every actor change in one pass.
+    this.tokenActiveEffectChanges[phase] = tokenChanges
   }
 
   /**


### PR DESCRIPTION
Closes #736.

## Problem

`DCCActor#applyActiveEffects()` fully replaces core Foundry's implementation, but never reproduced core's `token.`-prefix routing. So an Active Effect change keyed `token.light.dim` / `token.light.bright` — the native, module-free way to drive token light/vision in Foundry v14 — falls through to the actor and crashes in `setProperty` trying to write a non-existent `token` field:

```
DCC | Failed to apply active effect change to token.light.bright:
TypeError: can't access property "light", target is null
```

The prior #738 fix re-fired the `applyActiveEffect` hook so the ATL module could apply its `ATL.*` custom-mode changes. That is the module path. This PR makes the core path work, as requested on the issue ("we should be supporting the core foundry way of doing things, not what a particular module wants").

## Fix

Mirror core's `Actor#applyActiveEffects`: when a change key starts with `token.`, strip the prefix, stash the change on `this.tokenActiveEffectChanges[phase]`, and skip actor-side application. Core's `TokenDocument#applyActiveEffects` then reads `actor.tokenActiveEffectChanges[phase]`, filters by `_ACTIVE_EFFECT_TARGETABLE_KEYS` (`light`, `sight`, `name`, …) and applies the override to each token document.

The ATL hook re-fire is left intact for back-compat with existing `ATL.*` effects.

## Tests

- **+2 unit** (`active-effects.test.js`): `token.*` changes are stripped/stashed and not written to the actor; a mixed actor+token effect still applies the actor part.
- Full module unit suite on this branch: **715 passed / 24 skipped**.

An additional end-to-end assertion (a `token.light` override landing on the TokenDocument against live Foundry) plus this same fix is also on `refactor/dcc-core-lib-adapter`, where the full Playwright suite was run green; the e2e spec change is kept with that branch's live world.