### PR TITLE
fix(skills): NPC skill items inherit the actor action die (useDie:false)

### DIFF
--- a/module/__tests__/actor.test.js
+++ b/module/__tests__/actor.test.js
@@ -2004,6 +2004,63 @@ test('roll skill check without useLevel config', async () => {
   )
 })
 
+test('NPC skill item with useDie:false + a value modifier inherits the actor action die', async () => {
+  // Regression: imported NPCs carry skill items configured with
+  // `useDie: false` but a flat `value` (e.g. "Divine Aid +4"). Before
+  // the fix the missing-die fallback only matched built-in slots
+  // (`!skillItem`), so these rolled with no action die. Now a rollable
+  // skill item inherits the actor's action die.
+  dccRollCreateRollMock.mockClear()
+
+  const skillItem = new DCCItem({
+    name: 'Divine Aid',
+    type: 'skill',
+    system: {
+      config: {
+        useSummary: true,
+        useAbility: false,
+        useDie: false,
+        useLevel: false,
+        useValue: true,
+        showLastResult: false,
+        applyCheckPenalty: false
+      },
+      ability: 'int',
+      die: '1d20',
+      value: '4',
+      description: { value: '' }
+    }
+  })
+  global.itemTypesMock.mockReturnValue({
+    skill: {
+      find: vi.fn().mockReturnValue(skillItem)
+    }
+  })
+
+  // Ensure a clean action die (earlier tests can leave config.actionDice
+  // mutated to 'invalid').
+  actor.system.config.actionDice = '1d20'
+
+  await actor.rollSkillCheck('Divine Aid')
+
+  expect(dccRollCreateRollMock).toHaveBeenCalledTimes(1)
+  const terms = dccRollCreateRollMock.mock.calls[0][0]
+
+  // Inherited the actor's action die (labelled "Action Die" because the
+  // skill item carries no per-skill die).
+  const dieTerm = terms.find(t => t.type === 'Die')
+  expect(dieTerm).toBeDefined()
+  expect(dieTerm.formula).toBe('1d20')
+  expect(dieTerm.label).toBe('Action Die')
+
+  // Flat +4 skill value carried through as a Compound term.
+  const valueTerm = terms.find(t => t.type === 'Compound')
+  expect(valueTerm).toBeDefined()
+  expect(valueTerm.formula).toBe('4')
+
+  global.itemTypesMock.mockReset()
+})
+
 test('computeSpellCheck propagates spellCheckOtherMod to cleric abilities', () => {
   // Set up cleric-like skills
   actor.system.skills.divineAid = { label: 'Divine Aid', value: '', ability: '' }

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -485,6 +485,20 @@ class DCCActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
           spells[i.system.level] = [i]
         }
       } else if (i.type === 'skill') {
+        // Resolve the die shown in the Skills "Die" column. A skill
+        // with its own die (useDie) shows that die. With useDie off, a
+        // rollable skill (value / ability / level) inherits the actor's
+        // action die — matching what `rollSkillCheck` actually rolls —
+        // so NPC skills no longer display "--" while still rolling the
+        // action die. A pure description-only skill shows nothing.
+        const skillConfig = i.system.config || {}
+        if (skillConfig.useDie && i.system.die) {
+          i.displayDie = i.system.die
+        } else if (!skillConfig.useDie && (skillConfig.useValue || skillConfig.useAbility || skillConfig.useLevel)) {
+          i.displayDie = this.options.document.getActionDice()[0]?.formula || '1d20'
+        } else {
+          i.displayDie = null
+        }
         skills.push(i)
       } else if (i.type === 'treasure') {
         let treatAsCoins = false

--- a/module/actor.js
+++ b/module/actor.js
@@ -1146,8 +1146,22 @@ class DCCActor extends Actor {
       hasDie = true
     }
 
-    // If no die is specified and no override, fall back to action dice for backward compatibility with built-in skills
-    if (!hasDie && !skillItem) {
+    // If no die is specified and no override, fall back to the actor's
+    // action die. Built-in skill slots always inherit it. Skill items
+    // inherit it too — but only when they actually roll something (they
+    // contribute a value, ability, or level modifier). A pure
+    // description-only skill item (useDie / useValue / useAbility /
+    // useLevel all off) must stay on the description path and gets no
+    // die. Fixes NPC skill items saved with `useDie: false` that carry
+    // a flat `value` modifier (e.g. an imported NPC's "Divine Aid +4"):
+    // before, the missing-die branch only matched built-in slots, so
+    // those items rolled with no action die.
+    const skillItemIsRollable = !!skillItem && (
+      skill.value !== undefined ||
+      !!(skill.ability && skill.ability.trim()) ||
+      skill.level !== undefined
+    )
+    if (!hasDie && (!skillItem || skillItemIsRollable)) {
       die = this.getActionDice()[0].formula || '1d20'
       hasDie = true
     }

--- a/templates/actor-partial-skills.html
+++ b/templates/actor-partial-skills.html
@@ -22,12 +22,8 @@
         </div>
         <label class="skill-check skill-name rollable" data-action="rollSkillCheck" data-drag="true" data-drag-action="skill">{{skill.name}}</label>
         <div>
-          {{#if skill.system.config.useDie}}
-            {{#if skill.system.die}}
-              {{skill.system.die}}
-            {{else}}
-              --
-            {{/if}}
+          {{#if skill.displayDie}}
+            {{skill.displayDie}}
           {{else}}
             --
           {{/if}}


### PR DESCRIPTION
## Problem

Imported NPCs carry skill items configured with `config.useDie: false` but a flat `value` modifier (e.g. a cleric NPC's "Divine Aid +4", "Turn Unholy +4"). On their sheet the Skills **Die** column showed `--` and the skill check **rolled with no action die** — the dispatcher dropped to the description-only path / produced a die-less roll.

Root cause: the missing-die fallback in `rollSkillCheck` only applied to a class's *built-in* skill slots (`!skillItem`). It never applied to skill *items*, so an NPC's `useDie:false` item resolved with no die at all. PCs were unaffected because their class skills are built-in slots, not items.

## Fix

- **Roll path** (`module/actor.js`): the action-die fallback now also covers *rollable* skill items — those contributing a value, ability, or level modifier — so they inherit the actor's action die. Pure description-only skill items (`useDie`/`useValue`/`useAbility`/`useLevel` all off) still take the description path, preserving that behavior.
- **Sheet display** (`module/actor-sheet.js` + `templates/actor-partial-skills.html`): the Die column now shows the inherited action die (e.g. `1d20`) for those skills instead of `--`, matching what actually rolls.

Net effect for the reported NPC: the three skills now roll **1d20 + 4** and the Die column reads `1d20`.

## Tests

- New regression in `module/__tests__/actor.test.js`: an NPC `useDie:false` + value skill rolls the action die (1d20) plus its value modifier.
- Full unit suite green; StandardJS clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)