### PR TITLE
test(e2e): make classLevelNames assertion robust to homebrew class modules

### DIFF
--- a/browser-tests/e2e/extension-api.spec.js
+++ b/browser-tests/e2e/extension-api.spec.js
@@ -2517,9 +2517,13 @@ test.describe('DCC Extension API', () => {
 
     expect(result.isFunction).toBe(true)
     expect(result.exposedKey).toBe(true)
-    expect(result.registeredIds).toEqual([
+    // The 7 canonical PC classes must always be seeded. Assert they are a
+    // subset (not an exact match) so the test stays green in worlds where
+    // sibling homebrew modules (xcc / mcc-classes / dcc-crawl-classes)
+    // register additional classIds via the same helper.
+    expect(result.registeredIds).toEqual(expect.arrayContaining([
       'cleric', 'dwarf', 'elf', 'halfling', 'thief', 'warrior', 'wizard'
-    ])
+    ]))
     expect(result.clericPrefix).toBe('cleric')
     expect(result.warriorPrefix).toBe('warrior')
   })


### PR DESCRIPTION
## Summary

The `extension-api.spec.js` test for `CONFIG.DCC.classLevelNames` asserted **exact equality** with the 7 canonical PC classes. That fails in any world where sibling homebrew modules (xcc / mcc-classes / dcc-crawl-classes) register additional classIds through the same `registerHomebrewClassForProgressionLoad` helper — the registry then carries entries like `arcane-warrior`, `luchador`, `tarantino-elf`, etc.

This switches to an `expect.arrayContaining(...)` (subset) assertion: the 7 built-ins must still be present, but extra homebrew classes no longer break the test.

## Why

Surfaced while validating a large `main`-merge: the full Playwright suite ran 217/218 green, with this test the only red — and the failure was purely a function of which modules were enabled in the test world, not a code regression.

## Testing

- Ran the single test against a live v14 world with the homebrew class modules active: now passes (previously failed with 15 extra classIds).
- `npm test` (Vitest) green via pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)