### PR TITLE
chore: add Dependabot config with a 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Dependabot configuration
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Policy: do not open update PRs for releases that are less than a week
+# old. The `cooldown.default-days: 7` setting makes Dependabot wait 7
+# days after a version is published before proposing it, so freshly
+# released (and most likely to be yanked/broken) versions are skipped.
+# Cooldown applies to version updates only — security updates are exempt
+# and still come through immediately.
+version: 2
+updates:
+  # Root system dependencies (package.json / package-lock.json)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  # Playwright end-to-end test dependencies
+  - package-ecosystem: "npm"
+    directory: "/browser-tests/e2e"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  # GitHub Actions used by the CI / release workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so Dependabot **won't open update PRs for releases less than a week old**, using the `cooldown.default-days: 7` option. Freshly published versions (the ones most likely to be yanked or broken) are held back for 7 days before being proposed.

The repo had no Dependabot config, so updates were running on defaults (that's where #754 came from). This makes the policy explicit and adds the cooldown.

## Covered ecosystems

| Ecosystem | Directory | Cooldown |
|-----------|-----------|----------|
| npm | `/` (root system deps) | 7 days |
| npm | `/browser-tests/e2e` (Playwright) | 7 days |
| github-actions | `/` (CI/release workflows) | 7 days |

## Notes

- Cooldown applies to **version updates only** — **security updates are exempt** and still come through immediately, which is the desired behavior.
- Validated that the YAML parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)