### PR TITLE
ci(release): keep package-lock.json in sync with version.txt

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -18,6 +18,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.3
+      - name: Sync package.json + package-lock.json to version.txt
+        # version.txt is the only file the maintainer hand-edits. The release
+        # action below rewrites system.json and commits everything with
+        # `git commit -am`, but it does not touch package.json / package-lock.json,
+        # so without this step the lockfile drifts (package.json gets bumped while
+        # package-lock.json keeps the previous version). `npm version` bumps the
+        # version field in BOTH package.json and package-lock.json without
+        # re-resolving dependencies, so the Release commit carries a consistent set.
+        run: npm version "$(tr -d '[:space:]' < version.txt)" --no-git-tag-version --allow-same-version --ignore-scripts
       - name: GitHub Release
         id: github-release
         uses: foundryvtt-dcc/foundry-release-action@main

--- a/docs/dev/RELEASE_PROCESS.md
+++ b/docs/dev/RELEASE_PROCESS.md
@@ -10,6 +10,11 @@ For automated release process:
 1. Ensure you run `npm run tojson' to copy the data out of levelDB files and into JSON, since LevelDB files are not checked in
 1. Merge all changes into main
 1. Commit `version.txt` File with new release version number in it (no 'v')
+   — this is the **only** file you hand-edit for a release. The
+   `Create GitHub Release` workflow syncs `package.json` **and**
+   `package-lock.json` to that version (via `npm version --no-git-tag-version`)
+   before the release action rewrites `system.json` and commits the lot, so the
+   lockfile no longer drifts behind the bumped `package.json`.
 1. GitHub Action will automatically create a draft release
 1. Edit draft release notes and title
 1. Publish the release


### PR DESCRIPTION
## Problem

`version.txt` is the only file hand-edited for a release. The `Create GitHub Release` workflow runs `foundry-release-action`, which rewrites `system.json` and commits everything with `git commit -am 'Release v<version>'` — but it **never touches `package.json` / `package-lock.json`**. The `Release` commit ends up bumping `package.json` while `package-lock.json` keeps the previous version, so the lockfile drifts a version behind after every release (this surfaced as a stray `package-lock.json` diff after a plain `npm install`).

## Fix

Add one workflow step before the release action:

```yaml
- name: Sync package.json + package-lock.json to version.txt
  run: npm version "$(tr -d '[:space:]' < version.txt)" --no-git-tag-version --allow-same-version --ignore-scripts
```

`npm version` bumps the version field in **both** `package.json` and `package-lock.json` without re-resolving dependencies, and since steps share the checkout, the subsequent `git commit -am` in the release action picks them both up. **`version.txt` stays the only file the maintainer hand-edits.**

## Verification

Ran the exact command locally:
- Same version → no-op (exit 0, no diff).
- Simulated bump to `0.70.99` → changed exactly 3 lines (package.json version + the two `package-lock.json` version fields), zero dependency churn. Reverted.

## Note

This fixes the DCC repo. The same drift affects the rest of the family (`xcc`, `mcc-classes`, etc.) since the shared `foundry-release-action` doesn't re-lock — a follow-up could push this step into the action itself so every consumer benefits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)