### PR TITLE
docs: release workflow makes a draft; maintainer publishes (assistants must not)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -63,14 +63,29 @@ Release v0.66.27
 * Add responsive tabs dropdown for actor sheets (Tim L. White)
 ```
 
-## 5. Publish the Release
+## 5. Hand Off the Draft — Do NOT Publish
+
+The release stays a **draft**. **Do not publish or promote it.** The maintainer
+publishes the draft manually. Stop here and tell the maintainer that draft
+`v{version}` is ready (with notes), and they will push it out.
+
+Publishing is what fires the downstream `release: published` workflows
+(`foundry-website-update`, `update-foundry-manifest-after-release`) that push the
+version to Foundry's registry — that step is the maintainer's call, not yours.
+
+Only run the publish command if the maintainer **explicitly tells you to in that
+session**:
 
 ```bash
+# ONLY when explicitly instructed by the maintainer:
 gh release edit v{version} --draft=false --latest
 ```
 
 ## Important
 
-- GitHub Action auto-creates draft release when version.txt updates on main
-- Never manually edit system.json version - it's auto-generated
-- If action fails, check logs with `gh run view`
+- GitHub Action auto-creates a **draft** release when version.txt updates on main.
+- **Never publish/promote a release** (no `gh release edit --draft=false`, no
+  marking latest) unless the maintainer explicitly tells you to. The default is
+  always: leave the draft for the maintainer to push out.
+- Never manually edit system.json version - it's auto-generated.
+- If action fails, check logs with `gh run view`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,16 @@ rule. They apply only to the scoped context described.
   default rule still applies to `main`: branch first, and only push to
   `main` (or open a PR into it) when explicitly told to.
 
+- **Never publish or promote a GitHub release.** The `Create GitHub
+  Release` workflow (triggered by a `version.txt` bump landing on `main`)
+  **always** produces a *draft*, and the maintainer publishes it manually
+  — publishing is what fires the `release: published` workflows that push
+  the version to Foundry's registry. Do **not** run
+  `gh release edit --draft=false`, mark a release latest, or otherwise
+  promote/publish a release unless the maintainer **explicitly** tells you
+  to in that session. Default: stop at the draft and hand off. See
+  `docs/dev/RELEASE_PROCESS.md` and the `/release` skill.
+
 - **Auto-commit refactor slices on `refactor/dcc-core-lib-adapter`;
   push per batch.** This is a stricter regime layered on the general
   rule above — on this branch, push is gated on the full E2E suite, not

--- a/docs/dev/RELEASE_PROCESS.md
+++ b/docs/dev/RELEASE_PROCESS.md
@@ -5,6 +5,15 @@
 
 When you are about to do a release, and not before:
 
+> **Publishing is the maintainer's job, always.** The `Create GitHub Release`
+> workflow only ever produces a **draft**. The maintainer reviews it and
+> manually publishes (promotes) it — publishing is what fires the
+> `release: published` workflows that push the version to Foundry's registry.
+> **Automated assistants must never publish or promote a release** (no
+> `gh release edit --draft=false`, no marking latest) unless the maintainer
+> explicitly asks for it in that session. The default is: stop at the draft and
+> hand off.
+
 For automated release process:
 1. You need to have the foundry-cli installed ([https://github.com/FoundryApp/foundry-cli](https://github.com/foundryvtt/foundryvtt-cli))
 1. Ensure you run `npm run tojson' to copy the data out of levelDB files and into JSON, since LevelDB files are not checked in
@@ -15,9 +24,11 @@ For automated release process:
    `package-lock.json` to that version (via `npm version --no-git-tag-version`)
    before the release action rewrites `system.json` and commits the lot, so the
    lockfile no longer drifts behind the bumped `package.json`.
-1. GitHub Action will automatically create a draft release
-1. Edit draft release notes and title
-1. Publish the release
+1. GitHub Action will automatically create a **draft** release (it never
+   publishes — the workflow always stops at a draft)
+1. Edit the draft release notes and title
+1. **The maintainer manually publishes the draft** (see the callout above —
+   assistants must not publish unless explicitly told)
 
 For manual release process:
 1. You need to have the foundry-cli installed ([https://github.com/FoundryApp/foundry-cli](https://github.com/foundryvtt/foundryvtt-cli))


### PR DESCRIPTION
## Summary

Corrects the release-process docs so the policy is unambiguous: the **`Create GitHub Release` workflow always produces a draft, and the maintainer publishes it manually.** Publishing is what fires the `release: published` workflows (`foundry-website-update`, `update-foundry-manifest-after-release`) that push the version to Foundry's registry — that is the maintainer's call, not an assistant's.

This closes the gap that led an assistant to auto-publish a release: the `/release` skill's old **Step 5 literally instructed publishing** (`gh release edit --draft=false --latest`).

## Changes
- **`.claude/skills/release/SKILL.md`** — Step 5 changed from "Publish the Release" to "Hand Off the Draft — Do NOT Publish"; the publish command is kept only as an "ONLY when explicitly instructed" note, and the Important section restates the default.
- **`docs/dev/RELEASE_PROCESS.md`** — adds a maintainer-publishes-only callout and clarifies the automated flow stops at a draft.
- **`CLAUDE.md`** (Standing authorizations) — new rule: never publish/promote a release unless the maintainer explicitly asks in that session.

## Test plan
- [x] Docs-only; `npm test` green (1930) via pre-commit hook.
- [x] No behavior/code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)