### PR TITLE
fix(spell): roll manifestation on the table's own die, not 1d100 (#773)

### DIFF
--- a/module/__tests__/item-spell-mixin.test.js
+++ b/module/__tests__/item-spell-mixin.test.js
@@ -148,6 +148,42 @@ describe('SpellItemMixin extraction', () => {
       })
     })
 
+    // Issue #773: manifestation must roll the table's own die (1d4 here), never a
+    // hardcoded 1d100 — a d100 lands outside the small table's range and never
+    // matches a result.
+    test('rollManifestation rolls the manifestation table die, not 1d100', async () => {
+      const item = makeSpell()
+      item.actor = actor
+
+      const drawnRoll = new FakeRoll('1d4', { value: 3 })
+      const table = {
+        formula: '1d4',
+        draw: vi.fn(async () => ({
+          roll: drawnRoll,
+          results: [{ description: 'caster glows faintly' }]
+        }))
+      }
+      const entry = { _id: 'tbl1', name: 'Probe Spell Manifestation' }
+      global.game.packs = {
+        get: vi.fn(() => ({
+          index: { find: vi.fn((fn) => (fn(entry) ? entry : undefined)) },
+          getDocument: vi.fn(async () => table)
+        }))
+      }
+      const createRoll = vi.fn(async (terms) => new FakeRoll(terms[0].formula, { value: 3 }))
+      global.game.dcc = { DCCRoll: { createRoll } }
+
+      await item.rollManifestation()
+
+      expect(createRoll).toHaveBeenCalledTimes(1)
+      expect(createRoll.mock.calls[0][0][0].formula).toBe('1d4')
+      expect(table.draw).toHaveBeenCalledOnce()
+      expect(item.update).toHaveBeenCalledWith(expect.objectContaining({
+        'system.manifestation.value': 3,
+        'system.manifestation.description': '<p>Caster glows faintly</p>'
+      }))
+    })
+
     test('rollMercurialMagic no-ops for a non-spell item', async () => {
       const item = makeSpell()
       Object.defineProperty(item, 'type', { value: 'armor', configurable: true })

--- a/module/item/spell-mixin.mjs
+++ b/module/item/spell-mixin.mjs
@@ -4,6 +4,26 @@ import { logSpellburn } from '../ability-score-log.js'
 import { ensurePlus } from '../utilities.js'
 
 /**
+ * Determine the die formula to roll for a manifestation table.
+ *
+ * Manifestation tables are small dice (1d3/1d4/1d5/1d6/1d8/1d10), one per spell.
+ * Prefer the table's own `formula`; if a table ships without one (a few core-book
+ * tables do), derive `1dN` from its highest result range so the roll still lands
+ * inside the table. With no table at all, fall back to 1d100 so a bare roll still
+ * produces something. See issue #773.
+ *
+ * @param {RollTable|null} table - the resolved manifestation table, if any
+ * @returns {string} a die formula such as `1d4`
+ */
+function manifestationDieFormula (table) {
+  if (!table) { return '1d100' }
+  if (table.formula && table.formula.trim()) { return table.formula }
+  const max = (table.results?.contents ?? table.results ?? [])
+    .reduce((hi, r) => Math.max(hi, r.range?.[1] ?? 0), 0)
+  return max > 0 ? `1d${max}` : '1d100'
+}
+
+/**
  * Spell-behavior mixin for {@link DCCItem}.
  *
  * Phase 7 (Appendix-A item.js shrinkage): the spell-item roll block —
@@ -206,6 +226,26 @@ export const SpellItemMixin = (Base) => class extends Base {
     const actor = this.actor
     if (!actor) { return }
 
+    // Resolve the manifestation table first (compendium first, then world) so we
+    // can roll its own die. Each manifestation table is a small die (1d3/1d4/etc.),
+    // never 1d100 — rolling a hardcoded 1d100 lands outside the table's range and
+    // never matches a result. See issue #773.
+    const manifestationPackName = game.settings.get('dcc', 'spellSideEffectsCompendium') || 'dcc-core-book.dcc-core-spell-side-effect-tables'
+    const manifestationTableName = `${this.name} Manifestation`
+    let table = null
+    const pack = game.packs.get(manifestationPackName)
+    if (pack) {
+      const entry = pack.index.find((entity) => entity.name === manifestationTableName)
+      if (entry) {
+        table = await pack.getDocument(entry._id)
+      } else {
+        console.warn(game.i18n.localize('DCC.SpellSideEffectsCompendiumNotFoundWarning'))
+      }
+    }
+    if (!table) {
+      table = game.tables.getName(manifestationTableName)
+    }
+
     let roll
 
     if (lookup) {
@@ -217,35 +257,18 @@ export const SpellItemMixin = (Base) => class extends Base {
       const terms = [
         {
           type: 'Die',
-          formula: '1d100'
+          formula: manifestationDieFormula(table)
         }
       ]
 
-      // Otherwise roll for a manifestation
+      // Otherwise roll for a manifestation on the table's own die
       roll = await game.dcc.DCCRoll.createRoll(terms, {}, options)
     }
 
-    // Lookup the manifestation table if available
+    // Draw the manifestation from the table using our roll
     let manifestationResult = null
-    const manifestationPackName = game.settings.get('dcc', 'spellSideEffectsCompendium') || 'dcc-core-book.dcc-core-spell-side-effect-tables'
-    const manifestationTableName = `${this.name} Manifestation`
-    const pack = game.packs.get(manifestationPackName)
-    if (pack) {
-      const entry = pack.index.find((entity) => entity.name === manifestationTableName)
-      if (entry) {
-        const table = await pack.getDocument(entry._id)
-        manifestationResult = await table.draw({ roll })
-      } else {
-        console.warn(game.i18n.localize('DCC.SpellSideEffectsCompendiumNotFoundWarning'))
-      }
-    }
-
-    // Local Lookup
-    if (!manifestationResult) {
-      const table = game.tables.getName(manifestationTableName)
-      if (table) {
-        manifestationResult = await table.draw({ roll })
-      }
+    if (table) {
+      manifestationResult = await table.draw({ roll })
     }
 
     // Grab the result from the table if present


### PR DESCRIPTION
## Summary

Fixes #773 — "Spell Manifestation Always Rolls 100".

`rollManifestation` hardcoded `1d100` for the roll, but every manifestation table uses a small die (1d3/1d4/1d5/1d6/1d8/1d10), one per spell. A d100 result lands far outside the table's range, so `table.draw({ roll })` never matched a result — the manifestation came back as a bare high roll (the d100 value) with no description.

This is a long-standing bug, not a refactor regression: the pre-refactor `item.js` had the same hardcoded `1d100`.

## Fix

- Resolve the manifestation table first (compendium, then world), then roll its **own** formula.
- New `manifestationDieFormula(table)` helper: prefers `table.formula`; derives `1dN` from the highest result range for the few core-book tables that ship without a formula; falls back to `1d100` only when no table is found.

Mercurial magic is untouched — its table genuinely is a d100 table.

> [!NOTE]
> Two core-book manifestation tables (`Detect Invisible`, `Feather Fall`) ship with an empty `formula` in the `dcc-core-book` module (ranges 1–3 and 1–4). The helper's range-derivation handles them gracefully, but the underlying data should be fixed in that module separately.

## Test plan

- Added a regression test asserting the manifestation rolls the table's die (`1d4`), `table.draw` is invoked, and the description is stowed.
- Full fast suite green: 1934 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)