### PR TITLE
fix(migration): lower data-model floor to 0.22 so mid-era worlds migrate (#774)

### DIFF
--- a/module/__tests__/check-migrations.test.js
+++ b/module/__tests__/check-migrations.test.js
@@ -10,7 +10,7 @@
  * returns (threaded onto the `dcc.ready` payload):
  *   - non-GM client      → `true`,  never runs migrateWorld
  *   - already migrated    → `true`,  skips (no migrateWorld)
- *   - pre-V14 world      → `false`, error toast, no migrateWorld
+ *   - ancient world (<0.22) → `false`, error toast, no migrateWorld
  *   - V14-era / fresh    → awaits migrateWorld; `true` on a clean run
  *
  * Globals (`game` / `ui` / `foundry`) are stubbed per-test in the same
@@ -84,8 +84,8 @@ describe('checkMigrations', () => {
     expect(globalThis.game.settings.set).not.toHaveBeenCalled()
   })
 
-  test('pre-V14 world is blocked: error toast, no migration, reports incomplete', async () => {
-    globalThis.game = stubGame({ storedVersion: 0.30 })
+  test('ancient world (<0.22) is blocked: error toast, no migration, reports incomplete', async () => {
+    globalThis.game = stubGame({ storedVersion: 0.20 })
 
     const result = await checkMigrations()
 

--- a/module/__tests__/migrations-data-driven.test.js
+++ b/module/__tests__/migrations-data-driven.test.js
@@ -63,7 +63,14 @@ beforeEach(() => {
   originalGame = globalThis.game
   originalFoundry = globalThis.foundry
   originalFetch = globalThis.fetch
-  globalThis.game = { i18n: { localize: vi.fn((k) => k) } }
+  // `migrateActorData` reads the stored version for its gated fixups. Default
+  // to the ceiling so the version-gated branches (e.g. the 0.50 attackHitBonus
+  // split) are no-ops for the data-driven cases below; the gated suite
+  // overrides this per-test.
+  globalThis.game = {
+    i18n: { localize: vi.fn((k) => k) },
+    settings: { get: vi.fn(() => 0.68) }
+  }
   globalThis.foundry = stubFoundry()
 })
 
@@ -77,6 +84,45 @@ afterEach(() => {
 describe('migrateActorData — no-op baseline', () => {
   test('a fully-migrated actor produces an empty updateData', async () => {
     expect(await migrateActorData(cleanActor())).toEqual({})
+  })
+})
+
+// Version-gated fixup (issue #774): worlds at/below 0.50 predate the
+// melee/missile attackHitBonus split, so their per-mode bonus must be seeded
+// from the legacy flat attackBonus. Worlds in the (0.22, 0.66) band reach this
+// branch because the data-model floor is now 0.22, not 0.66.
+describe('migrateActorData — attackHitBonus from legacy attackBonus (<=0.50)', () => {
+  test('seeds melee/missile attackHitBonus from attackBonus for a pre-0.50 world', async () => {
+    globalThis.game.settings.get = vi.fn(() => 0.34)
+    const actor = cleanActor()
+    actor.system.details.attackBonus = '+3'
+    expect(await migrateActorData(actor)).toEqual({
+      'system.details.attackHitBonus.melee.value': '+3',
+      'system.details.attackHitBonus.missile.value': '+3'
+    })
+  })
+
+  test('fires at the 0.50 boundary', async () => {
+    globalThis.game.settings.get = vi.fn(() => 0.50)
+    const actor = cleanActor()
+    actor.system.details.attackBonus = '+1'
+    expect(await migrateActorData(actor)).toEqual({
+      'system.details.attackHitBonus.melee.value': '+1',
+      'system.details.attackHitBonus.missile.value': '+1'
+    })
+  })
+
+  test('is a no-op for a post-0.50 world even when attackBonus is present', async () => {
+    globalThis.game.settings.get = vi.fn(() => 0.67)
+    const actor = cleanActor()
+    actor.system.details.attackBonus = '+3'
+    expect(await migrateActorData(actor)).toEqual({})
+  })
+
+  test('is a no-op when attackBonus is absent (nothing to copy)', async () => {
+    globalThis.game.settings.get = vi.fn(() => 0.34)
+    const actor = cleanActor()
+    expect(await migrateActorData(actor)).toEqual({})
   })
 })
 

--- a/module/__tests__/migrations-version-gate-guard.test.js
+++ b/module/__tests__/migrations-version-gate-guard.test.js
@@ -1,25 +1,27 @@
 /**
- * Regression guard: prevent pre-V14 version-gated migration branches
- * from reappearing in `module/migrations.js`. The V14-era floor is 0.66
- * and is enforced up-front by `classifyMigrationDecision` / the
- * `MINIMUM_SUPPORTED_VERSION` guard in `migrations.js`'s
- * `checkMigrations` (awaited from `module/dcc.js`'s ready hook), so
- * per-branch `currentVersion <op> 0.NN` gates
- * below that floor are dead code.
+ * Migration version-policy guard for `module/migrations.js`.
  *
- * Rule: any `currentVersion` comparison against a numeric literal
- * below 0.66 (inclusive of 0.65, the last pre-V14 migration tier) is
- * the forbidden pattern. Data-driven checks (`typeof change.mode ===
- * 'number'`, `!actor.system?.details?.alignment`, etc.) stay — they
- * aren't gated on stored version.
+ * Policy (issue #774): the data-model floor is `MINIMUM_SUPPORTED_VERSION`
+ * = 0.22 — the pre-V14 lines (0.65.x / 0.66.x) only run their own migration
+ * for worlds stamped `<= 0.22`, so those are the only worlds a pre-V14
+ * release can actually carry forward. Worlds in the `[0.22, 0.68)` band are
+ * migrated in place here, by the data-driven checks plus a small set of
+ * version-gated fixups (e.g. the 0.50 attackHitBonus split). Worlds below
+ * 0.22 are blocked and referred to a pre-V14 release first.
+ *
+ * Rule: version-gated branches at/above the 0.22 floor are allowed (they
+ * fire for real worlds in the band). Gated branches BELOW the floor are the
+ * forbidden pattern — those worlds are blocked before `migrateActorData`
+ * runs, so a `currentVersion <op> 0.NN` for NN < 0.22 is dead code. Data-
+ * driven checks (`typeof change.mode === 'number'`, `!actor.system?.details
+ * ?.alignment`, etc.) stay — they aren't gated on stored version.
  *
  * Coverage:
- * - Behavioral: `classifyMigrationDecision` for fresh / pre-V14 / V14
- *   era inputs (includes the Foundry `default: 0` case).
- * - Source-scan: the anti-pattern regex must catch every deleted
- *   branch's operator style (`<=`, `<`, `===`, `!==`) and must not
- *   false-positive on `0.66+` comparisons. Meta-tests on the regex
- *   keep it honest under future edits.
+ * - Behavioral: `classifyMigrationDecision` for fresh / ancient / in-band /
+ *   migrated inputs (includes the Foundry `default: 0` case).
+ * - Source-scan: the anti-pattern regex must catch sub-floor gated branches
+ *   across operator styles (`<=`, `<`, `===`, `!==`) and must not false-
+ *   positive on `0.22+` comparisons. Meta-tests on the regex keep it honest.
  */
 
 import { readFileSync } from 'node:fs'
@@ -35,20 +37,21 @@ import {
 const __filename = fileURLToPath(import.meta.url)
 const MIGRATIONS_FILE = join(dirname(__filename), '..', 'migrations.js')
 
-// Exported so the meta-tests below can exercise the same regex we
-// apply to `migrations.js`.
-const antiPattern = /currentVersion\s*(?:<=?|>=?|===?|!==?)\s*0\.(?:[0-5]\d|6[0-5])\b|0\.(?:[0-5]\d|6[0-5])\b\s*(?:<=?|>=?|===?|!==?)\s*currentVersion/
+// Sub-floor (< 0.22) currentVersion comparisons are dead code — those worlds
+// are blocked before migrateActorData runs. Matches 0.00–0.21 only. Exported
+// shape so the meta-tests below exercise the same regex we apply to source.
+const antiPattern = /currentVersion\s*(?:<=?|>=?|===?|!==?)\s*0\.(?:0\d|1\d|2[01])\b|0\.(?:0\d|1\d|2[01])\b\s*(?:<=?|>=?|===?|!==?)\s*currentVersion/
 
 describe('classifyMigrationDecision', () => {
   test('exported floor + ceiling constants', () => {
-    expect(MINIMUM_SUPPORTED_VERSION).toBe(0.66)
+    expect(MINIMUM_SUPPORTED_VERSION).toBe(0.22)
     expect(NEEDS_MIGRATION_VERSION).toBe(0.68)
   })
 
   test('fresh world (default: 0) runs migrateWorld', () => {
-    // Foundry's `game.settings.get` returns the registered default,
-    // which is 0 for `systemMigrationVersion`. Treat that as "never
-    // migrated" — same bucket as null — and let data-driven fixes run.
+    // Foundry's `game.settings.get` returns the registered default, which is
+    // 0 for `systemMigrationVersion`. Treat that as "never migrated" — same
+    // bucket as null — and let the migrations run.
     expect(classifyMigrationDecision(0)).toBe('run')
   })
 
@@ -56,16 +59,24 @@ describe('classifyMigrationDecision', () => {
     expect(classifyMigrationDecision(null)).toBe('run')
   })
 
-  test('pre-V14 world (0.30) is blocked', () => {
-    expect(classifyMigrationDecision(0.30)).toBe('block')
+  test('ancient world (0.10) is blocked', () => {
+    expect(classifyMigrationDecision(0.10)).toBe('block')
   })
 
-  test('last pre-V14 tier (0.65) is blocked', () => {
-    expect(classifyMigrationDecision(0.65)).toBe('block')
+  test('just below the floor (0.21) is blocked', () => {
+    expect(classifyMigrationDecision(0.21)).toBe('block')
   })
 
-  test('V14 floor (0.66) runs migrateWorld for data-driven fixes', () => {
-    expect(classifyMigrationDecision(0.66)).toBe('run')
+  test('floor itself (0.22) runs migrateWorld', () => {
+    expect(classifyMigrationDecision(0.22)).toBe('run')
+  })
+
+  test('in-band world (0.34 — the issue #774 case) runs migrateWorld', () => {
+    expect(classifyMigrationDecision(0.34)).toBe('run')
+  })
+
+  test('last pre-V14 tier (0.65) runs migrateWorld in place', () => {
+    expect(classifyMigrationDecision(0.65)).toBe('run')
   })
 
   test('already migrated (0.68) skips', () => {
@@ -78,23 +89,25 @@ describe('classifyMigrationDecision', () => {
 })
 
 describe('version-gate anti-pattern regex', () => {
+  // Sub-floor (< 0.22) gates — dead code, must be caught.
   const knownBad = [
     'if (currentVersion <= 0.17)',
-    'if (currentVersion <= 0.50)',
-    'if (currentVersion < 0.65)',
     'if (currentVersion <= 0.11)',
     'if (currentVersion <= 0.21)',
-    'if (currentVersion <= 0.22)',
-    'if (currentVersion < 0.51)',
-    'if (currentVersion === 0.50)',
-    'if (currentVersion !== 0.22)',
-    'if (currentVersion == 0.30)',
+    'if (currentVersion <= 0.20)',
+    'if (currentVersion < 0.05)',
+    'if (currentVersion === 0.10)',
+    'if (currentVersion !== 0.21)',
+    'if (currentVersion == 0.15)',
     'if (0.17 >= currentVersion)'
   ]
 
+  // At/above the floor — allowed (these fire for real in-band worlds).
   const knownGood = [
-    'if (currentVersion < 0.66)', // the floor itself is not a gate
-    'if (currentVersion < 0.67)', // ceiling check, allowed
+    'if (currentVersion <= 0.22)', // the floor itself is migratable in place
+    'if (currentVersion <= 0.50)', // re-added attackHitBonus split (#774)
+    'if (currentVersion < 0.65)',
+    'if (currentVersion < 0.67)',
     'if (currentVersion >= 0.66)',
     'if (currentVersion === null)',
     'if (currentVersion == null)',
@@ -114,7 +127,7 @@ describe('version-gate anti-pattern regex', () => {
   }
 })
 
-test('no pre-0.66 currentVersion comparisons remain in migrations.js', () => {
+test('no sub-floor (<0.22) currentVersion comparisons remain in migrations.js', () => {
   const source = readFileSync(MIGRATIONS_FILE, 'utf8')
   const offenders = []
   source.split('\n').forEach((line, idx) => {
@@ -122,5 +135,5 @@ test('no pre-0.66 currentVersion comparisons remain in migrations.js', () => {
       offenders.push(`migrations.js:${idx + 1}: ${line.trim()}`)
     }
   })
-  expect(offenders, `pre-0.66 version-gated migration branch reintroduced:\n${offenders.join('\n')}`).toEqual([])
+  expect(offenders, `sub-floor version-gated migration branch (dead code) found:\n${offenders.join('\n')}`).toEqual([])
 })

--- a/module/migrations.js
+++ b/module/migrations.js
@@ -66,11 +66,19 @@ async function buildClassNameLookup () {
 export const NEEDS_MIGRATION_VERSION = 0.68
 
 /**
- * Floor for V14-era worlds. Worlds at or above this value can be migrated
- * forward by the surviving data-driven branches; worlds below it predate
- * V14 and must first upgrade through a pre-V14 DCC release.
+ * Floor below which a world must first pass through a pre-V14 DCC release.
+ *
+ * The pre-V14 lines (0.65.x / 0.66.x) only RUN their migration when the
+ * stored version is `<= 0.22` (their own `NEEDS_MIGRATION_VERSION` gate),
+ * so those are the only worlds a pre-V14 release can actually carry forward
+ * (it stamps them up to 0.66). Worlds stamped in the `(0.22, 0.68)` band are
+ * skipped by the pre-V14 gate, so the old "open in a pre-V14 release first"
+ * instruction never advanced them — they sat below the previous 0.66 floor
+ * forever. They are migrated in place here instead, by the data-driven
+ * branches plus the version-gated fixups in `migrateActorData`. The floor is
+ * therefore the pre-V14 gate value, not 0.66 (issue #774).
  */
-export const MINIMUM_SUPPORTED_VERSION = 0.66
+export const MINIMUM_SUPPORTED_VERSION = 0.22
 
 /**
  * Classify what `checkMigrations` should do for a stored migration
@@ -81,10 +89,11 @@ export const MINIMUM_SUPPORTED_VERSION = 0.66
  *   to the same "fresh world" bucket as `null`).
  * @returns {'skip'|'block'|'run'}
  *   - `'skip'`: already migrated (>= ceiling), nothing to do.
- *   - `'block'`: known pre-V14 world, refuse and tell the user to upgrade
- *     through a pre-V14 release first.
- *   - `'run'`: fresh or V14-era world that still needs data-driven fixes;
- *     run `migrateWorld`.
+ *   - `'block'`: an ancient world (below `MINIMUM_SUPPORTED_VERSION`) a
+ *     pre-V14 release CAN still carry forward — refuse and tell the user to
+ *     upgrade through a pre-V14 release first.
+ *   - `'run'`: fresh world, or any world in the `[floor, ceiling)` band that
+ *     still needs data-driven + version-gated fixes; run `migrateWorld`.
  */
 export function classifyMigrationDecision (currentVersion) {
   const needsMigration = (currentVersion == null) || (currentVersion < NEEDS_MIGRATION_VERSION)
@@ -322,6 +331,23 @@ const migrateCompendium = async function (pack) {
  */
 export const migrateActorData = async function (actor) {
   const updateData = {}
+
+  // Version-gated fixup for worlds that predate a schema change but were never
+  // carried through a pre-V14 release (the pre-V14 gate is `<= 0.22`, so worlds
+  // in the `(0.22, 0.66)` band slipped past it). The data-model floor blocks
+  // anything below `MINIMUM_SUPPORTED_VERSION`, so only branches at/above that
+  // floor can ever fire here (issue #774). The 0.65 base-speed split is already
+  // handled data-driven below (it reads `_source` to see past the schema
+  // default), so only the 0.50 attackHitBonus split needs an explicit gate.
+  const currentVersion = game.settings.get('dcc', 'systemMigrationVersion')
+
+  // If migrating from 0.50 or earlier, seed the per-mode attackHitBonus from the
+  // legacy flat attackBonus — these worlds predate the melee/missile split, so
+  // their attackHitBonus is still the schema default.
+  if (currentVersion <= 0.50 && actor.system?.details?.attackBonus !== undefined) {
+    updateData['system.details.attackHitBonus.melee.value'] = actor.system.details.attackBonus
+    updateData['system.details.attackHitBonus.missile.value'] = actor.system.details.attackBonus
+  }
 
   if (actor.system.details.luckyRoll) {
     updateData['system.details.birthAugur'] = actor.system.details.luckyRoll


### PR DESCRIPTION
## Summary

Fixes #774 — "DCC Upgrade Issues" (world stuck on `DCC world data version (0.34) is below the minimum supported version (0.66)`).

A world stamped between **0.22 and 0.66** is bricked on V14, and the error's instruction can't rescue it:

| Release line | Foundry | Migration gate | Effect on a 0.34 world |
|---|---|---|---|
| 0.66.x (last v13 / "pre-V14") | 13 | `currentVersion <= 0.22` | **Skipped** — 0.34 > 0.22, never migrated/re-stamped |
| 0.67.x (first v14) | 14 | `currentVersion < 0.68` | Would migrate & stamp 0.68 (but superseded) |
| 0.70.x (current) | 14 | floor `MINIMUM_SUPPORTED_VERSION = 0.66` | **Blocked** — 0.34 < 0.66 → error toast |

The 0.70.0 refactor (#720) set the floor to 0.66 on the theory that old worlds get migrated by a pre-V14 release first — but the pre-V14 lines only run their migration for worlds `<= 0.22`, so anything in the **(0.22, 0.66)** band slips past them and never advances. The referral target literally cannot help these worlds.

## Fix (per maintainer decision)

- **Lower `MINIMUM_SUPPORTED_VERSION` to 0.22** — the pre-V14 gate value, i.e. the highest version a pre-V14 release can actually carry forward. Worlds `< 0.22` are still blocked + referred (the referral genuinely works for them, since pre-V14 migrates `<= 0.22`); worlds in `[0.22, 0.68)` now migrate in place.
- **Re-add the version-gated `attackHitBonus` fixup (`<= 0.50`)** in `migrateActorData` so pre-split worlds seed their per-mode melee/missile bonus from the legacy flat `attackBonus`. The 0.65 base-speed split is already covered data-driven (it reads `_source` to see past the schema default), so no extra branch is needed there.
- **Repurpose the version-gate guard test**: gated branches at/above the 0.22 floor are allowed; only sub-floor (dead-code) gates remain forbidden.

The error message in `lang/en.json` is unchanged — it's now shown only to genuinely-ancient (`< 0.22`) worlds, for which "open in a pre-V14 0.65.x release first" is accurate.

## Test plan

- New `attackHitBonus` gated-migration cases in `migrations-data-driven.test.js` (fires `<=0.50`, boundary at 0.50, no-op above, no-op when `attackBonus` absent).
- Rewrote `migrations-version-gate-guard.test.js` to the new policy (floor 0.22; `0.10`/`0.21` block, `0.22`/`0.34`/`0.65` run; anti-pattern now catches only sub-0.22 gates).
- Updated the `check-migrations.test.js` block case to a sub-floor `0.20`.
- Full fast suite green: **1940 passed** (+6).

> [!NOTE]
> Migration-on-load isn't meaningfully exercised by the standard E2E world (already at the ceiling), so this relies on the unit coverage above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)