### PR TITLE
fix(migration): stamp version on partial failure + Item Piles sheet-override repair macro (#777)

### DIFF
--- a/docs/user-guide/Bundled-Macros.md
+++ b/docs/user-guide/Bundled-Macros.md
@@ -46,6 +46,35 @@ A batch version of **Set Up Player Token**. Updates all Player-type actors and t
 | Vision | Not set | Enabled |
 | Actor link | Not set | Enabled |
 
+## Repair Sheet Overrides
+
+A GM-only troubleshooting macro for a specific corruption: actor and item
+sheets that suddenly render as a stripped panel showing only the **name and
+portrait, with no body** (no abilities, attacks, equipment, etc.).
+
+This is almost always caused by another module — most often **Item Piles** —
+writing a *sheet override* onto your documents that forces them to use a
+different sheet. Because the override is stored on the documents (and in a
+world setting), it survives disabling the module and even restoring a world
+backup, so the broken sheets persist.
+
+Running this macro:
+
+1. Scans every actor and item for an Item Piles sheet override
+   (`flags.core.sheetClass` / `flags.item-piles`) and checks the world's
+   default sheet registration.
+2. Shows you a count of what it found and asks for confirmation.
+3. Removes those overrides so the documents fall back to their normal DCC
+   sheets, then reloads the page.
+
+It only touches overrides that reference Item Piles — any other sheet
+override you have set deliberately is left alone. If nothing is found, it
+tells you and makes no changes. **Back up your world before running it.**
+
+If the macro reports "nothing to repair" but your sheets are still broken
+with all modules disabled, the cause is something other than a sheet
+override — please [report it](Reporting-Bugs.md) with the details.
+
 ## Dragging Rollable Items to the Macro Bar
 
 Any rollable item (weapons, spells, skills, etc.) can be dragged directly to the macro bar for quick access:

--- a/module/__tests__/migrate-world.test.js
+++ b/module/__tests__/migrate-world.test.js
@@ -24,6 +24,7 @@ beforeEach(() => {
   info = vi.fn()
   vi.spyOn(console, 'error').mockImplementation(() => {})
   vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
 
   // The shared foundry mock's utils bag omits isEmpty (migrateActorData gates
   // .update() on it); provide a faithful implementation.
@@ -62,7 +63,7 @@ describe('migrateWorld orchestration', () => {
     expect(info.mock.calls.some(([m]) => m.includes('DCC.MigrationComplete'))).toBe(true)
   })
 
-  test('a per-document update failure leaves the version UNSTAMPED and warns', async () => {
+  test('a per-document update failure STILL stamps the version (forward progress) and warns', async () => {
     const ok = worldActor('Good')
     const bad = worldActor('Bad', vi.fn(async () => { throw new Error('update rejected') }))
     globalThis.game.actors = [ok, bad]
@@ -72,9 +73,14 @@ describe('migrateWorld orchestration', () => {
     // The good actor still migrates; the failure is caught + accumulated, not thrown.
     expect(ok.update).toHaveBeenCalled()
     expect(bad.update).toHaveBeenCalled()
-    // Version is NOT stamped, so the idempotent migrations re-run next load.
-    expect(settingsSet).not.toHaveBeenCalled()
-    // The GM is warned with the failure count rather than silently swallowing it.
+    // Forward-progress (issue #777): the version IS stamped even with a
+    // failure, so `migrateWorld` is NOT re-run on the next load — a single
+    // permanently-failing document can no longer re-sweep the whole world
+    // every boot (the loop that, on an Item Piles world, re-corrupted a
+    // freshly-restored backup).
+    expect(settingsSet).toHaveBeenCalledWith('dcc', 'systemMigrationVersion', NEEDS_MIGRATION_VERSION)
+    // The GM is still warned with the failure count rather than silently
+    // swallowing it, and `migrationComplete` reflects that it was not clean.
     expect(warn).toHaveBeenCalledTimes(1)
     expect(warn.mock.calls[0][0]).toContain('DCC.MigrationFailures')
     expect(warn.mock.calls[0][0]).toContain('"count":1')

--- a/module/__tests__/migration-outcome.test.js
+++ b/module/__tests__/migration-outcome.test.js
@@ -1,10 +1,17 @@
 /**
  * Unit tests for `migrationOutcome` — the pure stamp / notify policy
  * `migrateWorld` applies after accumulating per-document failures
- * (Phase 7 session 11). A clean run stamps the world version and shows
- * the "complete" toast; a run with any failure leaves the version
- * unstamped (the idempotent data-driven migrations re-run next load)
- * and warns the GM with the count instead of silently swallowing it.
+ * (Phase 7 session 11).
+ *
+ * Forward-progress policy (issue #777): a completed run ALWAYS stamps the
+ * version — `stampVersion` is `true` whether the run was clean or hit
+ * failures — so a partially-failing world is swept exactly once instead of
+ * re-running every boot. `clean` distinguishes the two: a clean run also
+ * notifies "complete"; a run with failures stamps anyway, notifies
+ * "failures" with the count, and (in `migrateWorld`) logs the offenders for
+ * manual repair. Previously a single permanently-failing document left the
+ * version unstamped and re-swept the whole world on every load — see the
+ * issue for the Item Piles re-corruption loop this prevents.
  *
  * The function takes no Foundry globals, so it's unit-testable in
  * isolation — same pattern as `classifyMigrationDecision`.
@@ -17,29 +24,41 @@ describe('migrationOutcome', () => {
   test('clean run (no failures) stamps the version and notifies complete', () => {
     expect(migrationOutcome([])).toEqual({
       stampVersion: true,
+      clean: true,
       notify: 'complete',
       failureCount: 0
     })
   })
 
-  test('a single failure does NOT stamp the version and notifies failures', () => {
+  test('a single failure STILL stamps the version (forward progress) and notifies failures', () => {
     expect(migrationOutcome([{ type: 'Actor', name: 'Bob' }])).toEqual({
-      stampVersion: false,
+      stampVersion: true,
+      clean: false,
       notify: 'failures',
       failureCount: 1
     })
   })
 
-  test('multiple failures report the exact count', () => {
+  test('multiple failures stamp the version and report the exact count', () => {
     const failures = [
       { type: 'Actor', name: 'Bob' },
       { type: 'Item', name: 'Sword' },
       { type: 'Scene', name: 'Cave' }
     ]
     const outcome = migrationOutcome(failures)
-    expect(outcome.stampVersion).toBe(false)
+    expect(outcome.stampVersion).toBe(true)
+    expect(outcome.clean).toBe(false)
     expect(outcome.notify).toBe('failures')
     expect(outcome.failureCount).toBe(3)
+  })
+
+  test('the version is always stamped — a failing world is never re-swept on the next load', () => {
+    // Forward-progress guarantee (issue #777): regardless of how many
+    // documents fail, `migrateWorld` advances the stored version so
+    // `classifyMigrationDecision` returns 'skip' next boot.
+    expect(migrationOutcome([]).stampVersion).toBe(true)
+    expect(migrationOutcome([{ type: 'Actor', name: 'X' }]).stampVersion).toBe(true)
+    expect(migrationOutcome(Array.from({ length: 50 }, (_, i) => ({ type: 'Item', name: `I${i}` }))).stampVersion).toBe(true)
   })
 
   test('defensive: a non-array argument is treated as a clean run', () => {
@@ -47,9 +66,10 @@ describe('migrationOutcome', () => {
     // caller passing null/undefined rather than throwing mid-migration.
     expect(migrationOutcome(undefined)).toEqual({
       stampVersion: true,
+      clean: true,
       notify: 'complete',
       failureCount: 0
     })
-    expect(migrationOutcome(null).stampVersion).toBe(true)
+    expect(migrationOutcome(null).clean).toBe(true)
   })
 })

--- a/module/migrations.js
+++ b/module/migrations.js
@@ -108,34 +108,55 @@ export function classifyMigrationDecision (currentVersion) {
  * stamp / notify policy is unit-testable in isolation (same pattern as
  * `classifyMigrationDecision`).
  *
- * Policy: a clean run stamps the world at `NEEDS_MIGRATION_VERSION` and
- * shows the "complete" notification. A run with any failed document does
- * NOT advance the version (so the world stays flagged and re-runs the —
- * idempotent — migrations on the next load after the GM resolves the
- * issue) and surfaces a `ui.notifications.warn` carrying the count. The
- * pre-this-change behavior swallowed each failure with a bare
- * `console.error` and stamped the version regardless, leaving a GM with
- * a green "complete" toast over a partially-migrated world.
+ * Policy: a completed run ALWAYS advances the stored version to
+ * `NEEDS_MIGRATION_VERSION` — `stampVersion` is `true` whether the run was
+ * clean or hit per-document failures. A clean run also shows the "complete"
+ * notification; a run with failures stamps anyway but warns the GM with the
+ * failure count (and logs each stack) so the failed documents are visible
+ * for manual repair.
+ *
+ * Why stamp on failure (issue #777): the previous policy left the version
+ * UNSTAMPED on any failure so the idempotent migrations would re-run next
+ * load. But `checkMigrations` re-runs `migrateWorld` on EVERY subsequent
+ * boot until it's stamped, and `migrateWorld` `.update()`s every actor and
+ * item each pass. A single permanently-failing document (e.g. one an active
+ * sheet-overriding module like Item Piles rejects in its own update hook)
+ * therefore turned world load into a perpetual world-wide `update()` storm —
+ * and, with that module live, re-fired its hooks every boot, so restoring a
+ * clean backup never stuck (the next load re-mutated it). Guaranteeing
+ * forward progress sweeps a partially-failing world exactly ONCE; the GM
+ * fixes the flagged documents and re-migrates them manually (e.g. via the
+ * "Repair Sheet Overrides" macro) rather than the system re-sweeping forever.
+ *
+ * `clean` is surfaced separately so callers can keep the prior
+ * `migrationComplete` semantics (true only for a fully-clean run) on the
+ * `dcc.ready` payload while the version is stamped regardless.
  *
  * @param {Array<{type: string, name: string}>} failures - One entry per
  *   document whose migration threw. Empty array means a clean run.
- * @returns {{ stampVersion: boolean, notify: 'complete'|'failures', failureCount: number }}
+ * @returns {{ stampVersion: boolean, clean: boolean, notify: 'complete'|'failures', failureCount: number }}
  */
 export function migrationOutcome (failures) {
   const failureCount = Array.isArray(failures) ? failures.length : 0
-  return failureCount === 0
-    ? { stampVersion: true, notify: 'complete', failureCount: 0 }
-    : { stampVersion: false, notify: 'failures', failureCount }
+  const clean = failureCount === 0
+  return {
+    stampVersion: true,
+    clean,
+    notify: clean ? 'complete' : 'failures',
+    failureCount
+  }
 }
 
 /**
  * Migrate the current world to the current version of the system
  *
  * @return {Promise<{ migrationComplete: boolean }>}  Resolves once the
- *   migration finishes. `migrationComplete` is `true` for a clean run
- *   (version stamped) and `false` if any document failed (version left
- *   unstamped so the idempotent migrations re-run next load). The flag is
- *   threaded onto the `dcc.ready` payload via `checkMigrations`.
+ *   migration finishes. `migrationComplete` is `true` for a clean run and
+ *   `false` if any document failed. Either way the stored version is now
+ *   stamped (issue #777) — a failing world is swept once, not on every
+ *   load — so `migrationComplete: false` means "stamped, but some documents
+ *   need manual repair", not "will re-run next load". The flag is threaded
+ *   onto the `dcc.ready` payload via `checkMigrations`.
  */
 export const migrateWorld = async function () {
   ui.notifications.info(game.i18n.format('DCC.MigrationInfo', { systemVersion: game.system.version }, { permanent: true }))
@@ -195,21 +216,26 @@ export const migrateWorld = async function () {
     failures.push(...await migrateCompendium(p))
   }
 
-  // Decide the finish: a clean run stamps the world at
-  // `NEEDS_MIGRATION_VERSION` (so subsequent loads classify as 'skip'
-  // in `classifyMigrationDecision`) and shows the "complete" toast; a
-  // run with failures leaves the version unstamped (the idempotent
-  // data-driven migrations re-run on the next load) and warns the GM
-  // with the count rather than silently swallowing the errors.
+  // Decide the finish: stamp the world at `NEEDS_MIGRATION_VERSION`
+  // unconditionally once the run completes (so subsequent loads classify
+  // as 'skip' in `classifyMigrationDecision` and the world is swept once,
+  // not re-swept on every boot — issue #777). A clean run shows the
+  // "complete" toast; a run with failures stamps anyway but logs the
+  // failed documents and warns the GM with the count so they can be
+  // repaired and re-migrated manually rather than the system re-running
+  // the whole world's updates forever.
   const outcome = migrationOutcome(failures)
   if (outcome.stampVersion) {
     game.settings.set('dcc', 'systemMigrationVersion', NEEDS_MIGRATION_VERSION)
+  }
+  if (outcome.clean) {
     ui.notifications.info(game.i18n.format('DCC.MigrationComplete', { systemVersion: game.system.version }, { permanent: true }))
   } else {
+    console.warn(`DCC | Migration completed with ${outcome.failureCount} failed document(s); version stamped to halt the re-run loop. Failed:`, failures)
     ui.notifications.warn(game.i18n.format('DCC.MigrationFailures', { count: outcome.failureCount }), { permanent: true })
   }
 
-  return { migrationComplete: outcome.stampVersion }
+  return { migrationComplete: outcome.clean }
 }
 
 /* -------------------------------------------- */
@@ -230,8 +256,10 @@ export const migrateWorld = async function () {
  * world fully migrated:
  *   - `true`  — nothing to migrate (already at the ceiling), a non-GM
  *               client (never migrates locally), or a clean `migrateWorld`.
- *   - `false` — a pre-V14 world was refused (blocked), or `migrateWorld`
- *               finished with per-document failures (version left unstamped).
+ *   - `false` — an ancient world was refused (blocked), or `migrateWorld`
+ *               finished with per-document failures (version still stamped
+ *               to halt the re-run loop; flagged documents need manual
+ *               repair — issue #777).
  *
  * @returns {Promise<{ migrationComplete: boolean }>}
  */

--- a/packs/dcc-macros/src/Repair_Sheet_Overrides_DCCRepairShts1AB.json
+++ b/packs/dcc-macros/src/Repair_Sheet_Overrides_DCCRepairShts1AB.json
@@ -1,0 +1,29 @@
+{
+  "name": "Repair Sheet Overrides",
+  "type": "script",
+  "author": "QljWNZW91EoRV9gI",
+  "img": "icons/svg/repair.svg",
+  "scope": "global",
+  "command": "/*\n * DCC — Repair Sheet Overrides\n *\n * Symptom this fixes: actor / item sheets render as a stripped \"name + image\"\n * panel with no body (often after an Item Piles mishap that flags every\n * document and forces its sheet). The override lives on the DOCUMENTS\n * (flags.core.sheetClass / flags.item-piles) and/or the world's default sheet\n * map (core.sheetClasses), so it survives disabling the module and restoring\n * a world backup. Clearing it lets the documents fall back to their normal\n * DCC sheets.\n *\n * Safe to run repeatedly. GM only. BACK UP YOUR WORLD FIRST.\n * https://github.com/foundryvtt-dcc/dcc/issues/777\n */\nif (!game.user.isGM) {\n  ui.notifications.warn('Only a GM can run the DCC sheet-override repair.')\n  return\n}\n\n// Matches the Item Piles package id in a registered sheet class string\n// (e.g. \"item-piles.ItemPileInventoryApp\") or its document-flag namespace.\nconst PATTERN = /item-?piles/i\n\n// --- Scan documents -------------------------------------------------------\nconst targets = []\nfor (const collection of [game.actors, game.items]) {\n  for (const doc of collection) {\n    const sheetClass = doc.getFlag('core', 'sheetClass')\n    const hasPileFlag = !!doc.flags?.['item-piles']\n    if ((typeof sheetClass === 'string' && PATTERN.test(sheetClass)) || hasPileFlag) {\n      targets.push({ doc, sheetClass: sheetClass || null, hasPileFlag })\n    }\n  }\n}\n\n// --- Scan the world default sheet map -------------------------------------\nconst sheetClasses = game.settings.get('core', 'sheetClasses') || {}\nconst worldDefaults = []\nfor (const docType of ['Actor', 'Item']) {\n  for (const [subtype, cls] of Object.entries(sheetClasses[docType] || {})) {\n    if (typeof cls === 'string' && PATTERN.test(cls)) worldDefaults.push(`${docType}.${subtype}`)\n  }\n}\n\nconst actorCount = targets.filter(t => t.doc.documentName === 'Actor').length\nconst itemCount = targets.filter(t => t.doc.documentName === 'Item').length\n\nif (!targets.length && !worldDefaults.length) {\n  ui.notifications.info('DCC: no Item Piles sheet overrides found — nothing to repair.')\n  return\n}\n\n// --- Confirm --------------------------------------------------------------\nconst content = `\n  <p>This clears Item Piles sheet overrides so documents fall back to their DCC sheets:</p>\n  <ul>\n    <li><strong>${actorCount}</strong> actor(s)</li>\n    <li><strong>${itemCount}</strong> item(s)</li>\n    <li><strong>${worldDefaults.length}</strong> world default sheet registration(s)</li>\n  </ul>\n  <p>For each flagged document it removes <code>flags.core.sheetClass</code> and the\n  <code>flags.item-piles</code> data, and strips any Item Piles entry from the world's\n  default sheet map. Overrides that do <em>not</em> reference Item Piles are left untouched.</p>\n  <p><strong>Back up your world first.</strong> The page reloads when the repair finishes.</p>\n`\n\nconst confirmed = await foundry.applications.api.DialogV2.confirm({\n  window: { title: 'DCC — Repair Sheet Overrides' },\n  content,\n  modal: true,\n  rejectClose: false\n})\nif (!confirmed) return\n\n// --- Apply ----------------------------------------------------------------\nlet repaired = 0\nconst failures = []\nfor (const { doc, sheetClass, hasPileFlag } of targets) {\n  const update = {}\n  if (sheetClass) update['flags.core.-=sheetClass'] = null\n  if (hasPileFlag) update['flags.-=item-piles'] = null\n  if (foundry.utils.isEmpty(update)) continue\n  try {\n    await doc.update(update)\n    repaired++\n  } catch (err) {\n    console.error(`DCC repair: failed on ${doc.documentName} \"${doc.name}\" (${doc.id})`, err)\n    failures.push(`${doc.documentName} \"${doc.name}\"`)\n  }\n}\n\nif (worldDefaults.length) {\n  const updated = foundry.utils.deepClone(sheetClasses)\n  for (const docType of ['Actor', 'Item']) {\n    for (const subtype of Object.keys(updated[docType] || {})) {\n      if (typeof updated[docType][subtype] === 'string' && PATTERN.test(updated[docType][subtype])) {\n        delete updated[docType][subtype]\n      }\n    }\n  }\n  try {\n    await game.settings.set('core', 'sheetClasses', updated)\n  } catch (err) {\n    console.error('DCC repair: failed to update core.sheetClasses', err)\n    failures.push('world default sheet map')\n  }\n}\n\nconsole.log('DCC sheet-override repair complete.', { repaired, worldDefaults, failures })\nif (failures.length) {\n  ui.notifications.warn(`DCC repair finished with ${failures.length} failure(s) — see the console (F12). Repaired ${repaired} document(s).`)\n} else {\n  ui.notifications.info(`DCC repair complete: ${repaired} document(s) cleaned, ${worldDefaults.length} world default(s) reset. Reloading…`)\n  setTimeout(() => foundry.utils.debouncedReload(), 1500)\n}",
+  "folder": null,
+  "sort": 0,
+  "flags": {
+    "core": {}
+  },
+  "_id": "DCCRepairShts1AB",
+  "_stats": {
+    "coreVersion": "13.342",
+    "systemId": null,
+    "systemVersion": null,
+    "createdTime": null,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!macros!DCCRepairShts1AB"
+}


### PR DESCRIPTION
Fixes the persistence mechanism behind #777 ("Sheets missing bodies after latest update") and ships a repair tool.

## Background — what #777 actually is

Reporter's actor/item sheets render as a stripped **name + image panel, no body**, and it survived disabling all modules and restoring a world backup. Investigation (chrome-devtools against a live v14 world) established:

- **It's Item Piles document corruption, not a DCC template/data bug.** Item Piles overrides which sheet renders via `flags.core.sheetClass` (+ a `flags.item-piles` pile marker) on documents, and/or the world-level `core.sheetClasses` default map. A bad batch op flags *every* actor/item, so they all render as the Item Piles sheet.
- The DCC sheet underneath is healthy: a *dangling* override (class missing, module off) **falls back cleanly to the full `DCCActorSheet`** in testing. A `_prepareContext` throw yields no window at all; any single part-template throw yields an empty body (`_renderHTML` is atomic) — so "name+image only" is the Item Piles sheet, not a DCC render failure.

## Why a restored backup didn't stick (the bug this PR fixes)

`migrateWorld` left `systemMigrationVersion` **unstamped** whenever any per-document update threw, so `checkMigrations` re-ran the *entire* world `.update()` sweep on **every** subsequent boot. A single permanently-failing document (e.g. one Item Piles rejects in its update hook) turned world load into a perpetual world-wide `update()` storm — and with Item Piles live, re-fired its hooks each load, re-corrupting a freshly-restored backup.

## Changes

- **`migrationOutcome`** now always returns `stampVersion: true` and adds a `clean` flag (preserving the prior `migrationComplete` clean-only semantics on the `dcc.ready` payload).
- **`migrateWorld`** stamps the version unconditionally once a run completes, logs the failed documents to the console, and still warns the GM with the count. A partially-failing world is swept **exactly once**, not every boot.
- **New GM-only "Repair Sheet Overrides" compendium macro** (`packs/dcc-macros`): clears `flags.core.sheetClass` + `flags.item-piles` and any item-piles entry in the `core.sheetClasses` world default map, then reloads. DialogV2 confirm, idempotent. Verified end-to-end against live Foundry (corrupted actor+item → flags cleared → fall back to `DCCActorSheet`/`DCCItemSheet`).

## Tests

- `migration-outcome.test.js` / `migrate-world.test.js` updated to assert forward progress (version stamped even on failure; GM still warned; `migrationComplete` stays clean-only).
- Full fast suite green: **1941 passed**. StandardJS clean.

## Notes / follow-ups

- The macro pack's LevelDB is gitignored; `npm run todb` (Foundry shut down) or the release build compiles it.
- E2E (Playwright) not run — this is boot-path migration logic, not the attack/sheet/chat render path, and is unit-covered.
- Related latent hazard spotted (not fixed here): `DCCActorSheetGeneric._prepareContext` does a `document.update()` *during render*, which can thrash with Item Piles' update hooks.
- Reporter probes still outstanding to confirm their specific instance (stored `systemMigrationVersion`; `actor.sheet.constructor.name` with modules genuinely off; incognito / new-world isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)