### PR TITLE
fix(sheet): ability title click no longer opens the edit dialog (#779)

### DIFF
--- a/browser-tests/e2e/ability-score-log.spec.js
+++ b/browser-tests/e2e/ability-score-log.spec.js
@@ -207,6 +207,27 @@ test.describe('DCC Ability Score Log E2E Tests', () => {
     await expect(healedRow.locator('.heal-button')).toHaveCount(0)
   })
 
+  test('clicking the ability title rolls a check without opening the edit dialog (issue #779)', async ({ page }) => {
+    await createAndOpenActor(page)
+
+    // With the log enabled the title label drops its `for=` so a click is not
+    // forwarded to the readonly value input (which carries the edit action).
+    const strTitle = page.locator('.dcc.actor.sheet .ability-box[data-ability="str"] label.box-title.rollable')
+    await expect(strTitle).not.toHaveAttribute('for')
+
+    const messagesBefore = await page.evaluate(() => game.messages.size)
+
+    await strTitle.click()
+    await page.waitForTimeout(600)
+
+    // The check rolled (a chat card was created) ...
+    const messagesAfter = await page.evaluate(() => game.messages.size)
+    expect(messagesAfter).toBe(messagesBefore + 1)
+
+    // ... and the edit dialog did NOT pop open on top of the roll
+    await expect(page.locator('.dcc.ability-score-config')).toHaveCount(0)
+  })
+
   test('direct API updates are logged as manual entries, flagged updates are not', async ({ page }) => {
     await createAndOpenActor(page)
 

--- a/templates/actor-partial-pc-common.html
+++ b/templates/actor-partial-pc-common.html
@@ -205,7 +205,11 @@
     {{!-- Ability Scores --}}
     {{#* inline "abilityScore"}}
       <div class="ability-box" id="{{id}}" data-ability="{{id}}">
-        <label for="system.abilities.{{id}}.value" class="box-title rollable"
+        {{!-- When the Ability Score Log is enabled the value input becomes an
+              editAbilityScore action target; dropping the label's `for=` here
+              stops a title click from being forwarded to that input and firing
+              the edit dialog on top of the ability check (see issue #779). --}}
+        <label {{#unless @root.abilityScoreLogEnabled}}for="system.abilities.{{id}}.value"{{/unless}} class="box-title rollable"
                title="{{localize (concat 'DCC.Roll' (localize ability.label) 'CheckHint')}}"
                data-action="rollAbilityCheck" data-drag="true" data-drag-action="ability">
           {{localize ability.label}}


### PR DESCRIPTION
Fixes #779.

## Problem
With the **Ability Score Log** world setting enabled, clicking an ability **title** ("Strength", etc.) both rolled the ability check *and* popped open the score-edit dialog — the reporter's "a die is rolled for a skill check **and** the window pops open."

## Root cause
When the log is enabled the score value `<input>` gains `data-action="editAbilityScore"`. The rollable title `<label for="system.abilities.{id}.value">` is associated with that same input, so clicking the title fired its own `rollAbilityCheck` **and** the browser forwarded a synthetic click to the associated input (label-`for` forwarding fires on `readonly` inputs — only `disabled` blocks it), which fired `editAbilityScore`. With the log off the input has no action, so there was no second fire — hence the bug only appeared with the log on. It was the `for=`/`id` association, not CSS targeting.

## Fix
Drop the title label's `for=` when the log is enabled (`templates/actor-partial-pc-common.html`). Result — the chosen behavior:
- **Title** → rolls the check (only).
- **Number** → opens the edit dialog.

The luck `rollUnder` logic only compares `htmlFor` against the `.mod` id, so an empty `htmlFor` still rolls-under correctly. The change is scoped to the log-enabled config; log-off behavior is untouched.

## Tests
- `npm test` green (1883 passing).
- Added an E2E regression probe in `browser-tests/e2e/ability-score-log.spec.js`: clicking the Str title with the log on rolls exactly one chat card and does **not** open the edit dialog, and asserts the title has no `for=` when the log is enabled.

> [!NOTE]
> The browser/E2E suite is **not** run by CI and was **not** run locally for this PR — running it would require serving this branch from the Foundry system path, which would disrupt a parallel session on `main`. The new probe is committed for a manual run (`browser-tests/e2e` against live Foundry) when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)