### PR TITLE
fix: table-wide damage automation + consistent attack cards (#783) + V14 dcc-qol compat

### DIFF
--- a/module/__tests__/chat-message.test.js
+++ b/module/__tests__/chat-message.test.js
@@ -1,0 +1,39 @@
+/**
+ * Unit coverage for module/chat-message.js — the DCCChatMessage compatibility
+ * shim. V14 removed the `getSpeakerActor()` instance method in favour of the
+ * `speakerActor` getter; the shim restores the method by delegating to it so
+ * modules/macros (e.g. dcc-qol) calling the V13 form don't throw (issue: QoL
+ * `message.getSpeakerActor is not a function`).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+let DCCChatMessage
+
+beforeEach(async () => {
+  // Minimal ChatMessage base exposing the V14 `speakerActor` getter.
+  globalThis.ChatMessage = class ChatMessage {
+    get speakerActor () { return this._speakerActor ?? null }
+  }
+  DCCChatMessage = (await import('../chat-message.js')).default
+})
+
+afterEach(() => { delete globalThis.ChatMessage })
+
+describe('DCCChatMessage.getSpeakerActor', () => {
+  test('is a callable instance method (the V13 form modules still use)', () => {
+    const msg = new DCCChatMessage()
+    expect(typeof msg.getSpeakerActor).toBe('function')
+  })
+
+  test('delegates to the V14 speakerActor getter', () => {
+    const actor = { name: 'Speaker' }
+    const msg = new DCCChatMessage()
+    msg._speakerActor = actor
+    expect(msg.getSpeakerActor()).toBe(actor)
+  })
+
+  test('returns null when there is no speaker actor', () => {
+    expect(new DCCChatMessage().getSpeakerActor()).toBeNull()
+  })
+})

--- a/module/__tests__/enhanced-attack-card.test.js
+++ b/module/__tests__/enhanced-attack-card.test.js
@@ -132,12 +132,29 @@ describe('buildEnhancedCardData', () => {
     expect(data.diceHTML).toBe('<a>15</a>')
   })
 
-  test('automated reads the setting and surfaces rolled fields', async () => {
+  test('automated falls back to the live setting for legacy cards (no stored flag)', async () => {
     settings.automateDamageFumblesCrits = true
     const msg = makeMessage({ isToHit: true }, { damageInlineRoll: '<a>7</a>', critResult: 'x' })
     const data = await buildEnhancedCardData(msg, pcActor, weapon)
     expect(data.automated).toBe(true)
     expect(data.damageInlineRoll).toBe('<a>7</a>')
+  })
+
+  // Issue #783: the card is rendered from the creation-time `automated` flag,
+  // not the viewer's live (client-readable) setting, so every viewer sees the
+  // same buttons-vs-results regardless of their own automation preference.
+  test('stored automated:true flag wins over a manual live setting (auto-roll attacker, manual viewer)', async () => {
+    settings.automateDamageFumblesCrits = false
+    const msg = makeMessage({ isToHit: true, automated: true }, { damageInlineRoll: '<a>7</a>' })
+    const data = await buildEnhancedCardData(msg, pcActor, weapon)
+    expect(data.automated).toBe(true)
+  })
+
+  test('stored automated:false flag wins over an automatic live setting (manual attacker, auto viewer)', async () => {
+    settings.automateDamageFumblesCrits = true
+    const msg = makeMessage({ isToHit: true, automated: false }, { damageRollFormula: '1d6' })
+    const data = await buildEnhancedCardData(msg, pcActor, weapon)
+    expect(data.automated).toBe(false)
   })
 
   test('NPC attacker: no weapon description exposed', async () => {

--- a/module/__tests__/init-hook.test.js
+++ b/module/__tests__/init-hook.test.js
@@ -25,6 +25,7 @@ vi.mock('../actor-sheets-dcc.js', () => ({
   DCCActorSheetGeneric: { name: 'Generic' }
 }))
 vi.mock('../combatant.js', () => ({ default: { name: 'DCCCombatant' } }))
+vi.mock('../chat-message.js', () => ({ default: { name: 'DCCChatMessage' } }))
 vi.mock('../item.js', () => ({ default: { name: 'DCCItem' } }))
 vi.mock('../item-sheet.js', () => ({ default: { name: 'DCCItemSheet' } }))
 vi.mock('../dcc-roll.js', () => ({ default: { name: 'DCCRoll' } }))
@@ -116,7 +117,8 @@ beforeEach(() => {
     Dice: { fulfillment: {} },
     Actor: {},
     Item: {},
-    Combatant: {}
+    Combatant: {},
+    ChatMessage: {}
   }
   globalThis.game = { settings: { register: vi.fn() } }
   globalThis.Hooks = { once: vi.fn() }
@@ -159,6 +161,7 @@ describe('registerDocumentConfig', () => {
     expect(globalThis.CONFIG.Actor.documentClass.name).toBe('DCCActor')
     expect(globalThis.CONFIG.Item.documentClass.name).toBe('DCCItem')
     expect(globalThis.CONFIG.Combatant.documentClass.name).toBe('DCCCombatant')
+    expect(globalThis.CONFIG.ChatMessage.documentClass.name).toBe('DCCChatMessage')
     expect(globalThis.CONFIG.ActiveEffect.documentClass.name).toBe('DCCActiveEffect')
   })
 

--- a/module/actor/rolls-weapon-mixin.mjs
+++ b/module/actor/rolls-weapon-mixin.mjs
@@ -241,6 +241,11 @@ export const RollsWeaponMixin = (Base) => class extends Base {
 
     const flags = {
       'dcc.isToHit': true,
+      // Record the automation decision made here, at creation time, so viewers
+      // render the card from what actually happened rather than re-deriving it
+      // from their own setting (issue #783). The enhanced attack card reads this
+      // to choose Roll buttons vs. resolved results consistently for everyone.
+      'dcc.automated': automateDamageFumblesCrits,
       'dcc.isBackstab': options.backstab,
       'dcc.isFumble': attackRollResult.fumble,
       'dcc.isCrit': attackRollResult.crit,

--- a/module/chat-message.js
+++ b/module/chat-message.js
@@ -1,0 +1,28 @@
+/* global ChatMessage */
+
+/**
+ * Extend the base ChatMessage document with a backward-compatibility shim for
+ * the `getSpeakerActor()` instance method that Foundry removed in V14.
+ *
+ * V14 replaced the instance method with the `speakerActor` getter (the static
+ * `ChatMessage.getSpeakerActor(speaker)` remains). Modules and macros that
+ * still call the V13 instance form — notably dcc-qol's attack-card hook
+ * (`enhanceAttackRollCard`) — otherwise throw `message.getSpeakerActor is not a
+ * function`, which aborts chat-card rendering and spams the console. Restoring
+ * the method here keeps those callers working without each one needing its own
+ * V14 fix (DCC already tracks dcc-qol compatibility — see CLAUDE.md).
+ *
+ * @extends {ChatMessage}
+ */
+class DCCChatMessage extends ChatMessage {
+  /**
+   * The Actor that represents the speaker of this message, if any.
+   * V13 instance-method shim delegating to the V14 `speakerActor` getter.
+   * @returns {Actor|null}
+   */
+  getSpeakerActor () {
+    return this.speakerActor
+  }
+}
+
+export default DCCChatMessage

--- a/module/chat/enhanced-attack-card.mjs
+++ b/module/chat/enhanced-attack-card.mjs
@@ -11,8 +11,10 @@
  * `.message-content`, so it is **mutually exclusive with the emote-roll rewrite
  * for attack cards** (the wiring skips the attack emote path when this renders).
  *
- * The damage/crit/fumble buttons appear only when `automateDamageFumblesCrits`
- * is off (otherwise the rolls are already resolved and shown inline). Clicking a
+ * The damage/crit/fumble buttons appear only when the card was created with
+ * automation off (recorded in the `dcc.automated` flag at creation time — not
+ * re-read from the viewer's live setting, so the card renders the same for
+ * everyone; otherwise the rolls are already resolved and shown inline). Clicking a
  * button rolls via `DCCRoll.createRoll` (honoring the modifier dialog) and posts
  * a standalone roll message — the system's existing crit/fumble table lookup
  * renders the result on that message — then marks the originating card so the
@@ -88,10 +90,20 @@ export async function buildEnhancedCardData (message, actor, weapon) {
   const hasTarget = !!flag('hasTarget')
   const hitsTarget = !!flag('hitsTarget')
 
-  let automated = false
-  try {
-    automated = game.settings.get('dcc', 'automateDamageFumblesCrits') === true
-  } catch { automated = false }
+  // Whether damage/crit/fumble were auto-rolled is fixed when the card is
+  // created (by the attacker's client), so render from the stored `automated`
+  // flag rather than this viewer's live setting — otherwise the card renders
+  // inconsistently between players and the GM (issue #783). Fall back to the
+  // live setting for legacy cards created before the flag existed.
+  let automated
+  const storedAutomated = flag('automated')
+  if (storedAutomated === undefined) {
+    try {
+      automated = game.settings.get('dcc', 'automateDamageFumblesCrits') === true
+    } catch { automated = false }
+  } else {
+    automated = storedAutomated === true
+  }
 
   let showHitMiss = true
   try {

--- a/module/init-hook.mjs
+++ b/module/init-hook.mjs
@@ -22,6 +22,7 @@ import DCCActiveEffect from './active-effect.js'
 import DCCActor from './actor.js'
 import DCCActorSheet from './actor-sheet.js'
 import * as DCCSheets from './actor-sheets-dcc.js'
+import DCCChatMessage from './chat-message.js'
 import DCCCombatant from './combatant.js'
 import DCCItem from './item.js'
 import DCCItemSheet from './item-sheet.js'
@@ -177,6 +178,9 @@ export function registerDocumentConfig () {
   CONFIG.Actor.documentClass = DCCActor
   CONFIG.Item.documentClass = DCCItem
   CONFIG.Combatant.documentClass = DCCCombatant
+  // Restores the V13 `getSpeakerActor()` instance method removed in V14, so
+  // modules/macros still calling it (e.g. dcc-qol) don't throw on card render.
+  CONFIG.ChatMessage.documentClass = DCCChatMessage
 }
 
 /**

--- a/module/settings.js
+++ b/module/settings.js
@@ -314,12 +314,19 @@ export const registerSystemSettings = async function () {
   })
 
   /**
-   * Automatically roll damage, fumbles, and crits for attacks
+   * Automatically roll damage, fumbles, and crits for attacks.
+   *
+   * World-scoped: automation governs shared chat-card content (whether a card
+   * carries a resolved damage/crit/fumble roll or a manual Roll button) and
+   * whether players can roll their own damage, so it is a table-wide decision
+   * the GM owns — not a per-client preference. A client scope let a player's
+   * default (automatic) override a GM's manual choice and made enhanced cards
+   * render inconsistently between viewers (issue #783).
    */
   game.settings.register('dcc', 'automateDamageFumblesCrits', {
     name: 'DCC.SettingAutomateDamageFumblesCrits',
     hint: 'DCC.SettingAutomateDamageFumblesCritsHint',
-    scope: 'client',
+    scope: 'world',
     type: Boolean,
     default: true,
     config: true


### PR DESCRIPTION
Closes #783.

Two chat/attack-card fixes discovered together while reproducing #783.

## 1. Damage automation is now table-wide and cards render consistently (#783)

**Symptoms (reported via Discord):**
- With damage set to *manual*, the player saw a rolled damage result and no Roll button, while the judge saw a Roll button and no result.
- With dcc-qol active, damage auto-rolled even though the setting was manual.

**Root cause:** `automateDamageFumblesCrits` was **client-scoped** (default automatic). Whether damage actually rolled was fixed once, on the *attacker's* client, at card-creation; but the enhanced attack card re-derived automated-vs-manual from *each viewer's* live setting at render time. A player on the default (auto) and a GM on manual therefore saw different cards for the same attack, and a player's client could override the GM's manual choice.

**Fix:**
- `automateDamageFumblesCrits` → `scope: 'world'` (a GM/table-wide decision, matching the neighbouring `automate*` settings).
- Stamp a `dcc.automated` flag on the attack card at creation time; the enhanced card renders button-vs-result from that flag, not the live setting (legacy cards fall back to the setting). Every viewer now sees the same card.

> ⚠️ Scope change: a GM who had previously set this client-side to *manual* will see it reset to the world default (automatic) once after updating, and will need to set it once more — now it applies table-wide.

## 2. Restore `ChatMessage#getSpeakerActor()` for V14 (dcc-qol compat)

V14 removed the `getSpeakerActor()` instance method (replaced by the `speakerActor` getter; the static form remains). dcc-qol's `enhanceAttackRollCard` hook still calls the instance form, throwing `message.getSpeakerActor is not a function` on **every** attack-card render and aborting it. A `DCCChatMessage` document subclass restores the method by delegating to `speakerActor`. The real fix should also land in dcc-qol; this keeps any caller of the old API working in the meantime.

## Testing

- **Vitest:** 1950 pass (added coverage for the `automated`-flag precedence, the shim, and the new documentClass registration).
- **Playwright E2E (live V14 world), same session:**

  | Config | Failed | Passed |
  |--------|-------:|-------:|
  | main + dcc-qol **on** (before) | 19 | 208 |
  | this branch + dcc-qol **on** (after) | **7** | 220 |
  | this branch + dcc-qol **off** | 2 | 225 |

  With dcc-qol enabled the branch is **strictly better** (19 → 7); the shim repairs every `getSpeakerActor` crash. All 7 remaining QoL-on failures are a **subset** of main's 19 (QoL-takes-over-combat specs that also fail on main and pass with QoL off). The only two failures present in *every* config — `extension-api.spec.js:1542` (migrationOutcome) and `:2423` (level-pack discovery) — are pre-existing/environmental, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)