### PR TITLE
chore: scrub stale refactor-doc pointers from code comments

### DIFF
--- a/module/__tests__/adapter-spell-check.test.js
+++ b/module/__tests__/adapter-spell-check.test.js
@@ -711,7 +711,7 @@ test('naked spell check on a Cleric actor uses cleric profile (D4 naked)', async
 })
 
 test('naked spell check honors options.checkLabel as the chat flavor base (raw-check relabel)', async () => {
-  // SPELL_CHECK_LABEL_OVERRIDE: a raw (no-item) spell check rolled from
+  // checkLabel override: a raw (no-item) spell check rolled from
   // a class cell can carry a label override so e.g. MCC's "Mutation
   // Check" reads correctly in chat instead of the generic "Spell Check".
   // `checkLabel` is an i18n key or a literal — `localize` passes a

--- a/module/__tests__/class-dispatch-i18n-guard.test.js
+++ b/module/__tests__/class-dispatch-i18n-guard.test.js
@@ -7,7 +7,7 @@
  * class label at sheet-init time (`module/actor-sheets-dcc.js`), so any
  * dispatch like `className === game.i18n.localize('DCC.Halfling')`
  * silently breaks when the user's locale isn't English. The historical
- * bug (`actor.js:1725` per `ARCHITECTURE_REIMAGINED.md §2`) was fixed
+ * bug (`actor.js:1725`) was fixed
  * pre-refactor; C3 audits the codebase to confirm no residuals and
  * plants this guard so a future bug can't drift back in.
  *

--- a/module/__tests__/schema-slimming-guard.test.js
+++ b/module/__tests__/schema-slimming-guard.test.js
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'vitest'
 import { actorToCharacter } from '../adapter/character-accessors.mjs'
 
-// §2.1 schema-slimming resolution guard (see docs/dev/SCHEMA_SLIMMING.md).
+// Schema-slimming resolution guard.
 //
 // §2.1 ("the Player schema is monolithic") cannot be resolved by making a
 // halfling's schema differ from a wizard's — Foundry's defineSchema() is static,

--- a/module/actor/derived-stats-mixin.mjs
+++ b/module/actor/derived-stats-mixin.mjs
@@ -128,8 +128,8 @@ export const DerivedStatsMixin = (Base) => class extends Base {
 
     // Stable extension hook — modules can adjust `system.class.spellCheck`
     // (and any related skill mirror fields) here without subclassing
-    // DCCActor. Closes ARCHITECTURE_REIMAGINED.md §2.5 "Actor document
-    // class customization" for XCC's blaster-die / elf-trickster
+    // DCCActor. Closes the "Actor document class customization" pain
+    // point for XCC's blaster-die / elf-trickster
     // computation. See docs/dev/EXTENSION_API.md.
     Hooks.callAll('dcc.afterComputeSpellCheck', this)
   }

--- a/module/adapter/debug.mjs
+++ b/module/adapter/debug.mjs
@@ -49,8 +49,7 @@ export function logDispatch (rollType, path, details = {}) {
  * e2e run, the safety net has served its purpose and each `warnIfDivergent`
  * call can be removed (the surrounding two-pass stays — it is the adapter's
  * design, not scaffolding). Until then, keep them: a silent lib bump that
- * shifts a total is exactly what this is here to catch. Tracked against
- * ARCHITECTURE_REIMAGINED.md §8.6.
+ * shifts a total is exactly what this is here to catch.
  *
  * @param {string} rollType - e.g. 'rollToHit', 'rollDamage', 'rollCritical'
  * @param {number} foundryTotal - Foundry Roll's final total

--- a/module/adapter/table-cache.mjs
+++ b/module/adapter/table-cache.mjs
@@ -41,8 +41,7 @@
  * the walk would return null again unless a world-table CRUD event
  * fires (which is when the cache invalidates).
  *
- * See `docs/00-progress.md` "PR #720 review backlog" → "Uncached
- * compendium walks" for the surfacing context.
+ * Surfaced in PR #720's review backlog (uncached compendium walks).
  */
 
 export const disapprovalTableCache = new Map()

--- a/module/built-in-class-mixins.mjs
+++ b/module/built-in-class-mixins.mjs
@@ -11,8 +11,7 @@
  * Sharing the registration list between `module/dcc.js`'s `init` hook
  * and the integration-test setup (`module/__integration__/setup-foundry.js`)
  * means new class mixins land in one place and both environments stay
- * in sync. See `docs/dev/CLASS_DECOMPOSITION.md` §3.1 and
- * `docs/dev/EXTENSION_API.md` for the broader contract.
+ * in sync. See `docs/dev/EXTENSION_API.md` for the broader contract.
  */
 import { DiceField } from './data/fields/_module.mjs'
 

--- a/module/extension-api.mjs
+++ b/module/extension-api.mjs
@@ -2,9 +2,9 @@
  * Stable extension-API helpers exposed via `game.dcc`.
  *
  * Each export here is **stable from day one** per
- * `docs/dev/EXTENSION_API.md` — the surface relieves an
- * `ARCHITECTURE_REIMAGINED.md §2` pain point that would otherwise
- * leak into core if module authors had to invent their own boilerplate.
+ * `docs/dev/EXTENSION_API.md` — the surface relieves a pain point that
+ * would otherwise leak into core if module authors had to invent their
+ * own boilerplate.
  *
  * Stay narrow: each helper does ONE thing and binds to ONE existing
  * pain point.
@@ -601,8 +601,7 @@ export function registerHomebrewClassForProgressionLoad (classId, itemPrefix, de
  * Register a variant ruleset. Variants give the system a named identity
  * for the active set of classes ("dcc", "xcc", "mcc") so sibling content
  * modules can ship as a Foundry module rather than overriding
- * `CONFIG.Actor.documentClass` globally. Closes the
- * `ARCHITECTURE_REIMAGINED.md §2.5 / §3.6` pressure point that
+ * `CONFIG.Actor.documentClass` globally. Closes the pressure point that
  * previously forced variants like XCC to fight the system for the
  * documentClass slot.
  *

--- a/module/init-hook.mjs
+++ b/module/init-hook.mjs
@@ -119,8 +119,7 @@ export const TEMPLATE_PATHS = Object.freeze([
  *   registration table lives in `module/built-in-class-mixins.mjs` so the
  *   integration-test setup can register the same set without duplicating
  *   mixin bodies. Sibling modules contribute their own classes' mixins via
- *   `game.dcc.registerClassMixin` (see `docs/dev/EXTENSION_API.md` +
- *   `docs/dev/CLASS_DECOMPOSITION.md`).
+ *   `game.dcc.registerClassMixin` (see `docs/dev/EXTENSION_API.md`).
  * - Class defaults (Phase 5 session 1) lift the per-class `_prepareContext`
  *   first-open default-write blocks off each sheet subclass onto a registry;
  *   sheets call `applyClassDefaults(actor, classId)`.

--- a/module/spell-check-processor.mjs
+++ b/module/spell-check-processor.mjs
@@ -6,9 +6,8 @@
  * Stable extension surface — `game.dcc.processSpellCheck` is published
  * via the init hook in `module/dcc.js` and consumed by `DCCItem.rollSpellCheck`,
  * `DCCActor.rollSpellCheck`'s adapter-declined paths, and sibling content
- * modules. See `docs/dev/EXTENSION_API.md`'s Stable surface table and
- * `docs/00-progress.md`'s Decision #6 (permanent stable API, no
- * deprecation path).
+ * modules. See `docs/dev/EXTENSION_API.md`'s Stable surface table
+ * (permanent stable API, no deprecation path).
  *
  * Originally a pure (byte-identical) extraction of the inline definition;
  * since extended with the explicit `castingMode` override (issue #375).

--- a/scripts/sync-core-lib.mjs
+++ b/scripts/sync-core-lib.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 // Sync @moonloch/dcc-core-lib's built dist/ into module/vendor/dcc-core-lib/.
 // Foundry loads system files directly (no bundler), so we vendor the lib's
-// compiled ESM output and commit it. See docs/dev/ARCHITECTURE_REIMAGINED.md.
+// compiled ESM output and commit it. See the "Working with dcc-core-lib"
+// section of CLAUDE.md for the vendor-sync workflow.
 //
 // Source of truth defaults to the co-evolving checkout at
 // /Users/timlwhite/WebstormProjects/dcc-core-lib. Override with


### PR DESCRIPTION
Follow-up to #787. After removing the completed dcc-core-lib refactor docs, several code comments still pointed at those deleted files. This rewords each so the comment carries the point inline instead of citing a file that no longer exists.

**Comment-only — no behavior change.** Touches 11 references across:
- `module/extension-api.mjs` (×2), `init-hook.mjs`, `spell-check-processor.mjs`, `built-in-class-mixins.mjs`, `adapter/table-cache.mjs`, `adapter/debug.mjs`, `actor/derived-stats-mixin.mjs`, `scripts/sync-core-lib.mjs`
- tests: `class-dispatch-i18n-guard`, `schema-slimming-guard`, `adapter-spell-check`

Verified: `grep` for the deleted doc names across `module/` + `scripts/` returns nothing; 1952 unit tests pass; format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)