### PR TITLE
feat(attack): add editable situational bonus to attack modifier dialog (#791)

### DIFF
--- a/browser-tests/e2e/adapter-dispatch.spec.js
+++ b/browser-tests/e2e/adapter-dispatch.spec.js
@@ -2206,6 +2206,69 @@ test.describe('DCC Adapter Dispatch Validation', () => {
       assertPath(damageLine, 'adapter', { weapon: 'P1-Longsword' })
     })
 
+    test('warrior modifier dialog exposes an editable "+0" attack bonus that flows into the total (issue #791)', async ({ page }) => {
+      // A warrior's to-hit is a deed die with no flat component, so the
+      // modifier dialog used to offer only die rows — there was nowhere to
+      // type a separate situational bonus (the Discord report). The dialog
+      // now always exposes a flat, editable "Bonus" row defaulting to +0.
+      await page.evaluate(async () => {
+        const actor = await Actor.create({
+          name: 'P1 Warrior Bonus',
+          type: 'Player',
+          system: {
+            details: { sheetClass: 'Warrior', attackBonus: '+d4' },
+            class: { className: 'Warrior' },
+            config: { attackBonusMode: 'autoPerAttack' }
+          }
+        })
+        await actor.createEmbeddedDocuments('Item', [{
+          name: 'P1-DeedSword',
+          type: 'weapon',
+          system: { actionDie: '1d20', toHit: '@ab', damage: '1d8+@ab', melee: true, equipped: true }
+        }])
+        await game.settings.set('dcc', 'automateDamageFumblesCrits', true)
+      })
+      const weaponId = await page.evaluate(() =>
+        game.actors.getName('P1 Warrior Bonus').items.getName('P1-DeedSword').id
+      )
+
+      // Fire the attack; it blocks on the modifier dialog.
+      await page.evaluate((id) => {
+        window.__attackBonusPromise = game.actors
+          .getName('P1 Warrior Bonus')
+          .rollWeaponAttack(id, { showModifierDialog: true })
+      }, weaponId)
+
+      const dialog = page.locator('.dcc-roll-modifier')
+      await dialog.locator('button.roll').waitFor({ state: 'visible', timeout: 5000 })
+
+      // The new situational bonus row: labelled "Bonus", editable, default +0.
+      const bonusLabel = dialog.locator('label.term-label', { hasText: 'Bonus' })
+      await expect(bonusLabel).toHaveCount(1)
+      const forId = await bonusLabel.getAttribute('for')
+      const bonusInput = dialog.locator(`#${forId}`)
+      await expect(bonusInput).toHaveValue('+0')
+
+      // Add a large, unmistakable bonus, then roll.
+      await bonusInput.fill('+50')
+      await dialog.locator('button.roll').click()
+
+      // The attack card's "hits AC" total must include the +50. A warrior's
+      // d20 + deed d4 maxes at 24, so a total >= 51 proves the bonus applied.
+      const hitsAc = await page.evaluate(async () => {
+        const deadline = Date.now() + 4000
+        while (Date.now() < deadline) {
+          const msg = game.messages.contents.slice().reverse().find(m =>
+            m.getFlag('dcc', 'isToHit') && m.speaker?.alias === 'P1 Warrior Bonus'
+          )
+          if (msg) return msg.system?.hitsAc ?? null
+          await new Promise(resolve => setTimeout(resolve, 50))
+        }
+        return null
+      })
+      expect(hitsAc).toBeGreaterThanOrEqual(51)
+    })
+
     test('floored damage: libDamageResult.total rides the min-1 floor and matches the displayed total (PR #720 clamp closure)', async ({ page }) => {
       // PR #720 design call (closed 2026-05-31, resolved-upstream): the
       // backlog premise was that Foundry clamped the displayed total to 1

--- a/module/__tests__/adapter-weapon-attack.test.js
+++ b/module/__tests__/adapter-weapon-attack.test.js
@@ -278,6 +278,50 @@ test('adapter path fires when options.showModifierDialog is set (session 13 / A6
   expect(createRollOptions.damageTerms[0].formula).toBe('1d8')
 })
 
+test('adapter path appends a situational "+0" bonus term when the dialog is shown (issue #791)', async () => {
+  // The modifier dialog must always expose a flat, editable bonus row so
+  // warriors/dwarves — whose to-hit is a deed die with no flat component —
+  // have somewhere to type a separate attack bonus (e.g. +2).
+  logDispatch.mockClear()
+  dccRollCreateRollMock.mockClear()
+  const restore = withAutomate(true)
+  // noinspection JSCheckFunctionSignatures
+  const actor = new DCCActor()
+  const weapon = makeSimpleWeapon()
+
+  try {
+    await actor.rollToHit(weapon, { showModifierDialog: true })
+  } finally {
+    restore()
+  }
+
+  const terms = dccRollCreateRollMock.mock.calls.at(-1)[0]
+  const bonusTerm = terms.find(t => t.type === 'Modifier' && t.formula === '+0')
+  expect(bonusTerm).toBeDefined()
+  expect(bonusTerm.label).toBe(globalThis.game.i18n.localize('DCC.Bonus'))
+})
+
+test('adapter path does NOT append the situational bonus term when no dialog is shown (issue #791)', async () => {
+  // Gate defensive: normal (non-dialog) attacks must be byte-identical, so
+  // the "+0" bonus term is never added when showModifierDialog is unset.
+  logDispatch.mockClear()
+  dccRollCreateRollMock.mockClear()
+  const restore = withAutomate(true)
+  // noinspection JSCheckFunctionSignatures
+  const actor = new DCCActor()
+  const weapon = makeSimpleWeapon()
+
+  try {
+    await actor.rollToHit(weapon, {})
+  } finally {
+    restore()
+  }
+
+  const terms = dccRollCreateRollMock.mock.calls.at(-1)[0]
+  const bonusTerm = terms.find(t => t.type === 'Modifier' && t.formula === '+0')
+  expect(bonusTerm).toBeUndefined()
+})
+
 test('adapter path skips damageTerms when dialog shown but weapon has no damage', async () => {
   // Gate defensive: `rollOptions.damageTerms` should NOT be set if the
   // weapon lacks a damage formula — mirrors legacy branch at

--- a/module/actor/rolls-weapon-mixin.mjs
+++ b/module/actor/rolls-weapon-mixin.mjs
@@ -481,6 +481,23 @@ export const RollsWeaponMixin = (Base) => class extends Base {
       }
     }
 
+    // Situational attack bonus (issue #791): when the modifier dialog is
+    // shown, always offer a flat, editable "+0" bonus term so any attacker
+    // has a clear place to add a one-off bonus (e.g. +2). This matters most
+    // for warriors/dwarves, whose to-hit is a deed die with no flat
+    // component — without this their dialog only exposes die rows and there
+    // is nowhere to type a separate attack bonus. Gated on the dialog being
+    // shown so normal (non-dialog) attacks are byte-identical; the entered
+    // value flows through the Foundry roll total, which is authoritative for
+    // the "hits AC" result shown on the chat card.
+    if (options.showModifierDialog) {
+      terms.push({
+        type: 'Modifier',
+        label: game.i18n.localize('DCC.Bonus'),
+        formula: '+0'
+      })
+    }
+
     const termsLengthBefore = terms.length
     const proceed = Hooks.call('dcc.modifyAttackRollTerms', terms, this, weapon, options)
     if (!proceed) return


### PR DESCRIPTION
## Summary

Closes #791 (Discord report from Locotomo: a warrior wanted to apply a manual `+2` to an attack roll but the dialog had no field for it).

Ctrl/cmd-clicking an attack already opens the roll-modifier dialog. For most actors the to-hit decomposes into an editable flat **modifier** row, but a **warrior/dwarf's to-hit is a deed die** (e.g. `+d4`) with no flat component — so the dialog only showed *die* rows and there was nowhere to type a separate one-off bonus.

This change makes `rollToHit` always append a flat, editable **"Bonus"** term (defaulting to `+0`, with the existing +1/−1/reset controls) when the modifier dialog is shown. Every attacker now has a clear place to add a situational bonus.

## Design notes

- **Gated on `showModifierDialog`** — normal (non-dialog) attacks are byte-identical; no stray `+0` in regular rolls.
- The entered value flows through **Foundry's roll total**, which is what the chat card's "Hits AC" reads (consistent with how all other dialog edits already behave; the lib total is not authoritative for the displayed AC result).
- Reused the existing `DCC.Bonus` i18n key (already present in all 7 locales) — no new translations needed.
- The added term is a `Modifier` (no die), so the deed-die detection (`attackRoll.dice[1]`) is unaffected.

## Tests

- **Unit** (`module/__tests__/adapter-weapon-attack.test.js`): asserts the `+0` Bonus term is present when the dialog is shown and absent otherwise.
- **E2E** (`browser-tests/e2e/adapter-dispatch.spec.js`): a warrior's modifier dialog exposes the editable `+0` Bonus row, and entering `+50` produces an attack whose total includes it.
- Full Vitest suite green locally (1896 passed); StandardJS lint clean.

> ⚠️ The Playwright E2E suite was **not** run — Foundry isn't installed in the remote session environment (integration/E2E are skipped there). The new E2E spec should be exercised in an environment with Foundry available before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018RMNz7nNmeNab4TtYXk69X)_