### PR TITLE
Resolve custom-class level data from unregistered world items

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -7,4 +7,8 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-npm install --no-audit --no-fund
+# Use `npm ci` for a deterministic install from package-lock.json: it never
+# rewrites the lockfile (unlike `npm install`, which can reconcile it and leave
+# stray churn in the working tree). Requires the lockfile to be in sync, which
+# is the desired failure mode in an ephemeral session.
+npm ci --no-audit --no-fund

--- a/browser-tests/e2e/custom-class-level-data.spec.js
+++ b/browser-tests/e2e/custom-class-level-data.spec.js
@@ -1,0 +1,67 @@
+/* eslint-disable no-undef -- Browser globals (game, Actor, Item) used in page.evaluate */
+const { expect, createSessionTest } = require('./fixtures')
+
+/**
+ * Custom-class level data — world-item fallback (module/actor-level-change.js)
+ * end-to-end against live Foundry. Mirrors the crit/fumble table resolvers'
+ * `game.tables` fallback: the level-up dialog's `_lookupLevelItem` resolves a
+ * `{class}-{level}` level item from the registered `CONFIG.DCC.levelDataPacks`
+ * first, then falls back to an UNREGISTERED `level`-type Item sitting loose in
+ * the world's Items sidebar. This proves a homebrew class works with no pack
+ * registration at all, using the live-served module so the deployed code path
+ * is what is exercised. Uses a `level`-name prefix (`e2e-bloodwitch`) that no
+ * shipped pack claims, so the world item is the only possible match.
+ */
+const test = createSessionTest()
+
+test.describe('Custom class level-data world-item fallback', () => {
+  test('_lookupLevelItem resolves an unregistered world level item by name', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const { default: DCCActorLevelChange } =
+        await import('../../../../../../../../systems/dcc/module/actor-level-change.js')
+
+      let worldItem, decoyItem, actor
+      try {
+        // A `level` item in the world Items sidebar — NOT inside any registered
+        // levelDataPack. Named per the {class}-{level} convention (lowercased).
+        worldItem = await Item.create({
+          name: 'e2e-bloodwitch-1',
+          type: 'level',
+          system: { levelData: 'system.attributes.hitDice.value=1d30' }
+        })
+        // A same-named non-`level` item that the type filter must skip.
+        decoyItem = await Item.create({ name: 'e2e-bloodwitch-1', type: 'weapon' })
+
+        actor = await Actor.create({ name: 'P_LevelFallback', type: 'Player' })
+        const dialog = new DCCActorLevelChange({ document: actor })
+
+        const found = await dialog._lookupLevelItem('e2e-bloodwitch', 1)
+        const spaced = await dialog._lookupLevelItem('e2e bloodwitch', 1) // spaces → hyphens
+        const miss = await dialog._lookupLevelItem('e2e-nosuchclass', 1)
+
+        return {
+          worldItemId: worldItem.id,
+          foundId: found?.id ?? null,
+          foundType: found?.type ?? null,
+          foundLevelData: found?.system?.levelData ?? null,
+          spacedId: spaced?.id ?? null,
+          missIsEmptyObject:
+            miss && typeof miss === 'object' && Object.keys(miss).length === 0
+        }
+      } finally {
+        await actor?.delete()
+        await worldItem?.delete()
+        await decoyItem?.delete()
+      }
+    })
+
+    // The world item is resolved even though it was never registered.
+    expect(result.foundId).toBe(result.worldItemId)
+    expect(result.foundType).toBe('level')
+    expect(result.foundLevelData).toContain('1d30')
+    // Class names with spaces normalize to the hyphenated item name.
+    expect(result.spacedId).toBe(result.worldItemId)
+    // No match anywhere still returns the empty-object sentinel.
+    expect(result.missIsEmptyObject).toBe(true)
+  })
+})

--- a/docs/user-guide/Creating-a-Custom-Class.md
+++ b/docs/user-guide/Creating-a-Custom-Class.md
@@ -1,0 +1,193 @@
+# Creating a Custom Class
+
+The DCC system can level characters of your own homebrew classes, the same
+way it levels the built‑in classes. This page explains how the level‑up
+machinery actually works and how to author the **Level** items that drive it.
+
+> If you only want the seven core classes, you don't need any of this —
+> install the DCC Core Book module and it ships the level data for you. See
+> [Level Up](Level-Up.md). This page is for **module authors and GMs building
+> their own classes.**
+
+## How leveling works
+
+When you click the **Level** label on a character sheet, the system does *not*
+read stats from any item on the actor. Instead it:
+
+1. Reads the character's **Class Name** (`system.class.className`).
+2. Looks through every registered *level‑data compendium pack* for an item
+   **named** `<class-name>-<level>` (see the naming rules below).
+3. Parses that item's **Level Data** text field into a list of
+   `path = value` changes.
+4. Applies those changes to the character and rolls new hit points.
+
+So a custom class is really just **a set of `level`‑type items, one per level,
+sitting in a compendium the system has been told to scan.**
+
+There are two mistakes that stop this from working, and they're the ones AI
+assistants almost always make:
+
+- **Putting stats in the wrong place.** A `level` item has *no*
+  `system.details.attackBonus` field, no `system.saves.*` field, and so on.
+  Setting those directly on the item does nothing — Foundry silently discards
+  them. Every stat change must go inside the single **Level Data** text field
+  as `path = value` lines.
+- **Getting the item name wrong.** The lookup lowercases the class name and
+  replaces spaces with hyphens. `Blood-Witch-1` or `Blood Witch 1` will **not**
+  be found — the item must be named `blood-witch-1`.
+
+## Step 1 — Create the Level items
+
+In an item folder or compendium, create a new item and choose the **Level**
+type. Create one per level you want to support.
+
+Set the item's **name** to:
+
+```
+<class-name-lowercased-with-spaces-as-hyphens>-<level>
+```
+
+| Character's Class Name | Level | Item name       |
+|------------------------|-------|-----------------|
+| `Bard`                 | 1     | `bard-1`        |
+| `Bard`                 | 2     | `bard-2`        |
+| `Blood Witch`          | 1     | `blood-witch-1` |
+| `Blood Witch`          | 3     | `blood-witch-3` |
+
+The character's **Class Name** field on the sheet must match (case doesn't
+matter — it's lowercased before the lookup). It also must not be left as the
+default `Generic` / `Zero-Level`, or the level dialog will refuse to run.
+
+## Step 2 — Fill in the Level Data
+
+Everything the level grants goes into the **Level Data** field as newline‑
+separated `path = value` lines. Each `path` is an **actor** update path
+(always starting with `system.`). For example, a level‑1 spellcaster:
+
+```
+system.attributes.hitDice.value=1d6
+system.attributes.actionDice.value=1d20
+system.attributes.critical.die=1d6
+system.attributes.critical.table=I
+system.details.attackBonus=+0
+system.saves.ref.classBonus=+1
+system.saves.frt.classBonus=+0
+system.saves.wil.classBonus=+1
+```
+
+Notes on values:
+
+- Values that look like plain numbers are stored as numbers; dice (`1d6`) and
+  letters (`I`, `III`, `M`) are kept as text. You don't need quotes.
+- `system.attributes.actionDice.value` accepts a comma‑separated list for
+  characters who get extra action dice (e.g. `1d20,1d14`); the first entry
+  becomes the active action die and the full list is offered in the dropdown.
+
+### Valid paths
+
+These are the paths the built‑in classes set at each level. All are relative
+to the actor.
+
+| What it sets            | Path                                        |
+|-------------------------|---------------------------------------------|
+| Hit die                 | `system.attributes.hitDice.value`           |
+| Action die(s)           | `system.attributes.actionDice.value`        |
+| Critical die            | `system.attributes.critical.die`            |
+| Critical table          | `system.attributes.critical.table`          |
+| Base attack (deed) bonus| `system.details.attackBonus`                |
+| Reflex class bonus      | `system.saves.ref.classBonus`               |
+| Fortitude class bonus   | `system.saves.frt.classBonus`               |
+| Will class bonus        | `system.saves.wil.classBonus`               |
+
+The save keys are `frt`, `ref`, and `wil` (there is no `fort` or `will`). Use
+`classBonus` — with the default "compute saving throws" setting on, it's added
+to the relevant ability modifier to produce the save total. If you'd rather set
+a save's total directly and bypass the calculation, set
+`system.saves.<save>.value` instead.
+
+For the full catalog of actor paths you can target, see
+[Attribute Paths for Third‑Party Modules](Attribute-Paths-for-Modules.md).
+
+> **Paths that do _not_ exist:** `system.details.casterLevel` and
+> `system.details.spellbook` are commonly guessed but are not fields on the
+> actor — writing them does nothing. Caster level is derived automatically from
+> `system.details.level.value`.
+
+### Alignment‑specific data (optional)
+
+`level` items also have **Level Data (Lawful)**, **(Neutral)**, and
+**(Chaotic)** fields. Whichever one matches the character's alignment is
+appended to the shared Level Data before it's applied — handy for classes whose
+progression differs by alignment. Leave them blank if you don't need them.
+
+## Step 3 — Register the compendium
+
+**Correct naming is not enough on its own — the pack must be registered.** The
+level dialog only searches compendiums whose ids have been registered with the
+system; it never scans every compendium in the world, and it never reads loose
+items sitting in an item folder. Think of it as two separate switches:
+
+- **Registration** decides *which compendiums* are searched.
+- **Naming** decides *which item inside a searched pack* matches.
+
+You need both. The items must live in a compendium pack, and that pack's id must
+be registered via the `dcc.registerLevelDataPack` hook. A content module
+registers its pack from an `init` hook:
+
+```js
+Hooks.once('init', () => {
+  Hooks.callAll('dcc.registerLevelDataPack', 'my-module.blood-witch-levels')
+})
+```
+
+Replace `my-module.blood-witch-levels` with your pack's full id
+(`<module-name>.<pack-name>` as declared in your module manifest).
+
+**No module? Register a world compendium instead.** If you built the level
+items in a *world* compendium (its id is `world.<pack-name>`), you can register
+it without shipping a module by firing the same hook from a script — for
+example a one‑line script macro you run once per session:
+
+```js
+Hooks.callAll('dcc.registerLevelDataPack', 'world.blood-witch-levels')
+```
+
+The dialog reads the registered‑packs list live, so registering any time before
+you open the Level dialog is enough.
+
+If you also want the class's progression picked up by the class‑progression
+loader (for features that read it outside the level dialog), register the class
+in the same hook:
+
+```js
+Hooks.once('init', () => {
+  Hooks.callAll('dcc.registerLevelDataPack', 'my-module.blood-witch-levels')
+  game.dcc.registerHomebrewClassForProgressionLoad('blood-witch', 'blood-witch')
+})
+```
+
+## Step 4 — Level a character
+
+Set the character's **Class Name** to your class, then click the **Level**
+label on the sheet and step the level up. The dialog previews the changes it
+found for the target level; accept it to apply them, log the change to chat, and
+roll hit points.
+
+**Dragging a `level` item onto the sheet does nothing** — leveling only happens
+through this dialog.
+
+## Troubleshooting
+
+If the level dialog says the level data wasn't found, or nothing changes:
+
+- **Item name.** Must be lowercase, spaces as hyphens, `-<level>` suffix —
+  `blood-witch-1`, not `Blood-Witch-1`.
+- **Class Name.** The sheet's Class Name must match the item‑name prefix and
+  must not still be `Generic` / `Zero-Level`.
+- **Pack registered?** Confirm your `dcc.registerLevelDataPack` hook ran. In
+  the browser console, `CONFIG.DCC.levelDataPacks.packs` should list your pack.
+- **Stats in Level Data, not on the item.** Double‑check every change is a
+  `path = value` line inside the Level Data field, not a field you tried to set
+  on the item itself.
+- **Right paths.** Compare against the table above; drop `casterLevel` and
+  `spellbook`.

--- a/docs/user-guide/Creating-a-Custom-Class.md
+++ b/docs/user-guide/Creating-a-Custom-Class.md
@@ -15,14 +15,17 @@ When you click the **Level** label on a character sheet, the system does *not*
 read stats from any item on the actor. Instead it:
 
 1. Reads the character's **Class Name** (`system.class.className`).
-2. Looks through every registered *level‑data compendium pack* for an item
-   **named** `<class-name>-<level>` (see the naming rules below).
+2. Looks for a `level`‑type item **named** `<class-name>-<level>` (see the
+   naming rules below) — first in every registered *level‑data compendium
+   pack*, then, if none is found, among the `level` items sitting loose in
+   your world.
 3. Parses that item's **Level Data** text field into a list of
    `path = value` changes.
 4. Applies those changes to the character and rolls new hit points.
 
 So a custom class is really just **a set of `level`‑type items, one per level,
-sitting in a compendium the system has been told to scan.**
+named by convention** — either bundled in a compendium a module registers, or
+simply created in your world's Items sidebar.
 
 There are two mistakes that stop this from working, and they're the ones AI
 assistants almost always make:
@@ -120,19 +123,28 @@ For the full catalog of actor paths you can target, see
 appended to the shared Level Data before it's applied — handy for classes whose
 progression differs by alignment. Leave them blank if you don't need them.
 
-## Step 3 — Register the compendium
+## Step 3 — Make the items findable
 
-**Correct naming is not enough on its own — the pack must be registered.** The
-level dialog only searches compendiums whose ids have been registered with the
-system; it never scans every compendium in the world, and it never reads loose
-items sitting in an item folder. Think of it as two separate switches:
+The level dialog resolves your `level` items in this order:
 
-- **Registration** decides *which compendiums* are searched.
-- **Naming** decides *which item inside a searched pack* matches.
+1. **Registered level‑data compendiums** (searched first).
+2. **Loose `level` items in your world's Items sidebar** (the fallback).
 
-You need both. The items must live in a compendium pack, and that pack's id must
-be registered via the `dcc.registerLevelDataPack` hook. A content module
-registers its pack from an `init` hook:
+You only need *one* of these. Pick based on how you're distributing the class.
+
+### The simple way: world items (no registration)
+
+If you're building a class just for your own game, **you don't need to register
+anything.** Create the `level` items directly in your world's **Items** sidebar,
+named by convention (`blood-witch-1`, `blood-witch-2`, …), and the dialog finds
+them automatically — the same way a crit or fumble table you drop into the
+sidebar just works. This is the recommended path for one‑off homebrew.
+
+### The packaged way: a registered compendium
+
+If you're shipping the class inside a **module**, put the `level` items in a
+compendium pack and register that pack's id via the `dcc.registerLevelDataPack`
+hook from an `init` hook:
 
 ```js
 Hooks.once('init', () => {
@@ -141,19 +153,9 @@ Hooks.once('init', () => {
 ```
 
 Replace `my-module.blood-witch-levels` with your pack's full id
-(`<module-name>.<pack-name>` as declared in your module manifest).
-
-**No module? Register a world compendium instead.** If you built the level
-items in a *world* compendium (its id is `world.<pack-name>`), you can register
-it without shipping a module by firing the same hook from a script — for
-example a one‑line script macro you run once per session:
-
-```js
-Hooks.callAll('dcc.registerLevelDataPack', 'world.blood-witch-levels')
-```
-
-The dialog reads the registered‑packs list live, so registering any time before
-you open the Level dialog is enough.
+(`<module-name>.<pack-name>` as declared in your module manifest). Registered
+packs are searched **before** world items, so an official pack always wins over a
+stray same‑named world item.
 
 If you also want the class's progression picked up by the class‑progression
 loader (for features that read it outside the level dialog), register the class
@@ -184,8 +186,11 @@ If the level dialog says the level data wasn't found, or nothing changes:
   `blood-witch-1`, not `Blood-Witch-1`.
 - **Class Name.** The sheet's Class Name must match the item‑name prefix and
   must not still be `Generic` / `Zero-Level`.
-- **Pack registered?** Confirm your `dcc.registerLevelDataPack` hook ran. In
-  the browser console, `CONFIG.DCC.levelDataPacks.packs` should list your pack.
+- **Where the items live.** World items must be `level`‑type items in the
+  **Items** sidebar (items inside a compendium are only searched if that
+  compendium was registered). If you went the packaged route, confirm your
+  `dcc.registerLevelDataPack` hook ran — in the browser console,
+  `CONFIG.DCC.levelDataPacks.packs` should list your pack.
 - **Stats in Level Data, not on the item.** Double‑check every change is a
   `path = value` line inside the Level Data field, not a field you tried to set
   on the item itself.

--- a/docs/user-guide/Level-Up.md
+++ b/docs/user-guide/Level-Up.md
@@ -13,3 +13,5 @@ Just click on the "Level" label next to the level of your PC:
 Once you accept this change, it will be logged to the Chat, and the Hit Points will be rolled.
 
 If you would like a different Hit Point formula, you can roll that in the chat yourself, and adjust your character as desired.
+
+Building your own class? See [Creating a Custom Class](Creating-a-Custom-Class.md) for how to author the level data that this dialog reads.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -22,6 +22,7 @@ This is the documentation for the FoundryVTT Dungeon Crawl Classics (DCC) System
 * [Thief](Thief.md)
 * [Wizard](Wizard.md)
 * [Level Up](Level-Up.md)
+* [Creating a Custom Class](Creating-a-Custom-Class.md)
 * [Party Sheet](Party-Sheet.md)
 
 ## Spells

--- a/module/__tests__/actor-level-change.test.js
+++ b/module/__tests__/actor-level-change.test.js
@@ -1,0 +1,97 @@
+/**
+ * Unit coverage for `DCCActorLevelChange._lookupLevelItem`'s world-item
+ * fallback (`module/actor-level-change.js`).
+ *
+ * The level-up dialog resolves a `{class}-{level}` level item from the
+ * registered `CONFIG.DCC.levelDataPacks` compendiums first, then falls
+ * back to an unregistered `level`-type Item sitting in the world — the
+ * same "just drop it in the sidebar" convenience the crit/fumble table
+ * resolvers in `utilities.js` already provide via `game.tables`. These
+ * tests pin that fallback and its priority ordering.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import '../__mocks__/foundry.js'
+import DCCActorLevelChange from '../actor-level-change.js'
+
+describe('DCCActorLevelChange._lookupLevelItem world fallback', () => {
+  let savedGame, savedConfig
+
+  // `_lookupLevelItem` only reaches into `this` for the non-English
+  // translation branch (skipped here since lang === 'en'), so a bare
+  // prototype-backed object is a sufficient receiver.
+  const lookup = (className, level) =>
+    DCCActorLevelChange.prototype._lookupLevelItem.call(
+      Object.create(DCCActorLevelChange.prototype), className, level
+    )
+
+  beforeEach(() => {
+    savedGame = globalThis.game
+    savedConfig = globalThis.CONFIG
+    globalThis.game = {
+      i18n: { lang: 'en', localize: (k) => k },
+      packs: { get: vi.fn(() => undefined) },
+      items: []
+    }
+    globalThis.CONFIG = { DCC: { levelDataPacks: null } }
+  })
+
+  afterEach(() => {
+    globalThis.game = savedGame
+    globalThis.CONFIG = savedConfig
+  })
+
+  test('resolves an unregistered world level item named {class}-{level}', async () => {
+    const worldItem = {
+      type: 'level',
+      name: 'blood-witch-1',
+      system: { levelData: 'system.attributes.hitDice.value=1d6' }
+    }
+    globalThis.game.items = [worldItem]
+
+    const found = await lookup('blood-witch', 1)
+
+    expect(found).toBe(worldItem)
+  })
+
+  test('normalizes spaces in the class name to hyphens for the world lookup', async () => {
+    const worldItem = { type: 'level', name: 'blood-witch-2', system: { levelData: '' } }
+    globalThis.game.items = [worldItem]
+
+    const found = await lookup('blood witch', 2)
+
+    expect(found).toBe(worldItem)
+  })
+
+  test('ignores world items of other types with the same name', async () => {
+    globalThis.game.items = [{ type: 'weapon', name: 'blood-witch-1', system: {} }]
+
+    const found = await lookup('blood-witch', 1)
+
+    expect(found).toEqual({})
+  })
+
+  test('a registered pack match wins over a same-named world item', async () => {
+    const packItem = { type: 'level', name: 'warrior-1', system: { levelData: 'pack' } }
+    const worldItem = { type: 'level', name: 'warrior-1', system: { levelData: 'world' } }
+    globalThis.game.items = [worldItem]
+    globalThis.CONFIG.DCC.levelDataPacks = { packs: ['dcc-core-book.levels'] }
+    globalThis.game.packs.get = vi.fn(() => ({
+      getIndex: async () => {},
+      index: [{ _id: 'x', name: 'warrior-1' }],
+      getDocument: async () => packItem
+    }))
+
+    const found = await lookup('warrior', 1)
+
+    expect(found).toBe(packItem)
+  })
+
+  test('returns {} when neither a pack nor a world item matches', async () => {
+    globalThis.game.items = [{ type: 'level', name: 'wizard-3', system: {} }]
+
+    const found = await lookup('cleric', 1)
+
+    expect(found).toEqual({})
+  })
+})

--- a/module/actor-level-change.js
+++ b/module/actor-level-change.js
@@ -172,6 +172,18 @@ class DCCActorLevelChange extends HandlebarsApplicationMixin(ApplicationV2) {
         }
       }
     }
+
+    // Fall back to an unregistered world-level item named by convention,
+    // mirroring the world-table fallback used for crit/fumble tables in
+    // utilities.js. Registered packs win (checked above) so installing an
+    // official level-data pack module never changes existing behavior;
+    // this lets homebrew classes work by simply dropping `level` items
+    // named `{class}-{level}` into the world without registering a pack.
+    const worldLevelItem = game.items?.find(item => item.type === 'level' && item.name === itemName)
+    if (worldLevelItem) {
+      return worldLevelItem
+    }
+
     return {}
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dcc",
-  "version": "0.70.8",
+  "version": "0.70.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dcc",
-      "version": "0.70.8",
+      "version": "0.70.13",
       "license": "MIT",
       "devDependencies": {
         "@foundryvtt/foundryvtt-cli": "^3.0.3",


### PR DESCRIPTION
## Summary

A user building homebrew classes found that their `level` items updated nothing on the sheet. The level-up dialog's `_lookupLevelItem` only searched **registered** `CONFIG.DCC.levelDataPacks` compendiums, so a homebrew class required a module to register a pack — unlike crit/fumble tables, which already resolve from a RollTable dropped straight into the world sidebar (via the `game.tables` fallback in `utilities.js`).

This PR adds the analogous fallback for level data, plus documentation, and fixes an unrelated lockfile/hook papercut discovered along the way.

## Changes

- **`module/actor-level-change.js`** — after the registered packs miss, `_lookupLevelItem` now resolves a `level`-type `Item` named `{class}-{level}` from `game.items`. Registered packs are still searched **first**, so installing an official level-data pack module never changes existing behavior; this only lets homebrew classes work by dropping named `level` items into the world with no pack registration.
- **`docs/user-guide/Creating-a-Custom-Class.md`** (new) — end-to-end guide: how the level-up machinery works, item naming (`blood-witch-1`, lowercased, spaces → hyphens), putting stat changes in the `levelData` text field as `path=value` lines, the valid-paths table, a note that `casterLevel`/`spellbook` are not actor fields, the world-item vs. registered-pack paths, and troubleshooting. Linked from `index.md`; cross-linked from `Level-Up.md`.
- **`.claude/hooks/session-start.sh`** — use `npm ci` instead of `npm install` for web sessions so the ephemeral install is deterministic and never rewrites `package-lock.json`.
- **`package-lock.json`** — sync the stale root `version` field (`0.70.8` → `0.70.13`) to match `package.json`. This was already out of sync on `main` after the `Release v0.70.13` commit; the sync is also what lets `npm ci` succeed.

## Tests

- **`module/__tests__/actor-level-change.test.js`** (new, 5 tests) — world item resolved by name, space→hyphen normalization, non-`level` items ignored, **registered pack wins over a same-named world item**, and the empty-object sentinel on no match.
- **`browser-tests/e2e/custom-class-level-data.spec.js`** (new) — drives the real `_lookupLevelItem` against a live world item, asserting the unregistered item resolves, spaces normalize, and a no-match returns the sentinel.
- `npm test` — 1901 unit tests pass locally. The E2E spec has not been run in the authoring environment (no Foundry available); relying on CI to exercise it.

## Notes / scope

- The class-progression **loader** (`module/adapter/foundry-data-loader.mjs`, feeds the vendored lib registry at `dcc.ready`) intentionally remains pack-registration-only. It reads a partly different key set from the same `levelData` text and drives lib-side helpers rather than the per-roll paths (which read the actor's own stored data), so it isn't needed to make homebrew leveling via the sheet work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RczPJt8AiK9z9UPi6ohDLv

---
_Generated by [Claude Code](https://claude.ai/code/session_01RczPJt8AiK9z9UPi6ohDLv)_