### PR TITLE
fix(chat): keep attack emote sentence intact when a deed table prompt shows

### DIFF
--- a/browser-tests/e2e/mighty-deeds.spec.js
+++ b/browser-tests/e2e/mighty-deeds.spec.js
@@ -221,6 +221,17 @@ test.describe('Mighty Deeds E2E Tests', () => {
     expect(await select.inputValue(), 'nothing preselected — placeholder is empty').toBe('')
     await expect(card.locator('.deed-table-result'), 'no lookup shown until a table is picked').toHaveCount(0)
 
+    // The attack sentence must stay intact: the block-level deed table picker
+    // renders *after* the "…for X points of damage!" sentence, not spliced into
+    // the middle of it (bug: the deed/damage emote text was cut apart because the
+    // picker landed between "deed roll of N" and "for X points of damage!").
+    const emoteOrder = await card.evaluate((el) => {
+      const html = (el.querySelector('.message-content') ?? el).innerHTML
+      return { damageIdx: html.indexOf('points of damage'), promptIdx: html.indexOf('deed-table-prompt') }
+    })
+    expect(emoteOrder.damageIdx, 'damage sentence present in emote').toBeGreaterThan(-1)
+    expect(emoteOrder.promptIdx, 'deed picker renders after the damage sentence, not inside it').toBeGreaterThan(emoteOrder.damageIdx)
+
     // Pick the test table → the looked-up result renders inline on the SAME card,
     // and no new chat message is posted.
     const messagesBefore = await page.evaluate(() => game.messages.size)

--- a/lang/cn.json
+++ b/lang/cn.json
@@ -133,7 +133,7 @@
   "DCC.AttackDistance": "攻击距离",
   "DCC.AttackRoll": "{weapon} 攻击投骰",
   "DCC.AttackRollDeedEmoteSegment": " {deed} 壮举投骰",
-  "DCC.AttackRollEmote": "{actorName} {actionName} 使用其 {weaponName} 命中 AC {rollHTML}{deedRollHTML} 造成 {damageRollHTML} 伤害！{crit}{fumble}{twoWeaponNote}",
+  "DCC.AttackRollEmote": "{actorName} {actionName} 使用其 {weaponName} 命中 AC {rollHTML}{deedRollHTML} 造成 {damageRollHTML} 伤害！{deedTablePrompt}{crit}{fumble}{twoWeaponNote}",
   "DCC.AttackRollInvalidFormulaInline": "<b>无效命中公式`{formula}`<\/b>",
   "DCC.ArmorDetails": "护甲细节",
   "DCC.ArmorSettings": "护甲设置",

--- a/lang/de.json
+++ b/lang/de.json
@@ -133,7 +133,7 @@
   "DCC.AttackDistance": "Angriffsreichweite",
   "DCC.AttackRoll": "Angriffswurf",
   "DCC.AttackRollDeedEmoteSegment": " mit Kriegerwürfel {deed}",
-  "DCC.AttackRollEmote": "Angriff mit {weaponName}. Trifft RK {rollHTML}{deedRollHTML} mit {damageRollHTML} Schaden!{crit}{fumble}{twoWeaponNote}",
+  "DCC.AttackRollEmote": "Angriff mit {weaponName}. Trifft RK {rollHTML}{deedRollHTML} mit {damageRollHTML} Schaden!{deedTablePrompt}{crit}{fumble}{twoWeaponNote}",
   "DCC.AttackRollInvalidFormulaInline": "<b>Ungültige Formel '{formula}' für Angriff</b>",
   "DCC.ArmorDetails": "Rüstungsdetails",
   "DCC.ArmorSettings": "Rüstungseinstellungen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -133,7 +133,7 @@
   "DCC.AttackDistance": "Attack Distance",
   "DCC.AttackRoll": "Attack Roll with {weapon}",
   "DCC.AttackRollDeedEmoteSegment": " with deed roll of {deed}",
-  "DCC.AttackRollEmote": "{actorName} {actionName} with their {weaponName} and hits AC {rollHTML}{deedRollHTML} for {damageRollHTML} points of damage!{crit}{fumble}{twoWeaponNote}",
+  "DCC.AttackRollEmote": "{actorName} {actionName} with their {weaponName} and hits AC {rollHTML}{deedRollHTML} for {damageRollHTML} points of damage!{deedTablePrompt}{crit}{fumble}{twoWeaponNote}",
   "DCC.AttackRollInvalidFormulaInline": "<b>Invalid To Hit formula '{formula}'</b>",
   "DCC.ArmorDetails": "Armor Details",
   "DCC.ArmorSettings": "Armor Settings",

--- a/lang/es.json
+++ b/lang/es.json
@@ -133,7 +133,7 @@
   "DCC.AttackDistance": "Distancia de ataque",
   "DCC.AttackRoll": "Tirada de ataque con {weapon}",
   "DCC.AttackRollDeedEmoteSegment": " con tirada de acción de {deed}",
-  "DCC.AttackRollEmote": "{actorName} {actionName} con su {weaponName} y golpea CA {rollHTML}{deedRollHTML} causando {damageRollHTML} puntos de daño!{crit}{fumble}{twoWeaponNote}",
+  "DCC.AttackRollEmote": "{actorName} {actionName} con su {weaponName} y golpea CA {rollHTML}{deedRollHTML} causando {damageRollHTML} puntos de daño!{deedTablePrompt}{crit}{fumble}{twoWeaponNote}",
   "DCC.AttackRollInvalidFormulaInline": "<b>Fórmula inválida para acertar '{formula}'</b>",
   "DCC.ArmorDetails": "Detalles de la armadura",
   "DCC.ArmorSettings": "Configuración de armadura",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -121,7 +121,7 @@
   "DCC.AttackDistance": "Distance d'Attaque",
   "DCC.AttackRoll": "Jet d'attaque avec {weapon}",
   "DCC.AttackRollDeedEmoteSegment": "Avec un jet de haut fait de {deed}",
-  "DCC.AttackRollEmote": "Attaque avec {weaponName} et touche une CA {rollHTML}{deedRollHTML} pour {damageRollHTML} points de dégats!{crit}{fumble}{twoWeaponNote}",
+  "DCC.AttackRollEmote": "Attaque avec {weaponName} et touche une CA {rollHTML}{deedRollHTML} pour {damageRollHTML} points de dégats!{deedTablePrompt}{crit}{fumble}{twoWeaponNote}",
   "DCC.AttackRollInvalidFormulaInline": "<b>Formule pour touche invalide '{formula}'</b>",
   "DCC.Avatar": "Avatar du joueur",
   "DCC.Backstab": "Att. sourn.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -133,7 +133,7 @@
   "DCC.AttackDistance": "Distanza d'Attacco",
   "DCC.AttackRoll": "Attacca con {weapon}",
   "DCC.AttackRollDeedEmoteSegment": " con Dado Cimento di {deed}",
-  "DCC.AttackRollEmote": "{actorName} attacca con {weaponName}: {rollHTML}<br>{deedRollHTML}<br><i class='fa fa-sword'></i> {damageRollHTML} danni{crit}{fumble}{twoWeaponNote}",
+  "DCC.AttackRollEmote": "{actorName} attacca con {weaponName}: {rollHTML}<br>{deedRollHTML}<br><i class='fa fa-sword'></i> {damageRollHTML} danni{deedTablePrompt}{crit}{fumble}{twoWeaponNote}",
   "DCC.AttackRollInvalidFormulaInline": "<b>Errore: '{formula}' non è un tiro valido</b>",
   "DCC.ArmorDetails": "Dettagli",
   "DCC.ArmorSettings": "Impostazioni",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -133,7 +133,7 @@
   "DCC.AttackDistance": "Dystans Ataku",
   "DCC.AttackRoll": "Rzut na Atak z {weapon}",
   "DCC.AttackRollDeedEmoteSegment": " z rzutem czynu {deed}",
-  "DCC.AttackRollEmote": "{actorName} {actionName} swoim {weaponName} i trafia KP {rollHTML}{deedRollHTML} zadając {damageRollHTML} punktów obrażeń!{crit}{fumble}{twoWeaponNote}",
+  "DCC.AttackRollEmote": "{actorName} {actionName} swoim {weaponName} i trafia KP {rollHTML}{deedRollHTML} zadając {damageRollHTML} punktów obrażeń!{deedTablePrompt}{crit}{fumble}{twoWeaponNote}",
   "DCC.AttackRollInvalidFormulaInline": "<b>Nieprawidłowa formuła Trafienia '{formula}'</b>",
   "DCC.ArmorDetails": "Szczegóły Zbroi",
   "DCC.ArmorSettings": "Ustawienia Zbroi",

--- a/module/chat.js
+++ b/module/chat.js
@@ -246,6 +246,7 @@ export const emoteAttackRoll = function (message, html) {
   if (!message.rolls || !message.isContentVisible || !message.getFlag('dcc', 'isToHit')) return
 
   let deedRollHTML = ''
+  let deedTablePrompt = ''
   if (message.system.deedDieRollResult) {
     const critical = message.system.deedSucceed ? ' critical' : ''
     let iconClass = 'fa-dice-d4'
@@ -271,8 +272,10 @@ export const emoteAttackRoll = function (message, html) {
     }
     deedRollHTML = game.i18n.format('DCC.AttackRollDeedEmoteSegment', { deed: deedDieHTML })
 
-    // Re-add the Mighty Deed table prompt, since the emote replaces the card content
-    deedRollHTML += buildMightyDeedPrompt(message)
+    // Re-add the Mighty Deed table prompt, since the emote replaces the card content.
+    // Kept separate from the inline deed-roll text so this block-level markup lands
+    // *after* the "…for X points of damage!" sentence instead of splitting it apart.
+    deedTablePrompt = buildMightyDeedPrompt(message)
   }
 
   let crit = ''
@@ -329,6 +332,7 @@ export const emoteAttackRoll = function (message, html) {
     rollHTML: message.rolls[0].toAnchor().outerHTML,
     deedRollHTML,
     damageRollHTML: damageInlineRoll,
+    deedTablePrompt,
     crit,
     fumble,
     twoWeaponNote


### PR DESCRIPTION
The Mighty Deed table picker (and its looked-up deed description) is
block-level markup, but it was concatenated onto the inline "with deed
roll of N" segment that sits mid-sentence in the attack emote. That
split the run-on sentence apart, orphaning "for X points of damage!"
below the deed description card.

Separate the block-level prompt from the inline deed-roll text and give
it its own {deedTablePrompt} placeholder at the end of DCC.AttackRollEmote
(all locales), so the picker/description render after the complete
"…for X points of damage!" sentence instead of inside it.

Adds an e2e assertion that the deed picker renders after the damage
sentence in the emote card.