### PR TITLE
fix: import Purple Sorcerer equipment with prices and containers

### DIFF
--- a/browser-tests/e2e/actor-import.spec.js
+++ b/browser-tests/e2e/actor-import.spec.js
@@ -1,0 +1,118 @@
+/* eslint-disable no-undef -- Browser globals used in page.evaluate */
+const { expect, createSessionTest, assertFoundryUp } = require('./fixtures')
+
+const test = createSessionTest()
+
+/**
+ * Actor importer E2E tests (#817).
+ *
+ * Drives `createActors` (module/parser.js) end-to-end against the live
+ * dcc-core-book compendium packs, using real current Purple Sorcerer JSON
+ * output. Purple Sorcerer appends prices to equipment names ("Backpack
+ * (2 gp)") and uses different punctuation than the pack names ("Rope - 50'"
+ * vs "Rope, 50’"), and containers could never remap because the importer
+ * creates all goods as generic equipment items. This spec pins the whole
+ * pipeline: price stripping, normalized pack matching, container remap, and
+ * price retention on unmatched items.
+ *
+ * Setup: see docs/dev/TESTING.md#browser-tests-playwright. TL;DR:
+ *   npx @foundryvtt/foundryvtt-cli launch --world=v14
+ *   cd browser-tests/e2e && npm test -- actor-import.spec.js
+ */
+
+test.describe('DCC Actor Importer', () => {
+  test.beforeAll(async () => {
+    await assertFoundryUp()
+  })
+
+  test.beforeEach(async ({ page }) => {
+    // World-state hygiene (session page is reused across tests): close stray
+    // windows, drop notification banners, and purge probe actors left behind
+    // by failed prior runs.
+    await page.evaluate(async () => {
+      for (const app of Object.values(foundry.applications.instances ?? {})) {
+        if (app?.close) await app.close().catch(() => {})
+      }
+      document.querySelectorAll('#notifications .notification').forEach(n => n.remove())
+      const stale = game.actors.filter(a => a.name.startsWith('P817'))
+      for (const actor of stale) await actor.delete().catch(() => {})
+    })
+  })
+
+  test('imports Purple Sorcerer JSON with priced goods, remapping to compendium items (#817)', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const { default: parser } = await import('../../../../../../../../systems/dcc/module/parser.js')
+      const observed = {}
+      let actor
+      try {
+        // Real (abridged) Purple Sorcerer zero-level JSON, current output
+        // format: prices appended to equipment names, PS punctuation.
+        const psJson = JSON.stringify({
+          characters: [{
+            name: 'P817 Import Probe',
+            occTitle: 'Ostler',
+            strengthScore: '7',
+            agilityScore: '16',
+            staminaScore: '9',
+            personalityScore: '12',
+            intelligenceScore: '11',
+            luckScore: '11',
+            armorClass: '12',
+            hitPoints: '1',
+            weapon: 'Staff',
+            attackMod: '-1',
+            attackDamage: '1d4-1',
+            speed: '30',
+            initiative: '2',
+            saveReflex: '2',
+            saveFort: '0',
+            saveWill: '0',
+            equipment: "Rope - 50' (25 cp)",
+            equipment2: 'Backpack (2 gp)',
+            equipment3: 'Rations (1 day) (5 cp)',
+            tradeGood: 'Jar of honey (25 gp)',
+            startingFunds: '34 cp',
+            languages: 'Common'
+          }]
+        })
+
+        const actors = await parser.createActors('Player', null, psJson)
+        observed.actorCount = actors.length
+        actor = actors[0]
+
+        const byName = (name) => actor.items.find(i => i.name === name)
+
+        // "Rope - 50' (25 cp)" → matched to the pack's "Rope, 50’" despite
+        // the price suffix, hyphen-vs-comma, and straight-vs-curly apostrophe.
+        const rope = byName('Rope, 50’')
+        observed.rope = rope ? { type: rope.type, cp: rope.system.value.cp } : null
+
+        // "Backpack (2 gp)" → the pack's Backpack, imported as a CONTAINER
+        // with the compendium price (2 gp) — the core bug in #817.
+        const backpack = byName('Backpack')
+        observed.backpack = backpack ? { type: backpack.type, gp: backpack.system.value.gp } : null
+
+        // "Rations (1 day) (5 cp)" → name-mapped to "Rations, per day".
+        const rations = byName('Rations, per day')
+        observed.rations = rations ? { type: rations.type } : null
+
+        // Trade goods aren't in any pack: stays generic equipment, but keeps
+        // the parsed price instead of it being baked into the name.
+        const honey = byName('Jar of honey')
+        observed.honey = honey ? { type: honey.type, gp: honey.system.value.gp } : null
+        observed.hasPricedNames = actor.items.some(i => / \(\d+ (?:pp|ep|gp|sp|cp)\)/.test(i.name))
+      } finally {
+        if (actor) await actor.delete().catch(() => {})
+      }
+      return observed
+    })
+
+    expect(result.actorCount).toBe(1)
+    // Compendium price (25 cp) comes along with the remapped item
+    expect(result.rope).toEqual({ type: 'equipment', cp: '25' })
+    expect(result.backpack).toEqual({ type: 'container', gp: '2' })
+    expect(result.rations).toEqual({ type: 'equipment' })
+    expect(result.honey).toEqual({ type: 'equipment', gp: '25' })
+    expect(result.hasPricedNames).toBe(false)
+  })
+})

--- a/module/__tests__/parser-item-remap.test.js
+++ b/module/__tests__/parser-item-remap.test.js
@@ -1,0 +1,63 @@
+import { describe, test, expect } from 'vitest'
+import '../__mocks__/foundry.js'
+import { _normalizeItemName, _itemTypesCompatible } from '../parser.js'
+import { actorImporterNameMap } from '../config/actor-importer.mjs'
+
+// Item remap matching for the actor importer (#817). Purple Sorcerer equipment
+// names drifted from the dcc-core-book pack names (hyphens vs commas, straight
+// vs curly apostrophes, appended prices), and containers could never match
+// because the importer creates all goods as generic 'equipment' items. These
+// tests pin the normalization + type-compatibility contract the remap loop in
+// createActors relies on.
+
+describe('_normalizeItemName', () => {
+  // Real Purple Sorcerer output (left) vs real dcc-core-book pack names (right)
+  test.each([
+    ["Rope - 50'", 'Rope, 50’'],
+    ["Chain 10'", 'Chain, 10’'],
+    ['Pole - 10-foot', 'Pole, 10-foot'],
+    ['Sack (large)', 'Sack, large'],
+    ['Sack (small)', 'Sack, small'],
+    ['Chalk - 1 piece', 'Chalk, 1 piece'],
+    ['Holy water (1 vial)', 'Holy water, 1 vial**'],
+    ['Oil (1 flask)', 'Oil, 1 flask***'],
+    ["Thieves' tools", 'Thieves’ tools'],
+    ['Backpack', 'Backpack'],
+    ['Candle', 'Candle']
+  ])('matches Purple Sorcerer "%s" to pack name "%s"', (psName, packName) => {
+    expect(_normalizeItemName(psName)).toBe(_normalizeItemName(packName))
+  })
+
+  test('does not conflate distinct items', () => {
+    expect(_normalizeItemName('Sack, large')).not.toBe(_normalizeItemName('Sack, small'))
+    expect(_normalizeItemName('Rations (1 day)')).not.toBe(_normalizeItemName('Torch, each'))
+  })
+
+  test('name-map targets that normalization cannot bridge resolve via the map', () => {
+    // 'Rations (1 day)' vs 'Rations, per day' and 'Water skin' vs 'Waterskin'
+    // are true renames — check the map entries exist and point at the pack names
+    expect(actorImporterNameMap['Rations (1 day)']).toEqual(['Rations, per day'])
+    expect(actorImporterNameMap['Water skin']).toEqual(['Waterskin'])
+  })
+})
+
+describe('_itemTypesCompatible', () => {
+  test('exact type matches are compatible', () => {
+    expect(_itemTypesCompatible('weapon', 'weapon')).toBe(true)
+    expect(_itemTypesCompatible('equipment', 'equipment')).toBe(true)
+    expect(_itemTypesCompatible('container', 'container')).toBe(true)
+  })
+
+  test('generic equipment matches containers and ammunition', () => {
+    // The importer cannot tell a backpack is a container from the stat block
+    expect(_itemTypesCompatible('container', 'equipment')).toBe(true)
+    expect(_itemTypesCompatible('ammunition', 'equipment')).toBe(true)
+  })
+
+  test('other cross-type matches are rejected', () => {
+    expect(_itemTypesCompatible('weapon', 'equipment')).toBe(false)
+    expect(_itemTypesCompatible('spell', 'equipment')).toBe(false)
+    expect(_itemTypesCompatible('equipment', 'container')).toBe(false)
+    expect(_itemTypesCompatible('equipment', 'weapon')).toBe(false)
+  })
+})

--- a/module/__tests__/pc-parser-comprehensive.test.js
+++ b/module/__tests__/pc-parser-comprehensive.test.js
@@ -430,6 +430,43 @@ describe('PC Parser Comprehensive Tests', () => {
       expect(equipment.map(e => e.name)).toContain('Fine pottery')
     })
 
+    it('should strip trailing prices from equipment names into item value (#817)', async () => {
+      const result = parsePCs(`{
+        "equipment": "Rope - 50' (25 cp)",
+        "equipment2": "Backpack (2 gp)",
+        "equipment3": "Rations (1 day) (5 cp)",
+        "tradeGood": "Waterskin (5 sp)"
+      }`)
+
+      const equipment = result[0].items.filter(item => item.type === 'equipment')
+      expect(equipment).toHaveLength(4)
+      expect(equipment[0].name).toBe("Rope - 50'")
+      expect(equipment[0].system.value.cp).toBe('25')
+      expect(equipment[1].name).toBe('Backpack')
+      expect(equipment[1].system.value.gp).toBe('2')
+      // Only the trailing price parenthetical is stripped, not other parentheticals
+      expect(equipment[2].name).toBe('Rations (1 day)')
+      expect(equipment[2].system.value.cp).toBe('5')
+      expect(equipment[3].name).toBe('Waterskin')
+      expect(equipment[3].system.value.sp).toBe('5')
+    })
+
+    it('should keep the raw equipment text (price included) in the notes', async () => {
+      const result = parsePCs('{"equipment": "Candle (1 cp)"}')
+      expect(result[0]['details.notes.value']).toContain('Candle (1 cp)')
+      const equipment = result[0].items.filter(item => item.type === 'equipment')
+      expect(equipment[0].name).toBe('Candle')
+    })
+
+    it('should not strip non-price parentheticals from equipment names', async () => {
+      const result = parsePCs('{"equipment": "Rope (50 ft)", "equipment2": "Sack (large)"}')
+      const equipment = result[0].items.filter(item => item.type === 'equipment')
+      expect(equipment[0].name).toBe('Rope (50 ft)')
+      expect(equipment[0].system).toBeUndefined()
+      expect(equipment[1].name).toBe('Sack (large)')
+      expect(equipment[1].system).toBeUndefined()
+    })
+
     it('should handle spell parsing with spell check', async () => {
       const text = `Neutral Wizard (2nd level)
       Strength: 10 (0)

--- a/module/__tests__/pc-parser.test.js
+++ b/module/__tests__/pc-parser.test.js
@@ -60,9 +60,10 @@ Languages: Common`)
         }
       },
       {
-        name: 'Crowbar (2 gp)',
+        name: 'Crowbar',
         type: 'equipment',
-        img: 'systems/dcc/styles/images/item.webp'
+        img: 'systems/dcc/styles/images/item.webp',
+        system: { value: { gp: '2' } }
       },
       {
         name: 'Steel tongs',
@@ -165,9 +166,10 @@ test('beekeeper', () => {
         }
       },
       {
-        name: 'Sack (small) (8 cp)',
+        name: 'Sack (small)',
         type: 'equipment',
-        img: 'systems/dcc/styles/images/item.webp'
+        img: 'systems/dcc/styles/images/item.webp',
+        system: { value: { cp: '8' } }
       },
       {
         name: 'Water skin',
@@ -243,9 +245,10 @@ Languages: Common`)
     'saves.wil.value': '2',
     items: [
       {
-        name: 'Crowbar (2 gp)',
+        name: 'Crowbar',
         type: 'equipment',
-        img: 'systems/dcc/styles/images/item.webp'
+        img: 'systems/dcc/styles/images/item.webp',
+        system: { value: { gp: '2' } }
       },
       {
         name: 'Steel tongs',
@@ -350,9 +353,10 @@ Languages: Common `)
           }
         },
         {
-          name: 'Crowbar (2 gp)',
+          name: 'Crowbar',
           type: 'equipment',
-          img: 'systems/dcc/styles/images/item.webp'
+          img: 'systems/dcc/styles/images/item.webp',
+          system: { value: { gp: '2' } }
         },
         {
           name: 'Steel tongs',
@@ -411,9 +415,10 @@ Languages: Common `)
           }
         },
         {
-          name: 'Torch (1 cp)',
+          name: 'Torch',
           type: 'equipment',
-          img: 'systems/dcc/styles/images/item.webp'
+          img: 'systems/dcc/styles/images/item.webp',
+          system: { value: { cp: '1' } }
         },
         {
           name: 'Bundle of wood',
@@ -557,9 +562,10 @@ Spells: (Spell Check: d20+2)
         }
       },
       {
-        name: 'Waterskin (5 sp)',
+        name: 'Waterskin',
         type: 'equipment',
-        img: 'systems/dcc/styles/images/item.webp'
+        img: 'systems/dcc/styles/images/item.webp',
+        system: { value: { sp: '5' } }
       },
       {
         name: 'Shoehorn',
@@ -769,9 +775,10 @@ Cast Spell From Scroll (d16)`
         }
       },
       {
-        name: 'Holy symbol (25 gp)',
+        name: 'Holy symbol',
         type: 'equipment',
-        img: 'systems/dcc/styles/images/item.webp'
+        img: 'systems/dcc/styles/images/item.webp',
+        system: { value: { gp: '25' } }
       },
       {
         name: 'Fine dirt (1 lb.)',
@@ -1045,9 +1052,10 @@ Hide In Shadows: 11 (-4)`
         }
       },
       {
-        name: 'Iron spike (1 sp)',
+        name: 'Iron spike',
         type: 'equipment',
-        img: 'systems/dcc/styles/images/item.webp'
+        img: 'systems/dcc/styles/images/item.webp',
+        system: { value: { sp: '1' } }
       },
       {
         name: 'Hex doll',
@@ -1181,9 +1189,10 @@ Warrior trait: Lucky weapon - choose one weapon that you apply your luck mod to`
         }
       },
       {
-        name: 'Chest - empty (2 gp)',
+        name: 'Chest - empty',
         type: 'equipment',
-        img: 'systems/dcc/styles/images/item.webp'
+        img: 'systems/dcc/styles/images/item.webp',
+        system: { value: { gp: '2' } }
       },
       {
         name: 'Rag doll',
@@ -1336,9 +1345,10 @@ Spells: (Spell Check: d20+12)
         }
       },
       {
-        name: 'Sack (small) (8 cp)',
+        name: 'Sack (small)',
         type: 'equipment',
-        img: 'systems/dcc/styles/images/item.webp'
+        img: 'systems/dcc/styles/images/item.webp',
+        system: { value: { cp: '8' } }
       },
       {
         name: 'Bundle of wood',
@@ -1688,9 +1698,10 @@ Dwarf skill: Shield bash - make an extra d14 attack with your shield. (1d3 damag
         }
       },
       {
-        name: 'Iron spike (1 sp)',
+        name: 'Iron spike',
         type: 'equipment',
-        img: 'systems/dcc/styles/images/item.webp'
+        img: 'systems/dcc/styles/images/item.webp',
+        system: { value: { sp: '1' } }
       },
       {
         name: 'Steel vial',
@@ -1834,9 +1845,10 @@ Spells: (Spell Check: d20+5)
         }
       },
       {
-        name: 'Iron spike (1 sp)',
+        name: 'Iron spike',
         type: 'equipment',
-        img: 'systems/dcc/styles/images/item.webp'
+        img: 'systems/dcc/styles/images/item.webp',
+        system: { value: { sp: '1' } }
       },
       {
         name: 'Spyglass',
@@ -2033,9 +2045,10 @@ Warrior trait: Lucky weapon - choose one weapon that you apply your luck mod to`
         }
       },
       {
-        name: 'Sack (large) (12 cp)',
+        name: 'Sack (large)',
         type: 'equipment',
-        img: 'systems/dcc/styles/images/item.webp'
+        img: 'systems/dcc/styles/images/item.webp',
+        system: { value: { cp: '12' } }
       },
       {
         name: 'Quality cloak',
@@ -2148,9 +2161,10 @@ Warrior trait: Lucky weapon - choose one weapon that you apply your luck mod to`
         }
       },
       {
-        name: 'Sack (large) (12 cp)',
+        name: 'Sack (large)',
         type: 'equipment',
-        img: 'systems/dcc/styles/images/item.webp'
+        img: 'systems/dcc/styles/images/item.webp',
+        system: { value: { cp: '12' } }
       },
       {
         name: 'Quality cloak',
@@ -2263,9 +2277,10 @@ Warrior trait: Lucky weapon - choose one weapon that you apply your luck mod to`
         }
       },
       {
-        name: 'Sack (large) (12 cp)',
+        name: 'Sack (large)',
         type: 'equipment',
-        img: 'systems/dcc/styles/images/item.webp'
+        img: 'systems/dcc/styles/images/item.webp',
+        system: { value: { cp: '12' } }
       },
       {
         name: 'Quality cloak',
@@ -2438,9 +2453,10 @@ Dwarf skill: Shield bash - make an extra d14 attack with your shield. (1d3 damag
           }
         },
         {
-          name: 'Iron spike (1 sp)',
+          name: 'Iron spike',
           type: 'equipment',
-          img: 'systems/dcc/styles/images/item.webp'
+          img: 'systems/dcc/styles/images/item.webp',
+          system: { value: { sp: '1' } }
         },
         {
           name: 'Spyglass',
@@ -2621,9 +2637,10 @@ Dwarf skill: Shield bash - make an extra d14 attack with your shield. (1d3 damag
           }
         },
         {
-          name: 'Iron spike (1 sp)',
+          name: 'Iron spike',
           type: 'equipment',
-          img: 'systems/dcc/styles/images/item.webp'
+          img: 'systems/dcc/styles/images/item.webp',
+          system: { value: { sp: '1' } }
         },
         {
           name: 'Steel vial',

--- a/module/config/actor-importer.mjs
+++ b/module/config/actor-importer.mjs
@@ -80,6 +80,8 @@ export const actorImporterNameMap = {
   'Trowel (as dagger)': ['Dagger'],
   'Knife (as dagger)': ['Dagger'],
   'Stick (as club)': ['Club'],
+  'Rations (1 day)': ['Rations, per day'],
+  'Water skin': ['Waterskin'],
   'Patron Bond/Invoke Patron': ['Patron Bond', 'Patron Bond (Self)', 'Patron Bond (Other)', 'Invoke Patron'],
   'Demon Summoning': ['Demon Summoning', 'Demon Summoning - No Patron', 'Demon Summoning - Patron', 'Demon Summoning - True Name'],
   Blessing: ['Blessing', 'Blessing Self', 'Blessing Ally', 'Blessing Object']

--- a/module/parser.js
+++ b/module/parser.js
@@ -144,7 +144,8 @@ async function createActors (type, folderId, actorData) {
     }
   }
 
-  // Cache available items if importing players
+  // Cache available items if importing players, keyed by normalized name so
+  // Purple Sorcerer names like "Rope - 50'" match pack names like "Rope, 50’" (#817)
   // @TODO Implement a configuration mechanism for providing additional packs
   const itemMap = {}
   if (type === 'Player') {
@@ -153,7 +154,11 @@ async function createActors (type, folderId, actorData) {
       if (!pack) continue
 
       for (const entry of pack.index) {
-        itemMap[entry.name] = entry
+        const key = _normalizeItemName(entry.name)
+        if (!itemMap[key]) {
+          itemMap[key] = []
+        }
+        itemMap[key].push(entry)
       }
     }
   }
@@ -217,15 +222,18 @@ async function createActors (type, folderId, actorData) {
         const newItems = []
 
         for (const name of names) {
-          // Check for an item of this type in the cache
-          const mapEntry = itemMap[name]
-          if (mapEntry && mapEntry.type === originalItem.type) {
+          // Check for a type-compatible item of this name in the cache
+          const candidates = itemMap[_normalizeItemName(name)] ?? []
+          const mapEntry = candidates.find(entry => _itemTypesCompatible(entry.type, originalItem.type))
+          if (mapEntry) {
             // Lookup the item document
             const compendiumItem = await fromUuid(mapEntry.uuid)
             const newItem = compendiumItem.toObject()
 
-            // Keep the original item name if we're remapping to a single item
-            if (names.length === 1) {
+            // Keep the original item name if we're remapping to a single weapon
+            // or armor item (e.g. "Hammer (as club)"); generic equipment takes
+            // the compendium name so imported gear matches compendium gear
+            if (names.length === 1 && (originalItem.type === 'weapon' || originalItem.type === 'armor')) {
               newItem.name = originalItem.name
             }
 
@@ -313,6 +321,37 @@ function onRenderActorDirectory (app, html) {
 }
 
 /**
+ * Normalize an item name for compendium matching: lower-case, straighten curly
+ * apostrophes, and collapse commas, hyphens, parentheses, and asterisks to
+ * spaces, so Purple Sorcerer names like "Rope - 50'" or "Sack (large)" match
+ * pack names like "Rope, 50’" and "Sack, large" (#817)
+ * @param {string} name - The item name to normalize
+ * @return {string} The normalized name
+ */
+function _normalizeItemName (name) {
+  return name
+    .toLowerCase()
+    .replace(/[’‘]/g, "'")
+    .replace(/[-,()*]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/**
+ * Check whether a compendium index entry can satisfy an imported item's type.
+ * The stat-block importer creates all goods as generic 'equipment' items, so
+ * let those match 'container' and 'ammunition' pack entries too — otherwise
+ * backpacks and sacks can never remap to their container items (#817)
+ * @param {string} entryType - The compendium index entry's item type
+ * @param {string} itemType - The imported item's type
+ * @return {boolean} Whether the types are compatible
+ */
+function _itemTypesCompatible (entryType, itemType) {
+  return entryType === itemType ||
+    (itemType === 'equipment' && (entryType === 'container' || entryType === 'ammunition'))
+}
+
+/**
  * Try to match a birth augur string and apply the corresponding active effect
  * Also extracts and sets the birthAugurLuckMod on the actor
  * @param {Actor} actor - The actor to apply the effect to
@@ -349,6 +388,6 @@ async function _applyBirthAugurEffect (actor, birthAugurText) {
 
 export default { onRenderActorDirectory, createActors }
 
-// Exposed for unit testing — the birth-augur effect application is otherwise
-// only reachable through the heavyweight createActors import pipeline.
-export { _applyBirthAugurEffect }
+// Exposed for unit testing — these are otherwise only reachable through the
+// heavyweight createActors import pipeline.
+export { _applyBirthAugurEffect, _normalizeItemName, _itemTypesCompatible }

--- a/module/pc-parser.js
+++ b/module/pc-parser.js
@@ -191,35 +191,19 @@ function _parseJSONPCs (pcObject) {
       notes = notes + game.i18n.localize('DCC.Equipment') + ':<br/>'
       if (pcObject.equipment) {
         notes = notes + '  ' + pcObject.equipment + '<br/>'
-        pc.items.push({
-          name: pcObject.equipment,
-          type: 'equipment',
-          img: EntityImages.imageForItem('equipment')
-        })
+        pc.items.push(_parseEquipmentItem(pcObject.equipment))
       }
       if (pcObject.equipment2) {
         notes = notes + '  ' + pcObject.equipment2 + '<br/>'
-        pc.items.push({
-          name: pcObject.equipment2,
-          type: 'equipment',
-          img: EntityImages.imageForItem('equipment')
-        })
+        pc.items.push(_parseEquipmentItem(pcObject.equipment2))
       }
       if (pcObject.equipment3) {
         notes = notes + '  ' + pcObject.equipment3 + '<br/>'
-        pc.items.push({
-          name: pcObject.equipment3,
-          type: 'equipment',
-          img: EntityImages.imageForItem('equipment')
-        })
+        pc.items.push(_parseEquipmentItem(pcObject.equipment3))
       }
       if (pcObject.tradeGood) {
         notes = notes + '  ' + pcObject.tradeGood + ' (' + game.i18n.localize('DCC.TradeGoods') + ')<br/>'
-        pc.items.push({
-          name: pcObject.tradeGood,
-          type: 'equipment',
-          img: EntityImages.imageForItem('equipment')
-        })
+        pc.items.push(_parseEquipmentItem(pcObject.tradeGood))
       }
       notes = notes + '<br/>'
     }
@@ -564,6 +548,28 @@ function _parseWeapon (weaponString) {
   }
 
   return null
+}
+
+/**
+ * Create an equipment item from a Purple Sorcerer equipment string.
+ * Purple Sorcerer appends prices to equipment names (e.g. "Candle (1 cp)");
+ * strip the trailing price parenthetical from the name and store it in the
+ * item's currency value so the price survives import (#817).
+ * @param {string} equipmentString - The raw equipment or trade good text
+ * @return {Object} Equipment item data
+ */
+function _parseEquipmentItem (equipmentString) {
+  const item = {
+    name: equipmentString,
+    type: 'equipment',
+    img: EntityImages.imageForItem('equipment')
+  }
+  const priceMatch = equipmentString.match(/^(.*?)\s*\((\d+)\s*(pp|ep|gp|sp|cp)\)\s*$/i)
+  if (priceMatch) {
+    item.name = priceMatch[1]
+    item.system = { value: { [priceMatch[3].toLowerCase()]: priceMatch[2] } }
+  }
+  return item
 }
 
 function _parseArmor (armorString) {


### PR DESCRIPTION
## Summary

Fixes #817 — Purple Sorcerer now appends prices to equipment names (`Backpack (2 gp)`, `Rope - 50' (25 cp)`, confirmed against their live API), which broke the actor importer's exact-name compendium remap. Backpacks/sacks also could never import as containers because the importer creates all goods as generic `equipment` items but required an exact type match against the pack entry.

## Changes

- **`module/pc-parser.js`** — strip a trailing `(N pp|ep|gp|sp|cp)` price parenthetical from equipment/trade-good names and store it in the item's `system.value`, so the price survives import even when there's no compendium match (e.g. trade goods). The raw text (price included) still goes to the notes block.
- **`module/parser.js`** — the compendium item cache is now keyed by normalized name (lower-case, curly→straight apostrophes, commas/hyphens/parens/asterisks collapsed to spaces) so `Rope - 50'` matches the pack's `Rope, 50’`, `Sack (large)` matches `Sack, large`, etc. Generic `equipment` originals may now match `container` and `ammunition` pack entries, so backpacks, sacks, and chests import as real containers with capacity and price. Matched equipment takes the compendium name/image/price; weapons and armor keep their stat-block names (`Hammer (as club)`).
- **`module/config/actor-importer.mjs`** — name-map entries for the two true renames normalization can't bridge: `Rations (1 day)` → `Rations, per day` and `Water skin` → `Waterskin`.

## Testing

- Unit: new `parser-item-remap.test.js` pins the normalization pairs (real PS names vs real pack names) and the type-compatibility rules; new pc-parser tests cover price stripping/value capture; existing fixtures updated to the new contract. **2132/2132 passing.**
- E2E: new `browser-tests/e2e/actor-import.spec.js` drives `createActors` end-to-end against the live dcc-core-book packs with current Purple Sorcerer JSON — asserts the container remap, punctuation-drift matching, name-map remap, and price retention. **Full 257-test e2e suite passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)