### PR TITLE
Migrate chat card context menu entries to the v14 ContextMenuEntry shape

### DIFF
--- a/browser-tests/e2e/chat-context-menu.spec.js
+++ b/browser-tests/e2e/chat-context-menu.spec.js
@@ -1,0 +1,103 @@
+/* eslint-disable no-undef -- Browser globals used in page.evaluate */
+const { expect, createSessionTest } = require('./fixtures')
+
+/**
+ * Apply Damage / Apply Healing via the chat-card context menu (issue #828).
+ *
+ * The entries were migrated to the v14 ContextMenuEntry shape (label /
+ * class-name icon / visible / onClick), so these tests drive the real menu:
+ * right-click a damage-roll chat card and assert that core localizes the
+ * `label` keys, that `visible` gates on a controlled token, and that clicking
+ * Apply Damage actually deducts the rolled amount from the controlled actor.
+ */
+const test = createSessionTest()
+
+/** Create a controllable token with known HP and post a fixed damage roll. */
+async function setupDamageCard (page) {
+  return page.evaluate(async () => {
+    if (!game.canvas?.ready || !game.canvas?.scene) {
+      const scene = await Scene.create({ name: 'DCC ChatCtx Probe', width: 4000, height: 3000, grid: { type: 1, size: 100, distance: 5, units: 'ft' } })
+      await scene.view()
+    }
+    const scene = game.canvas.scene
+
+    const actor = await Actor.create({
+      name: 'DCC ChatCtx Target',
+      type: 'NPC',
+      system: { attributes: { hp: { value: 20, max: 20 } } },
+      prototypeToken: { actorLink: true }
+    })
+    const [tokenDoc] = await scene.createEmbeddedDocuments('Token', [{ name: 'T', actorId: actor.id, actorLink: true, x: 500, y: 500, width: 1, height: 1 }])
+    const deadline = Date.now() + 3000
+    while (Date.now() < deadline && !game.canvas.tokens.get(tokenDoc.id)) await new Promise(resolve => setTimeout(resolve, 50))
+    game.canvas.tokens.get(tokenDoc.id).control({ releaseOthers: true })
+
+    // A fixed-total roll so the applied damage is deterministic
+    const roll = await new Roll('1d1+4').evaluate()
+    const message = await roll.toMessage({ flavor: game.i18n.localize('DCC.Damage') })
+
+    return { actorId: actor.id, tokenId: tokenDoc.id, sceneId: scene.id, messageId: message.id }
+  })
+}
+
+/** Expand the sidebar onto the chat tab and scroll the card into view. */
+async function revealCard (page, messageId) {
+  await page.evaluate(() => ui.sidebar.expand())
+  await page.click('button[data-tab="chat"]')
+  await page.evaluate(() => ui.chat.scrollBottom({ immediate: true }))
+  const card = page.locator(`#chat .chat-message[data-message-id="${messageId}"]`)
+  await expect(card).toBeVisible()
+  return card
+}
+
+async function cleanupDamageCard (page, setup) {
+  await page.evaluate(async ({ actorId, tokenId, sceneId, messageId }) => {
+    game.canvas.tokens.releaseAll()
+    await game.scenes.get(sceneId)?.deleteEmbeddedDocuments('Token', [tokenId])
+    await game.actors.get(actorId)?.delete()
+    await game.messages.get(messageId)?.delete()
+  }, setup)
+}
+
+test.describe('Chat card Apply Damage / Apply Healing context menu', () => {
+  test('right-click on a damage card shows localized entries and applies the damage', async ({ page }) => {
+    const setup = await setupDamageCard(page)
+    try {
+      const card = await revealCard(page, setup.messageId)
+      await card.click({ button: 'right' })
+
+      // Core localizes the raw `label` i18n keys; the icon is a class name
+      const applyDamage = page.locator('#context-menu li.context-item:has-text("Apply Damage")')
+      await expect(applyDamage).toBeVisible()
+      await expect(page.locator('#context-menu li.context-item:has-text("Apply Healing")')).toBeVisible()
+      await expect(applyDamage.locator('i.fas.fa-user-minus')).toBeAttached()
+
+      await applyDamage.click()
+
+      // applyChatCardDamage is async (applyDamage → actor.update) — poll HP
+      await expect.poll(() =>
+        page.evaluate((id) => game.actors.get(id).system.attributes.hp.value, setup.actorId)
+      ).toBe(15) // 20 - (1d1+4)
+    } finally {
+      await cleanupDamageCard(page, setup)
+    }
+  })
+
+  test('entries are hidden when no token is controlled', async ({ page }) => {
+    const setup = await setupDamageCard(page)
+    try {
+      await page.evaluate(() => game.canvas.tokens.releaseAll())
+
+      const card = await revealCard(page, setup.messageId)
+      await card.click({ button: 'right' })
+
+      // The core menu opens, but both DCC entries are filtered out by `visible`
+      await expect(page.locator('#context-menu')).toBeVisible()
+      await expect(page.locator('#context-menu li.context-item:has-text("Apply Damage")')).toHaveCount(0)
+      await expect(page.locator('#context-menu li.context-item:has-text("Apply Healing")')).toHaveCount(0)
+      await page.keyboard.press('Escape')
+    } finally {
+      await cleanupDamageCard(page, setup)
+    }
+  })
+})

--- a/module/__tests__/chat-and-hook-wiring.test.js
+++ b/module/__tests__/chat-and-hook-wiring.test.js
@@ -313,8 +313,8 @@ describe('onGetUserContextOptions', () => {
 describe('onGetChatMessageContextOptions', () => {
   test('delegates to chat.addChatMessageContextOptions', () => {
     chat.addChatMessageContextOptions.mockReturnValue('ctx-result')
-    const result = onGetChatMessageContextOptions('<html/>', [{ name: 'A' }])
-    expect(chat.addChatMessageContextOptions).toHaveBeenCalledWith('<html/>', [{ name: 'A' }])
+    const result = onGetChatMessageContextOptions('<html/>', [{ label: 'A' }])
+    expect(chat.addChatMessageContextOptions).toHaveBeenCalledWith('<html/>', [{ label: 'A' }])
     expect(result).toBe('ctx-result')
   })
 })

--- a/module/__tests__/chat.test.js
+++ b/module/__tests__/chat.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import '../__mocks__/foundry.js'
 
 vi.mock('../utilities.js', async (importOriginal) => {
@@ -244,15 +244,19 @@ describe('addChatMessageContextOptions (chat card context menu, issue #828)', ()
 
   beforeEach(() => {
     applyDamage = vi.fn(async () => {})
-    globalThis.canvas = { tokens: { controlled: [{ actor: { applyDamage } }] } }
-    globalThis.game = {
+    vi.stubGlobal('canvas', { tokens: { controlled: [{ actor: { applyDamage } }] } })
+    vi.stubGlobal('game', {
       messages: { get: vi.fn() },
       i18n: { localize: (key) => key }
-    }
-    globalThis.ui = { notifications: { warn: vi.fn() } }
+    })
+    vi.stubGlobal('ui', { notifications: { warn: vi.fn() } })
     const options = addChatMessageContextOptions({}, [])
     damageEntry = options[0]
     healingEntry = options[1]
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('pushes two v14-shaped entries (label/visible/onClick, class-name icon)', () => {
@@ -279,7 +283,7 @@ describe('addChatMessageContextOptions (chat card context menu, issue #828)', ()
   })
 
   it('not visible when the card has neither a damage-applyable nor a dice total', () => {
-    expect(damageEntry.visible(makeLi())).toBeFalsy()
+    expect(damageEntry.visible(makeLi())).toBe(false)
   })
 
   it('onClick applies the damage-applyable amount to each controlled token actor', async () => {

--- a/module/__tests__/chat.test.js
+++ b/module/__tests__/chat.test.js
@@ -8,7 +8,7 @@ vi.mock('../utilities.js', async (importOriginal) => {
   return { ...actual, getCritTableResult: vi.fn(), getTableFromPath: vi.fn(async () => null) }
 })
 
-const { lookupCriticalRoll, buildMightyDeedPrompt, attachMightyDeedListeners } = await import('../chat.js')
+const { lookupCriticalRoll, buildMightyDeedPrompt, attachMightyDeedListeners, addChatMessageContextOptions } = await import('../chat.js')
 const { getCritTableResult } = await import('../utilities.js')
 
 /**
@@ -219,5 +219,87 @@ describe('attachMightyDeedListeners', () => {
     attachMightyDeedListeners(message, card)
 
     expect(select.changeListeners).toBe(1)
+  })
+})
+
+describe('addChatMessageContextOptions (chat card context menu, issue #828)', () => {
+  // The v14 ContextMenu passes a plain HTMLElement to visible/onClick — these
+  // stubs model `li` with just the queries the entries perform.
+  const makeLi = ({ damage = null, diceTotal = null } = {}) => ({
+    querySelector: (sel) => {
+      if (sel === '.damage-applyable' && damage !== null) {
+        return { getAttribute: (attr) => (attr === 'data-damage' ? damage : null) }
+      }
+      if (sel === '.dice-total' && diceTotal !== null) {
+        return { textContent: diceTotal }
+      }
+      return null
+    },
+    closest: () => null
+  })
+
+  let damageEntry
+  let healingEntry
+  let applyDamage
+
+  beforeEach(() => {
+    applyDamage = vi.fn(async () => {})
+    globalThis.canvas = { tokens: { controlled: [{ actor: { applyDamage } }] } }
+    globalThis.game = {
+      messages: { get: vi.fn() },
+      i18n: { localize: (key) => key }
+    }
+    globalThis.ui = { notifications: { warn: vi.fn() } }
+    const options = addChatMessageContextOptions({}, [])
+    damageEntry = options[0]
+    healingEntry = options[1]
+  })
+
+  it('pushes two v14-shaped entries (label/visible/onClick, class-name icon)', () => {
+    expect(damageEntry.label).toBe('DCC.ChatContextDamage')
+    expect(healingEntry.label).toBe('DCC.ChatContextHealing')
+    for (const entry of [damageEntry, healingEntry]) {
+      expect(entry.icon).not.toMatch(/</) // class name string, not an <i> HTML string
+      expect(typeof entry.visible).toBe('function')
+      expect(typeof entry.onClick).toBe('function')
+      expect(entry.name).toBeUndefined()
+      expect(entry.condition).toBeUndefined()
+      expect(entry.callback).toBeUndefined()
+    }
+  })
+
+  it('visible when a token is controlled and the card has an applyable amount', () => {
+    expect(damageEntry.visible(makeLi({ damage: '5' }))).toBe(true)
+    expect(damageEntry.visible(makeLi({ diceTotal: '7' }))).toBe(true)
+  })
+
+  it('not visible when no tokens are controlled', () => {
+    globalThis.canvas.tokens.controlled = []
+    expect(damageEntry.visible(makeLi({ damage: '5' }))).toBe(false)
+  })
+
+  it('not visible when the card has neither a damage-applyable nor a dice total', () => {
+    expect(damageEntry.visible(makeLi())).toBeFalsy()
+  })
+
+  it('onClick applies the damage-applyable amount to each controlled token actor', async () => {
+    await damageEntry.onClick(new Event('click'), makeLi({ damage: '5' }))
+    expect(applyDamage).toHaveBeenCalledWith('5', 1)
+  })
+
+  it('healing onClick applies the amount with a -1 multiplier', async () => {
+    await healingEntry.onClick(new Event('click'), makeLi({ damage: '3' }))
+    expect(applyDamage).toHaveBeenCalledWith('3', -1)
+  })
+
+  it('onClick falls back to the dice total for plain rolls', async () => {
+    await damageEntry.onClick(new Event('click'), makeLi({ diceTotal: '7' }))
+    expect(applyDamage).toHaveBeenCalledWith('7', 1)
+  })
+
+  it('onClick warns instead of applying when no amount can be found', async () => {
+    await damageEntry.onClick(new Event('click'), makeLi())
+    expect(applyDamage).not.toHaveBeenCalled()
+    expect(globalThis.ui.notifications.warn).toHaveBeenCalled()
   })
 })

--- a/module/chat.js
+++ b/module/chat.js
@@ -85,18 +85,18 @@ export const addChatMessageContextOptions = function (html, options) {
 
   options.push(
     {
-      name: 'DCC.ChatContextDamage',
-      icon: '<i class="fas fa-user-minus"></i>',
-      condition: canApply,
-      callback: li => applyChatCardDamage(li, 1)
+      label: 'DCC.ChatContextDamage',
+      icon: 'fas fa-user-minus',
+      visible: canApply,
+      onClick: (event, li) => applyChatCardDamage(li, 1)
     }
   )
   options.push(
     {
-      name: 'DCC.ChatContextHealing',
-      icon: '<i class="fas fa-user-plus"></i>',
-      condition: canApply,
-      callback: li => applyChatCardDamage(li, -1)
+      label: 'DCC.ChatContextHealing',
+      icon: 'fas fa-user-plus',
+      visible: canApply,
+      onClick: (event, li) => applyChatCardDamage(li, -1)
     }
   )
   return options

--- a/module/chat.js
+++ b/module/chat.js
@@ -71,7 +71,8 @@ export const highlightCriticalSuccessFailure = function (message, html) {
  * This function is used to hook into the Chat Log context menu to add additional options to each message
  * These options make it easy to conveniently apply damage to controlled tokens based on the value of a Roll
  *
- * @param {HTMLElement} html    The Chat Message being rendered
+ * @param {Application} html    The ChatLog application (unused; the hook fires
+ *                              once at its first render, not per message)
  * @param {Array} options       The Array of Context Menu options
  *
  * @return {Array}              The extended options Array including new context choices
@@ -79,8 +80,7 @@ export const highlightCriticalSuccessFailure = function (message, html) {
 export const addChatMessageContextOptions = function (html, options) {
   const canApply = function (li) {
     if (canvas.tokens.controlled.length === 0) return false
-    if (li.querySelector('.damage-applyable')) return true
-    if (li.querySelector('.dice-total')) return true
+    return !!(li.querySelector('.damage-applyable') || li.querySelector('.dice-total'))
   }
 
   options.push(


### PR DESCRIPTION
## Summary

- Migrates the **Apply Damage** / **Apply Healing** chat-card context menu entries in `module/chat.js` from the deprecated pre-v14 `ContextMenuEntry` fields to the v14 shape: `name` → `label` (raw i18n key), `icon` `<i>` HTML → class-name string, `condition` → `visible`, `callback` → `onClick(event, li)`. The old fields warn in v14 and are slated for removal in v16.
- `onClick` returns the promise from `applyChatCardDamage`, and `canApply` now returns an explicit boolean, matching the hardening done in #827.
- Adds unit coverage for the entries (previously untested): v14 shape assertions, `visible` gating on controlled tokens and applyable amounts, and damage/healing application with the correct multiplier, mirroring the `addUserContextOptions` tests from #826/#827.
- Adds a Playwright spec (`browser-tests/e2e/chat-context-menu.spec.js`) driving the real context menu on a damage-roll card: localized entries appear with the class-name icon, clicking Apply Damage deducts the rolled amount from the controlled token's actor, and both entries are hidden when no token is controlled.
- No dependent module (`dcc-qol`, `xcc`, `mcc-classes`, `dcc-crawl-classes`) references these entries; hook registration timing was already correct.

Fixes #828

## Test plan

- [x] `npm run check` (format, scss, unit tests, compare-lang) passes — 2272 tests green
- [x] New E2E spec passes against live Foundry v14 (menu renders localized, damage applied, hidden without a controlled token)
- [x] Full `browser-tests/e2e` Playwright suite green — 271 passed
- [x] Grepped `browser-tests/e2e/` and sibling modules for references to the old entry shape — none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)