### PR TITLE
Resolve manifestation tables language-independently in Babele worlds

### DIFF
--- a/browser-tests/e2e/friendly-fire.spec.js
+++ b/browser-tests/e2e/friendly-fire.spec.js
@@ -48,11 +48,14 @@ test.describe('Friendly fire', () => {
       const before = game.messages.size
       await attacker.rollWeaponAttack(weapon.id, {})
 
-      // Friendly fire is fire-and-forget (rolls → ChatMessage.create); poll for it.
+      // Friendly fire is fire-and-forget (rolls → ChatMessage.create); poll for
+      // it — but only among messages created by THIS attack. Earlier runs of
+      // this spec leave their friendly-fire cards in the world chat log, and a
+      // stale hit would break the crit branch's "no stray shot" assertion.
       let ffMessage = null
       const deadline = Date.now() + 4000
       while (Date.now() < deadline && !ffMessage) {
-        ffMessage = game.messages.contents.find(m => m.getFlag('dcc', 'isFriendlyFire'))
+        ffMessage = game.messages.contents.slice(before).find(m => m.getFlag('dcc', 'isFriendlyFire'))
         if (!ffMessage) await new Promise(resolve => setTimeout(resolve, 100))
       }
 

--- a/browser-tests/e2e/spell-manifestation.spec.js
+++ b/browser-tests/e2e/spell-manifestation.spec.js
@@ -1,0 +1,108 @@
+/* eslint-disable no-undef -- Browser globals used in page.evaluate */
+const { expect, createSessionTest } = require('./fixtures')
+
+/**
+ * Manifestation table resolution (issue #799).
+ *
+ * `rollManifestation` historically reconstructed the table name as
+ * `${this.name} Manifestation`, which breaks in Babele worlds where the
+ * spell's display name is translated but the side-effect table is not.
+ * These tests drive the two fixes end-to-end against live Foundry:
+ *  - the name fallback also tries the untranslated original name Babele
+ *    records in `flags.babele.originalName`
+ *  - an explicit `system.manifestation.table` reference resolves the table
+ *    language-independently, mirroring `system.results.table`
+ */
+const test = createSessionTest()
+
+/** Poll an item system path until it holds the expected/matching value. */
+const waitForValueFn = `async (item, path, matches) => {
+  const read = () => path.split('.').reduce((o, k) => o?.[k], item.system)
+  for (let i = 0; i < 40; i++) {
+    if (matches(read())) return read()
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  return read()
+}`
+
+test.describe('Spell manifestation table resolution', () => {
+  test('a Babele-translated spell resolves its untranslated manifestation table', async ({ page }) => {
+    const result = await page.evaluate(async (waitForValueSrc) => {
+      // eslint-disable-next-line no-eval
+      const waitForValue = eval(`(${waitForValueSrc})`)
+      const observed = {}
+      let actor, table
+      try {
+        // World table named for the UNTRANSLATED spell name — exactly what
+        // ships untranslated in dcc-core-book's side-effects pack.
+        table = await RollTable.create({
+          name: 'P799 Sleep Manifestation',
+          formula: '1d4',
+          results: [{ type: CONST.TABLE_RESULT_TYPES.TEXT, range: [1, 4], description: 'e2e caster snores gently', weight: 1 }]
+        })
+
+        actor = await Actor.create({ type: 'Player', name: 'P799_BabeleProbe' })
+        // The spell as Babele presents it: translated display name, original
+        // name preserved under flags.babele.
+        const [spell] = await actor.createEmbeddedDocuments('Item', [{
+          type: 'spell',
+          name: 'P799 Schlaf',
+          flags: { babele: { originalName: 'P799 Sleep', translated: true } }
+        }])
+
+        await spell.rollManifestation()
+        const value = await waitForValue(spell, 'manifestation.value', (v) => Number(v) >= 1)
+        observed.value = Number(value)
+        observed.description = spell.system.manifestation.description
+      } finally {
+        if (actor) await actor.delete().catch(() => {})
+        if (table) await table.delete().catch(() => {})
+      }
+      return observed
+    }, waitForValueFn)
+
+    // The roll landed on the 1d4 table resolved via the original name —
+    // before the fix this warned "no manifestation" and stowed nothing.
+    expect(result.value).toBeGreaterThanOrEqual(1)
+    expect(result.value).toBeLessThanOrEqual(4)
+    expect(result.description).toContain('snores gently')
+  })
+
+  test('an explicit system.manifestation.table reference resolves regardless of names', async ({ page }) => {
+    const result = await page.evaluate(async (waitForValueSrc) => {
+      // eslint-disable-next-line no-eval
+      const waitForValue = eval(`(${waitForValueSrc})`)
+      const observed = {}
+      let actor, table
+      try {
+        // Table name shares nothing with the spell name — only the explicit
+        // reference can resolve it.
+        table = await RollTable.create({
+          name: 'P799 Homebrew Side Effects',
+          formula: '1d4',
+          results: [{ type: CONST.TABLE_RESULT_TYPES.TEXT, range: [1, 4], description: 'e2e sparks drift upward', weight: 1 }]
+        })
+
+        actor = await Actor.create({ type: 'Player', name: 'P799_RefProbe' })
+        const [spell] = await actor.createEmbeddedDocuments('Item', [{
+          type: 'spell',
+          name: 'P799 Unrelated Spell Name',
+          system: { manifestation: { table: 'P799 Homebrew Side Effects' } }
+        }])
+
+        await spell.rollManifestation()
+        const value = await waitForValue(spell, 'manifestation.value', (v) => Number(v) >= 1)
+        observed.value = Number(value)
+        observed.description = spell.system.manifestation.description
+      } finally {
+        if (actor) await actor.delete().catch(() => {})
+        if (table) await table.delete().catch(() => {})
+      }
+      return observed
+    }, waitForValueFn)
+
+    expect(result.value).toBeGreaterThanOrEqual(1)
+    expect(result.value).toBeLessThanOrEqual(4)
+    expect(result.description).toContain('sparks drift upward')
+  })
+})

--- a/docs/user-guide/Creating-a-Spell.md
+++ b/docs/user-guide/Creating-a-Spell.md
@@ -62,6 +62,8 @@ If the spell has Manifestation, Misfire, or Corruption sub-tables, create each o
 
 (Dragging the table into the editor fills in the `@UUID[...]` link for you.)
 
+The **Roll Manifestation** button on the spell finds its table by the *`SPELL NAME` Manifestation* naming convention, searching the configured Spell Side Effects compendium first and then your world's Rollable Tables. Worlds running a translation module (e.g. Babele) are handled automatically — the lookup also matches on the untranslated original names. Advanced pack authors can instead point a spell at an arbitrarily-named table by setting `system.manifestation.table` (a table name, id, or `RollTable.<id>`) and optionally `system.manifestation.collection` (a compendium key) in the spell's source data, mirroring how `system.results` references the spell-check results table.
+
 ## Step 3: Link the Table to the Spell
 
 The spell needs to know which table to roll on. There are two ways to connect them:

--- a/module/__tests__/adapter-spell-check.test.js
+++ b/module/__tests__/adapter-spell-check.test.js
@@ -2002,6 +2002,33 @@ test('loadPatronTaintTable resolves an exact-name match from a compendium pack',
   game.packs = originalGamePacks
 })
 
+test('loadPatronTaintTable resolves a Babele-translated pack entry by its original name (#799)', async () => {
+  // In a translated world the pack index shows the translated table name,
+  // but the reconstructed `Patron Taint: <patron>` string is English — the
+  // loader must match on the untranslated original name Babele carries.
+  const originalPacks = CONFIG.DCC.patronTaintPacks
+  const originalGamePacks = game.packs
+  const fakeTable = {
+    id: 'bob-taint-de',
+    name: 'Schutzpatron-Makel: Bobugbubilz',
+    results: [{ range: [1, 1], description: 'Surrende Fliegen' }]
+  }
+  const fakePack = {
+    index: [{ _id: 'e3', name: 'Schutzpatron-Makel: Bobugbubilz', originalName: 'Patron Taint: Bobugbubilz' }],
+    getDocument: vi.fn().mockResolvedValue(fakeTable)
+  }
+  CONFIG.DCC.patronTaintPacks = { packs: ['dcc-core-book.dcc-core-spell-side-effect-tables'] }
+  game.packs = { get: () => fakePack }
+
+  const libTable = await loadPatronTaintTable(makePatronTaintActor('Bobugbubilz'))
+
+  expect(libTable?.entries).toHaveLength(1)
+  expect(fakePack.getDocument).toHaveBeenCalledWith('e3')
+
+  CONFIG.DCC.patronTaintPacks = originalPacks
+  game.packs = originalGamePacks
+})
+
 test('loadPatronTaintTable case-insensitive fallback resolves "The King of Elfland" against lowercase "the"', async () => {
   // The official dcc-core-book table is named
   // "Patron Taint: the King of Elfland" (lowercase "the"), but actors

--- a/module/__tests__/adapter-spell-check.test.js
+++ b/module/__tests__/adapter-spell-check.test.js
@@ -2285,6 +2285,27 @@ test('loadDisapprovalTable resolves a compendium table via CONFIG.DCC.disapprova
   game.packs = originalGamePacks
 })
 
+test('loadDisapprovalTable resolves a Babele-translated pack entry by its original name (#799)', async () => {
+  const originalPacks = CONFIG.DCC.disapprovalPacks
+  const originalGamePacks = game.packs
+  clearAllTableCaches()
+  const sourceTable = makeDisapprovalSourceTable('pack-doc-de', 'Missbilligung-1')
+  const pack = {
+    index: [{ _id: 'pack-doc-de', name: 'Missbilligung-1', originalName: 'Disapproval-1' }],
+    getDocument: vi.fn().mockResolvedValue(sourceTable)
+  }
+  CONFIG.DCC.disapprovalPacks = { packs: ['dcc-core-book.dcc-disapproval-tables'] }
+  game.packs = { get: vi.fn().mockReturnValue(pack) }
+
+  const libTable = await loadDisapprovalTable(makeDisapprovalActor('dcc-core-book.dcc-disapproval-tables.Disapproval-1'))
+
+  expect(libTable?.entries).toHaveLength(2)
+  expect(pack.getDocument).toHaveBeenCalledWith('pack-doc-de')
+
+  CONFIG.DCC.disapprovalPacks = originalPacks
+  game.packs = originalGamePacks
+})
+
 test('loadDisapprovalTable falls back to world tables when compendium lookup misses', async () => {
   const originalPacks = CONFIG.DCC.disapprovalPacks
   const originalGamePacks = game.packs

--- a/module/__tests__/adapter-spell-check.test.js
+++ b/module/__tests__/adapter-spell-check.test.js
@@ -1362,6 +1362,39 @@ test('loadMercurialMagicTable: classKey selects the class-specific world table',
   game.tables = originalGameTables
 })
 
+test('loadMercurialMagicTable: resolves a Babele-translated pack entry by its original name (#799)', async () => {
+  const originalTables = CONFIG.DCC.mercurialMagicTables
+  const originalDefault = CONFIG.DCC.mercurialMagicTable
+  const originalGamePacks = game.packs
+  const originalGameTables = game.tables
+
+  // Configured 3-part pack path names the table in English; the translated
+  // pack index shows a German display name and carries the original.
+  CONFIG.DCC.mercurialMagicTables = { default: 'dcc-core-book.dcc-core-tables.Table 5-2: Mercurial Magic DE Probe' }
+  CONFIG.DCC.mercurialMagicTable = null
+  const fakeTable = {
+    id: 'merc-de',
+    name: 'Tabelle 5-2: Launische Magie',
+    results: [{ range: [-20, 130], description: 'Blaue Aura.' }]
+  }
+  const fakePack = {
+    index: [{ _id: 'm1', name: 'Tabelle 5-2: Launische Magie', originalName: 'Table 5-2: Mercurial Magic DE Probe' }],
+    getDocument: vi.fn().mockResolvedValue(fakeTable)
+  }
+  game.packs = { get: (name) => (name === 'dcc-core-book.dcc-core-tables' ? fakePack : null) }
+  game.tables = { getName: () => null, find: () => null }
+
+  const libTable = await loadMercurialMagicTable('wizard')
+
+  expect(libTable?.entries?.[0]?.summary).toBe('Blaue Aura')
+  expect(fakePack.getDocument).toHaveBeenCalledWith('m1')
+
+  CONFIG.DCC.mercurialMagicTables = originalTables
+  CONFIG.DCC.mercurialMagicTable = originalDefault
+  game.packs = originalGamePacks
+  game.tables = originalGameTables
+})
+
 // Issue #339 — special (roll-again) entries map onto the lib's
 // `entry.special` so `rollMercurialMagic` expands them into sub-effects
 // instead of returning the literal instruction text.

--- a/module/__tests__/item-spell-mixin.test.js
+++ b/module/__tests__/item-spell-mixin.test.js
@@ -354,6 +354,38 @@ describe('SpellItemMixin extraction', () => {
       }))
     })
 
+    test('rollManifestation falls back to the name convention when an explicit reference dangles', async () => {
+      const item = makeSpell()
+      item.actor = actor
+      item.system.manifestation = { table: 'Renamed Or Deleted Table' }
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const drawnRoll = new FakeRoll('1d4', { value: 3 })
+      const table = {
+        formula: '1d4',
+        draw: vi.fn(async () => ({ roll: drawnRoll, results: [{ description: 'caster glows faintly' }] }))
+      }
+      // The dangling ref matches nothing in the pack, but the conventional
+      // `<name> Manifestation` entry is present and must still resolve.
+      const entry = { _id: 'tbl1', name: 'Probe Spell Manifestation' }
+      global.game.packs = {
+        get: vi.fn(() => ({
+          index: { find: vi.fn((fn) => (fn(entry) ? entry : undefined)) },
+          getDocument: vi.fn(async () => table)
+        }))
+      }
+      global.game.dcc = { DCCRoll: { createRoll: vi.fn(async (terms) => new FakeRoll(terms[0].formula, { value: 3 })) } }
+
+      await item.rollManifestation()
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Renamed Or Deleted Table'))
+      expect(table.draw).toHaveBeenCalledOnce()
+      expect(item.update).toHaveBeenCalledWith(expect.objectContaining({
+        'system.manifestation.value': 3
+      }))
+      warnSpy.mockRestore()
+    })
+
     test('rollManifestation resolves an explicit RollTable.<id> reference from world tables', async () => {
       const item = makeSpell()
       item.actor = actor

--- a/module/__tests__/item-spell-mixin.test.js
+++ b/module/__tests__/item-spell-mixin.test.js
@@ -6,13 +6,20 @@ import DCCItem from '../item.js'
 vi.mock('../dice-chain.js', () => ({
   default: { bumpDie: vi.fn((die) => die) }
 }))
-vi.mock('../utilities.js', async (importOriginal) => ({
-  ensurePlus: vi.fn((value) => (String(value).startsWith('-') ? String(value) : `+${value}`)),
-  getFirstDie: vi.fn(() => null),
-  // Real implementation — the special (roll-again) expansion tests below
-  // exercise its flag/text detection through rollMercurialMagic (#339)
-  getMercurialSpecial: (await importOriginal()).getMercurialSpecial
-}))
+vi.mock('../utilities.js', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ensurePlus: vi.fn((value) => (String(value).startsWith('-') ? String(value) : `+${value}`)),
+    getFirstDie: vi.fn(() => null),
+    // Real implementations — the special (roll-again) expansion tests exercise
+    // getMercurialSpecial's flag/text detection through rollMercurialMagic
+    // (#339), and the Babele-aware manifestation resolution tests exercise the
+    // name-candidate helpers (#799)
+    getMercurialSpecial: actual.getMercurialSpecial,
+    getNameCandidates: actual.getNameCandidates,
+    findPackEntryByName: actual.findPackEntryByName
+  }
+})
 
 // Deterministic Roll stub: `new Roll('@value', { value })` resolves total to the
 // looked-up value, mirroring the manifestation/mercurial lookup-by-value path.
@@ -252,6 +259,121 @@ describe('SpellItemMixin extraction', () => {
       expect(item.update).toHaveBeenCalledWith(expect.objectContaining({
         'system.manifestation.value': 2,
         'system.manifestation.description': '<p>Caster glows faintly</p>'
+      }))
+    })
+
+    // Issue #799 — Babele worlds translate the spell's name but not
+    // (necessarily) the side-effect table pack, so the reconstructed
+    // `<name> Manifestation` string must also be tried with the untranslated
+    // original name Babele records on the item.
+    test('rollManifestation resolves the untranslated table for a Babele-translated spell', async () => {
+      const item = makeSpell()
+      item.actor = actor
+      Object.defineProperty(item, 'name', { value: 'Schlaf', configurable: true })
+      item.flags = { babele: { originalName: 'Sleep', translated: true } }
+
+      const drawnRoll = new FakeRoll('1d4', { value: 3 })
+      const table = {
+        formula: '1d4',
+        draw: vi.fn(async () => ({ roll: drawnRoll, results: [{ description: 'caster glows faintly' }] }))
+      }
+      const entry = { _id: 'tbl1', name: 'Sleep Manifestation' }
+      global.game.packs = {
+        get: vi.fn(() => ({
+          index: { find: vi.fn((fn) => (fn(entry) ? entry : undefined)) },
+          getDocument: vi.fn(async () => table)
+        }))
+      }
+      global.game.dcc = { DCCRoll: { createRoll: vi.fn(async (terms) => new FakeRoll(terms[0].formula, { value: 3 })) } }
+
+      await item.rollManifestation()
+
+      expect(table.draw).toHaveBeenCalledOnce()
+      expect(item.update).toHaveBeenCalledWith(expect.objectContaining({
+        'system.manifestation.value': 3
+      }))
+    })
+
+    // Issue #799 (inverse asymmetry) — the side-effect pack IS translated but
+    // the spell keeps its English name: match on the index entry's original name.
+    test('rollManifestation resolves a Babele-translated pack entry by its original name', async () => {
+      const item = makeSpell()
+      item.actor = actor
+      Object.defineProperty(item, 'name', { value: 'Sleep', configurable: true })
+
+      const drawnRoll = new FakeRoll('1d4', { value: 2 })
+      const table = {
+        formula: '1d4',
+        draw: vi.fn(async () => ({ roll: drawnRoll, results: [{ description: 'caster glows faintly' }] }))
+      }
+      const entry = { _id: 'tbl1', name: 'Schlaf-Manifestation', originalName: 'Sleep Manifestation' }
+      global.game.packs = {
+        get: vi.fn(() => ({
+          index: { find: vi.fn((fn) => (fn(entry) ? entry : undefined)) },
+          getDocument: vi.fn(async () => table)
+        }))
+      }
+      global.game.dcc = { DCCRoll: { createRoll: vi.fn(async (terms) => new FakeRoll(terms[0].formula, { value: 2 })) } }
+
+      await item.rollManifestation()
+
+      expect(table.draw).toHaveBeenCalledOnce()
+      expect(item.update).toHaveBeenCalledWith(expect.objectContaining({
+        'system.manifestation.value': 2
+      }))
+    })
+
+    // Issue #799 — an explicit `system.manifestation.table` reference is
+    // language-independent and wins over name reconstruction, mirroring
+    // `system.results.table` / `.collection`.
+    test('rollManifestation honors an explicit table reference and its collection', async () => {
+      const item = makeSpell()
+      item.actor = actor
+      item.system.manifestation = { table: 'My Custom Manifestations', collection: 'world.homebrew-tables' }
+
+      const drawnRoll = new FakeRoll('1d4', { value: 4 })
+      const table = {
+        formula: '1d4',
+        draw: vi.fn(async () => ({ roll: drawnRoll, results: [{ description: 'sparks fly' }] }))
+      }
+      const entry = { _id: 'tblX', name: 'My Custom Manifestations' }
+      const refPack = {
+        index: { find: vi.fn((fn) => (fn(entry) ? entry : undefined)) },
+        getDocument: vi.fn(async () => table)
+      }
+      global.game.packs = { get: vi.fn((name) => (name === 'world.homebrew-tables' ? refPack : null)) }
+      global.game.dcc = { DCCRoll: { createRoll: vi.fn(async (terms) => new FakeRoll(terms[0].formula, { value: 4 })) } }
+
+      await item.rollManifestation()
+
+      expect(global.game.packs.get).toHaveBeenCalledWith('world.homebrew-tables')
+      expect(table.draw).toHaveBeenCalledOnce()
+      expect(item.update).toHaveBeenCalledWith(expect.objectContaining({
+        'system.manifestation.value': 4,
+        'system.manifestation.description': '<p>Sparks fly</p>'
+      }))
+    })
+
+    test('rollManifestation resolves an explicit RollTable.<id> reference from world tables', async () => {
+      const item = makeSpell()
+      item.actor = actor
+      item.system.manifestation = { table: 'RollTable.abc123' }
+
+      const drawnRoll = new FakeRoll('1d4', { value: 1 })
+      const table = {
+        _id: 'abc123',
+        name: 'Anything At All',
+        formula: '1d4',
+        draw: vi.fn(async () => ({ roll: drawnRoll, results: [{ description: 'a chill wind' }] }))
+      }
+      global.game.tables.contents = [table]
+      global.game.dcc = { DCCRoll: { createRoll: vi.fn(async (terms) => new FakeRoll(terms[0].formula, { value: 1 })) } }
+
+      await item.rollManifestation()
+
+      expect(table.draw).toHaveBeenCalledOnce()
+      expect(item.update).toHaveBeenCalledWith(expect.objectContaining({
+        'system.manifestation.value': 1
       }))
     })
 

--- a/module/__tests__/table-loading.test.js
+++ b/module/__tests__/table-loading.test.js
@@ -305,6 +305,20 @@ describe('getSkillTable', () => {
     expect(result).toBe(tableDoc)
   })
 
+  test('resolves a Babele-translated pack entry by its original name (#799)', async () => {
+    globalThis.CONFIG.DCC.turnUnholyTable = 'dcc-core-book.dcc-core-tables.Turn Unholy'
+    const tableDoc = { id: 'tt1', name: 'Unheilige vertreiben' }
+    const entry = { _id: 'tt1', name: 'Unheilige vertreiben', originalName: 'Turn Unholy' }
+    globalThis.game.packs.get = vi.fn(() => ({
+      index: { find: vi.fn((predicate) => (predicate(entry) ? entry : null)) },
+      getDocument: vi.fn().mockResolvedValue(tableDoc)
+    }))
+
+    const result = await getSkillTable('turnUnholy')
+
+    expect(result).toBe(tableDoc)
+  })
+
   test('falls back to a world table when the configured compendium pack is missing', async () => {
     globalThis.CONFIG.DCC.turnUnholyTable = 'missing.module.Turn Unholy'
     globalThis.game.packs.get = vi.fn(() => null)

--- a/module/__tests__/utilities.test.js
+++ b/module/__tests__/utilities.test.js
@@ -3,6 +3,7 @@
 import { expect, vi, describe, it, beforeEach } from 'vitest'
 import '../__mocks__/foundry.js'
 import {
+  docNameMatches,
   ensurePlus,
   findPackEntryByName,
   formatMercurialDescriptionHTML,
@@ -494,6 +495,13 @@ describe('Utilities', () => {
       expect(result).toEqual({ text: 'Critical hit result' })
     })
 
+    it('resolves a Babele-translated pack entry by its original name (#799)', async () => {
+      mockEntry.name = 'Table de Critique III'
+      mockEntry.originalName = 'Crit Table III'
+      const result = await getCritTableResult(mockRoll, 'Crit Table III')
+      expect(result).toEqual({ text: 'Critical hit result' })
+    })
+
     it('handles elemental crit table specially', async () => {
       await getCritTableResult(mockRoll, 'Crit Table EL')
       expect(CONFIG.DCC.criticalHitPacks.addPack).toHaveBeenCalledWith(
@@ -706,6 +714,22 @@ describe('Utilities', () => {
       const result = await getTableFromPath('Nonexistent Table')
       expect(result).toBeNull()
     })
+
+    it('resolves a Babele-translated pack entry by its original name (#799)', async () => {
+      mockPack.index = [{ _id: 'deed-table-id', name: 'Heldentat: Würfe', originalName: 'Deed: Trips and Throws' }]
+      const result = await getTableFromPath('some-module.deed-tables.Deed: Trips and Throws')
+      expect(mockPack.getDocument).toHaveBeenCalledWith('deed-table-id')
+      expect(result).toBe(mockTable)
+    })
+
+    it('falls back to a world table imported from a translated pack (#799)', async () => {
+      const worldTable = { name: 'Heldentat: Würfe', flags: { babele: { originalName: 'Deed: Trips and Throws' } } }
+      global.game.packs.get.mockReturnValue(null)
+      global.game.tables.find = vi.fn((predicate) => (predicate(worldTable) ? worldTable : null))
+
+      const result = await getTableFromPath('Deed: Trips and Throws')
+      expect(result).toBe(worldTable)
+    })
   })
 
   describe('getFumbleTableResult', () => {
@@ -791,6 +815,13 @@ describe('Utilities', () => {
       const result = await getFumbleTableResult(mockRoll)
       expect(result).toBe('Unable to find fumble result')
     })
+
+    it('resolves a Babele-translated pack entry by its original name (#799)', async () => {
+      mockEntry.name = 'Patzer-Tabelle'
+      mockEntry.originalName = 'Fumble Table'
+      const result = await getFumbleTableResult(mockRoll)
+      expect(result).toEqual({ text: 'Fumble result' })
+    })
   })
 
   describe('getNPCFumbleTableResult', () => {
@@ -834,6 +865,13 @@ describe('Utilities', () => {
       expect(result).toEqual({ text: 'NPC fumble result' })
       expect(global.game.packs.get).toHaveBeenCalledWith('dcc-core-book.dcc-monster-fumble-tables')
       expect(mockTable.getResultsForRoll).toHaveBeenCalledWith(12)
+    })
+
+    it('resolves a Babele-translated pack entry by its original name prefix (#799)', async () => {
+      mockEntry.name = 'Patzer-Tabelle M (Monster)'
+      mockEntry.originalName = 'Fumble Table M (Monsters)'
+      const result = await getNPCFumbleTableResult(mockRoll, 'Fumble Table M')
+      expect(result).toEqual({ text: 'NPC fumble result' })
     })
 
     it('handles missing fumble table name', async () => {
@@ -912,6 +950,28 @@ describe('Utilities', () => {
       expect(getNameCandidates(null)).toEqual([])
       expect(getNameCandidates(undefined)).toEqual([])
       expect(getNameCandidates({})).toEqual([])
+    })
+  })
+
+  describe('docNameMatches', () => {
+    it('matches exactly by default', () => {
+      expect(docNameMatches({ name: 'Crit Table III' }, 'Crit Table III')).toBe(true)
+      expect(docNameMatches({ name: 'Crit Table III (Warriors)' }, 'Crit Table III')).toBe(false)
+    })
+
+    it('matches by prefix when requested', () => {
+      expect(docNameMatches({ name: 'Crit Table III (Warriors)' }, 'Crit Table III', { prefix: true })).toBe(true)
+      expect(docNameMatches({ name: 'Crit Table II' }, 'Crit Table III', { prefix: true })).toBe(false)
+    })
+
+    it('matches prefixes against the Babele original name', () => {
+      const doc = { name: 'T. dei Critici III (Guerrieri)', originalName: 'Crit Table III (Warriors)' }
+      expect(docNameMatches(doc, 'Crit Table III', { prefix: true })).toBe(true)
+    })
+
+    it('tolerates missing docs and names', () => {
+      expect(docNameMatches(null, 'X')).toBe(false)
+      expect(docNameMatches({}, 'X', { prefix: true })).toBe(false)
     })
   })
 

--- a/module/__tests__/utilities.test.js
+++ b/module/__tests__/utilities.test.js
@@ -4,8 +4,10 @@ import { expect, vi, describe, it, beforeEach } from 'vitest'
 import '../__mocks__/foundry.js'
 import {
   ensurePlus,
+  findPackEntryByName,
   formatMercurialDescriptionHTML,
   getMercurialSpecial,
+  getNameCandidates,
   removeActiveEffectOverrides,
   getFirstDie,
   getFirstMod,
@@ -887,6 +889,62 @@ describe('Utilities', () => {
 
       const result = await getNPCFumbleTableResult(mockRoll, 'Fumble Table M')
       expect(result).toEqual({ text: 'World NPC fumble result' })
+    })
+  })
+
+  // Issue #799 — Babele-aware name resolution helpers
+  describe('getNameCandidates', () => {
+    it('returns just the display name for an untranslated document', () => {
+      expect(getNameCandidates({ name: 'Sleep' })).toEqual(['Sleep'])
+    })
+
+    it('adds the Babele original name for a translated document', () => {
+      const doc = { name: 'Schlaf', flags: { babele: { originalName: 'Sleep', translated: true } } }
+      expect(getNameCandidates(doc)).toEqual(['Schlaf', 'Sleep'])
+    })
+
+    it('deduplicates when the original name equals the display name', () => {
+      const doc = { name: 'Sleep', flags: { babele: { originalName: 'Sleep' } } }
+      expect(getNameCandidates(doc)).toEqual(['Sleep'])
+    })
+
+    it('tolerates null/undefined documents and missing names', () => {
+      expect(getNameCandidates(null)).toEqual([])
+      expect(getNameCandidates(undefined)).toEqual([])
+      expect(getNameCandidates({})).toEqual([])
+    })
+  })
+
+  describe('findPackEntryByName', () => {
+    const pack = (entries) => ({ index: entries })
+
+    it('matches an entry by its display name', () => {
+      const entry = { _id: 'a', name: 'Sleep Manifestation' }
+      expect(findPackEntryByName(pack([entry]), 'Sleep Manifestation')).toBe(entry)
+    })
+
+    it('matches a translated entry by its top-level originalName', () => {
+      const entry = { _id: 'a', name: 'Schlaf-Manifestation', originalName: 'Sleep Manifestation' }
+      expect(findPackEntryByName(pack([entry]), ['Sleep Manifestation'])).toBe(entry)
+    })
+
+    it('matches a translated entry by flags.babele.originalName', () => {
+      const entry = { _id: 'a', name: 'Schlaf-Manifestation', flags: { babele: { originalName: 'Sleep Manifestation' } } }
+      expect(findPackEntryByName(pack([entry]), ['Sleep Manifestation'])).toBe(entry)
+    })
+
+    it('accepts multiple candidate names and returns the first matching entry', () => {
+      const entries = [
+        { _id: 'a', name: 'Other Table' },
+        { _id: 'b', name: 'Schlaf Manifestation' }
+      ]
+      expect(findPackEntryByName(pack(entries), ['Sleep Manifestation', 'Schlaf Manifestation'])).toBe(entries[1])
+    })
+
+    it('returns null when nothing matches or the pack is missing', () => {
+      expect(findPackEntryByName(pack([{ _id: 'a', name: 'Other' }]), 'Sleep Manifestation')).toBeNull()
+      expect(findPackEntryByName(null, 'Sleep Manifestation')).toBeNull()
+      expect(findPackEntryByName({}, 'Sleep Manifestation')).toBeNull()
     })
   })
 })

--- a/module/adapter/spell-input.mjs
+++ b/module/adapter/spell-input.mjs
@@ -50,7 +50,7 @@ import { getCasterProfile } from '../vendor/dcc-core-lib/index.js'
 import { actorToCharacter } from './character-accessors.mjs'
 import { disapprovalTableCache, mercurialMagicTableCache } from './table-cache.mjs'
 import { normalizeLibDie } from './attack-input.mjs'
-import { getMercurialSpecial } from '../utilities.js'
+import { findPackEntryByName, getMercurialSpecial } from '../utilities.js'
 
 /**
  * Caster-type whitelist declared on spell definitions for the
@@ -561,7 +561,8 @@ async function resolveMercurialMagicTable (tableName) {
   if (parts.length === 3) {
     const pack = game.packs?.get?.(`${parts[0]}.${parts[1]}`)
     if (pack) {
-      const entry = pack.index?.find?.((e) => e.name === parts[2])
+      // Tolerate a Babele-translated pack index (issue #799)
+      const entry = findPackEntryByName(pack, parts[2])
       if (entry) {
         let doc
         try {

--- a/module/adapter/spell-input.mjs
+++ b/module/adapter/spell-input.mjs
@@ -50,7 +50,7 @@ import { getCasterProfile } from '../vendor/dcc-core-lib/index.js'
 import { actorToCharacter } from './character-accessors.mjs'
 import { disapprovalTableCache, mercurialMagicTableCache } from './table-cache.mjs'
 import { normalizeLibDie } from './attack-input.mjs'
-import { findPackEntryByName, getMercurialSpecial } from '../utilities.js'
+import { docNameMatches, findPackEntryByName, getMercurialSpecial } from '../utilities.js'
 
 /**
  * Caster-type whitelist declared on spell definitions for the
@@ -471,7 +471,10 @@ async function resolveDisapprovalTable (tableName) {
     if (!packName) continue
     const pack = game.packs?.get?.(packName)
     if (!pack) continue
-    const entry = pack.index?.find?.((e) => `${packName}.${e.name}` === tableName)
+    // Only this pack's tables can match the `packName.tableName` path; match
+    // the tail Babele-aware so a translated index still resolves (issue #799).
+    if (!tableName.startsWith(`${packName}.`)) continue
+    const entry = findPackEntryByName(pack, tableName.slice(packName.length + 1))
     if (!entry) continue
     let doc
     try {
@@ -494,7 +497,7 @@ async function resolveDisapprovalTable (tableName) {
   const worldTableName = tableName.includes('.')
     ? tableName.split('.').pop()
     : tableName
-  const worldTable = game.tables?.find?.((t) => t.name === worldTableName)
+  const worldTable = game.tables?.find?.((t) => docNameMatches(t, worldTableName))
   if (worldTable) {
     const libTable = toLibSimpleTable(worldTable)
     if (libTable) return libTable

--- a/module/adapter/spell-input.mjs
+++ b/module/adapter/spell-input.mjs
@@ -627,6 +627,14 @@ export async function loadPatronTaintTable (actor) {
   const expectedName = `Patron Taint: ${patron.trim()}`
   const expectedLower = expectedName.toLowerCase()
 
+  // Names a table can be matched under — the display name plus the
+  // untranslated original a Babele-translated pack index carries, so the
+  // reconstructed English `Patron Taint: <patron>` still resolves in a
+  // translated world (issue #799).
+  const namesOf = (doc) =>
+    [doc?.name, doc?.originalName, doc?.flags?.babele?.originalName]
+      .filter((name) => typeof name === 'string')
+
   const packManager = (typeof CONFIG !== 'undefined' && CONFIG?.DCC?.patronTaintPacks) || null
   const packs = packManager?.packs || []
 
@@ -635,8 +643,8 @@ export async function loadPatronTaintTable (actor) {
     const pack = game.packs?.get?.(packName)
     if (!pack) continue
     const entry =
-      pack.index?.find?.((e) => e.name === expectedName) ||
-      pack.index?.find?.((e) => typeof e.name === 'string' && e.name.toLowerCase() === expectedLower)
+      pack.index?.find?.((e) => namesOf(e).includes(expectedName)) ||
+      pack.index?.find?.((e) => namesOf(e).some((name) => name.toLowerCase() === expectedLower))
     if (!entry) continue
     let doc
     try {
@@ -656,8 +664,8 @@ export async function loadPatronTaintTable (actor) {
   // World-table fallback — match the full `Patron Taint: <patron>`
   // name, with case-insensitive fallback as above.
   const worldTable =
-    game.tables?.find?.((t) => t.name === expectedName) ||
-    game.tables?.find?.((t) => typeof t.name === 'string' && t.name.toLowerCase() === expectedLower)
+    game.tables?.find?.((t) => namesOf(t).includes(expectedName)) ||
+    game.tables?.find?.((t) => namesOf(t).some((name) => name.toLowerCase() === expectedLower))
   if (worldTable) {
     const libTable = toLibSimpleTable(worldTable)
     if (libTable) return libTable

--- a/module/data/item/spell-data.mjs
+++ b/module/data/item/spell-data.mjs
@@ -83,6 +83,12 @@ export class SpellData extends BaseItemData {
 
       // Manifestation
       manifestation: new SchemaField({
+        // Optional language-independent table reference (name, id, or
+        // RollTable.<id>) + source pack, mirroring `results.table` /
+        // `results.collection`. When unset, the table is resolved by the
+        // `<spell name> Manifestation` naming convention (issue #799).
+        table: new StringField({ initial: '' }),
+        collection: new StringField({ initial: '' }),
         value: new StringField({ initial: '' }),
         description: new StringField({ initial: '' }),
         displayInChat: new BooleanField({ initial: true })

--- a/module/data/item/spell-data.mjs
+++ b/module/data/item/spell-data.mjs
@@ -84,9 +84,11 @@ export class SpellData extends BaseItemData {
       // Manifestation
       manifestation: new SchemaField({
         // Optional language-independent table reference (name, id, or
-        // RollTable.<id>) + source pack, mirroring `results.table` /
-        // `results.collection`. When unset, the table is resolved by the
-        // `<spell name> Manifestation` naming convention (issue #799).
+        // RollTable.<id>) + source pack, in the style of `results.table` /
+        // `results.collection` (unlike results, a ref with no collection is
+        // searched in the configured side-effects pack before world tables).
+        // When unset, the table is resolved by the `<spell name> Manifestation`
+        // naming convention (issue #799).
         table: new StringField({ initial: '' }),
         collection: new StringField({ initial: '' }),
         value: new StringField({ initial: '' }),

--- a/module/item/spell-mixin.mjs
+++ b/module/item/spell-mixin.mjs
@@ -59,8 +59,10 @@ const MAX_MERCURIAL_SPECIAL_DEPTH = 5
  * `logDispatch` of their own — the dispatch-logged spell-check *routing* lives
  * on the actor side (`DCCActor._rollSpellCheckViaAdapter`); this item-level path
  * is the spell-sheet / macro entry point that builds terms and hands off to
- * `processSpellCheck`. The one module dependency is `ensurePlus`
- * (`../utilities.js`), used by `rollMercurialMagic`'s luck-modifier term.
+ * `processSpellCheck`. The module dependencies are the `../utilities.js`
+ * helpers: `ensurePlus` (luck-modifier term), `getMercurialSpecial`
+ * (roll-again expansion, #339), and `getNameCandidates` /
+ * `findPackEntryByName` (Babele-aware table resolution, #799).
  *
  * @param {typeof Item} Base - the document class to extend (production: a
  *   `CurrencyItemMixin(ContainerItemMixin(Item))`; unit tests: a stub).
@@ -262,6 +264,12 @@ export const SpellItemMixin = (Base) => class extends Base {
       }
       if (!table) {
         table = game.tables.contents.find(predicate)
+      }
+      if (!table) {
+        // A configured reference that resolves nowhere (renamed/deleted table)
+        // should not masquerade as "this spell has no manifestation" — leave a
+        // trace before falling back to the naming convention.
+        console.warn(`DCC | Spell "${this.name}": manifestation table reference "${manifestationRef.table}" did not resolve; falling back to name lookup`)
       }
     }
 

--- a/module/item/spell-mixin.mjs
+++ b/module/item/spell-mixin.mjs
@@ -1,7 +1,7 @@
 /* global game, ui, Roll, ChatMessage, CONFIG, console */
 
 import { logSpellburn } from '../ability-score-log.js'
-import { ensurePlus, getMercurialSpecial } from '../utilities.js'
+import { ensurePlus, findPackEntryByName, getMercurialSpecial, getNameCandidates } from '../utilities.js'
 
 /**
  * Determine the die formula to roll for a manifestation table.
@@ -246,20 +246,44 @@ export const SpellItemMixin = (Base) => class extends Base {
     // never 1d100 — rolling a hardcoded 1d100 lands outside the table's range and
     // never matches a result. See issue #773.
     const manifestationPackName = game.settings.get('dcc', 'spellSideEffectsCompendium') || 'dcc-core-book.dcc-core-spell-side-effect-tables'
-    const manifestationTableName = `${this.name} Manifestation`
     let table = null
-    const pack = game.packs.get(manifestationPackName)
-    if (pack) {
-      const entry = pack.index.find((entity) => entity.name === manifestationTableName)
-      if (entry) {
-        table = await pack.getDocument(entry._id)
+
+    // An explicit reference on the spell wins: language-independent, so it
+    // survives Babele translation the same way `system.results.table` does.
+    const manifestationRef = this.system.manifestation ?? {}
+    if (manifestationRef.table) {
+      const predicate = t => t.name === manifestationRef.table || t._id === manifestationRef.table.replace('RollTable.', '')
+      const refPack = game.packs.get(manifestationRef.collection || manifestationPackName)
+      if (refPack) {
+        const entry = refPack.index.find(predicate)
+        if (entry) {
+          table = await refPack.getDocument(entry._id)
+        }
       }
-    } else {
-      // The compendium itself is missing — tell the user to install/activate it.
-      console.warn(game.i18n.localize('DCC.SpellSideEffectsCompendiumNotFoundWarning'))
+      if (!table) {
+        table = game.tables.contents.find(predicate)
+      }
+    }
+
+    // Fall back to the `<spell name> Manifestation` naming convention. Both
+    // sides of that comparison are language-sensitive in a Babele world (the
+    // spell's name translates while the table pack may not, or vice versa), so
+    // try the untranslated original names on both sides too (issue #799).
+    const manifestationTableNames = getNameCandidates(this).map((name) => `${name} Manifestation`)
+    if (!table) {
+      const pack = game.packs.get(manifestationPackName)
+      if (pack) {
+        const entry = findPackEntryByName(pack, manifestationTableNames)
+        if (entry) {
+          table = await pack.getDocument(entry._id)
+        }
+      } else {
+        // The compendium itself is missing — tell the user to install/activate it.
+        console.warn(game.i18n.localize('DCC.SpellSideEffectsCompendiumNotFoundWarning'))
+      }
     }
     if (!table) {
-      table = game.tables.getName(manifestationTableName)
+      table = manifestationTableNames.map((name) => game.tables.getName(name)).find(Boolean) ?? null
     }
 
     // Many DCC spells (e.g. Invisibility) have no manifestation at all, so no
@@ -389,7 +413,8 @@ export const SpellItemMixin = (Base) => class extends Base {
         pack = game.packs.get(mercurialMagicTablePath[0] + '.' + mercurialMagicTablePath[1])
       }
       if (pack) {
-        const entry = pack.index.find((entity) => entity.name === mercurialMagicTablePath[2])
+        // Tolerate a Babele-translated pack index (issue #799)
+        const entry = findPackEntryByName(pack, mercurialMagicTablePath[2])
         if (entry) {
           table = await pack.getDocument(entry._id)
         }

--- a/module/table-loading.mjs
+++ b/module/table-loading.mjs
@@ -18,6 +18,7 @@
 
 import TablePackManager from './table-pack-manager.js'
 import { clearCritTableCaches } from './adapter/table-cache.mjs'
+import { findPackEntryByName } from './utilities.js'
 
 /**
  * Module-private predicate. Reads `game.i18n` per call so the localized
@@ -242,7 +243,8 @@ export async function getSkillTable (skillName) {
       pack = game.packs.get(tablePath[0] + '.' + tablePath[1])
     }
     if (pack) {
-      const entry = pack.index.find((entity) => entity.name === tablePath[2])
+      // Babele-aware: translated indexes match on originalName (#799)
+      const entry = findPackEntryByName(pack, tablePath[2])
       if (entry) {
         return pack.getDocument(entry._id)
       }

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -90,20 +90,38 @@ export function getNameCandidates (doc) {
 }
 
 /**
+ * Test whether a document (or index entry) is known under any of the given
+ * names, tolerating Babele translation: the display name is checked alongside
+ * the untranslated original Babele records (`originalName` on translated
+ * index entries, `flags.babele.originalName` on documents).
+ *
+ * @param {Object} doc - a Document or index entry (or plain object in tests)
+ * @param {String|Array<String>} names - candidate name(s) to match
+ * @param {Object} [options]
+ * @param {Boolean} [options.prefix] - match on startsWith instead of equality
+ *   (for the `Crit Table III …` style lookups that tolerate name suffixes)
+ * @returns {Boolean}
+ */
+export function docNameMatches (doc, names, { prefix = false } = {}) {
+  const candidates = Array.isArray(names) ? names : [names]
+  return [doc?.name, doc?.originalName, doc?.flags?.babele?.originalName]
+    .some((name) => name && (prefix
+      ? candidates.some((candidate) => name.startsWith(candidate))
+      : candidates.includes(name)))
+}
+
+/**
  * Find a compendium index entry by name, tolerating Babele translation on
- * the entry side. Babele's translated indexes carry the untranslated name
- * (`originalName` on the entry, or under `flags.babele`), so a translated
- * table still matches its English name and vice versa.
+ * the entry side (see {@link docNameMatches}) so a translated table still
+ * matches its English name and vice versa. Matches in pack index order.
  *
  * @param {Object} pack - a CompendiumCollection (or stub in tests)
  * @param {String|Array<String>} names - candidate name(s) to match
+ * @param {Object} [options] - passed through to {@link docNameMatches}
  * @returns {Object|null} the matching index entry, or null
  */
-export function findPackEntryByName (pack, names) {
-  const candidates = Array.isArray(names) ? names : [names]
-  return pack?.index?.find?.((entry) =>
-    [entry?.name, entry?.originalName, entry?.flags?.babele?.originalName]
-      .some((name) => name && candidates.includes(name))) ?? null
+export function findPackEntryByName (pack, names, options = {}) {
+  return pack?.index?.find?.((entry) => docNameMatches(entry, names, options)) ?? null
 }
 
 /**
@@ -271,12 +289,13 @@ async function resolveCritTable (critTableCanonical) {
     if (!criticalHitPackName) continue
     const pack = game.packs.get(criticalHitPackName)
     if (!pack) continue
-    const entry = pack.index.find((entity) => entity.name.startsWith(critTableCanonical))
+    // Prefix + Babele-aware: translated indexes match on originalName (#799)
+    const entry = findPackEntryByName(pack, critTableCanonical, { prefix: true })
     if (!entry) continue
     return await pack.getDocument(entry._id)
   }
 
-  const worldCritTable = game.tables.find((entity) => entity.name.startsWith(critTableCanonical))
+  const worldCritTable = game.tables.find((entity) => docNameMatches(entity, critTableCanonical, { prefix: true }))
   if (worldCritTable) return worldCritTable
 
   return null
@@ -323,14 +342,15 @@ function resolveCritTableLink (critTableSuffix) {
     if (!criticalHitPackName) continue
     const pack = game.packs.get(criticalHitPackName)
     if (!pack) continue
-    const entry = pack.index.find((entity) => entity.name.startsWith(critTableCanonical))
+    // Prefix + Babele-aware: translated indexes match on originalName (#799)
+    const entry = findPackEntryByName(pack, critTableCanonical, { prefix: true })
     if (entry) {
       return `@UUID[Compendium.${criticalHitPackName}.${entry._id}]`
     }
   }
 
   // Try in the local world
-  const worldCritTable = game.tables.find((entity) => entity.name.startsWith(critTableCanonical))
+  const worldCritTable = game.tables.find((entity) => docNameMatches(entity, critTableCanonical, { prefix: true }))
   if (worldCritTable) {
     return `@UUID[RollTable.${worldCritTable.id}]`
   }
@@ -353,15 +373,18 @@ export async function getTableFromPath (tablePath) {
     const tableName = pathComponents.slice(2).join('.')
     const pack = game.packs.get(packName)
     if (pack) {
-      const entry = pack.index.find((entity) => entity.name === tableName)
+      // Babele-aware: translated indexes match on originalName (#799)
+      const entry = findPackEntryByName(pack, tableName)
       if (entry) {
         return pack.getDocument(entry._id)
       }
     }
   }
 
-  // Fall back to a world table by name
-  return game.tables.getName(tablePath) || null
+  // Fall back to a world table by name (or its untranslated original)
+  return game.tables.getName(tablePath) ||
+    game.tables.find?.((entity) => docNameMatches(entity, tablePath)) ||
+    null
 }
 
 /**
@@ -371,7 +394,7 @@ export async function getTableFromPath (tablePath) {
  */
 export async function getFumbleTableResult (roll, localTableName = 'Table 4-2: Fumbles') {
   // First check for a local world table
-  const worldFumbleTable = game.tables.find((entity) => entity.name === localTableName)
+  const worldFumbleTable = game.tables.find((entity) => docNameMatches(entity, localTableName))
   if (worldFumbleTable) {
     const fumbleResult = worldFumbleTable.getResultsForRoll(roll.total)
     return fumbleResult[0] || 'Unable to find fumble result'
@@ -386,7 +409,8 @@ export async function getFumbleTableResult (roll, localTableName = 'Table 4-2: F
       pack = game.packs.get(fumbleTablePath[0] + '.' + fumbleTablePath[1])
     }
     if (pack) {
-      const entry = pack.index.find((entity) => entity.name === fumbleTablePath[2])
+      // Babele-aware: translated indexes match on originalName (#799)
+      const entry = findPackEntryByName(pack, fumbleTablePath[2])
       if (entry) {
         const table = await pack.getDocument(entry._id)
         const fumbleResult = table.getResultsForRoll(roll.total)
@@ -427,16 +451,17 @@ export async function getNPCFumbleTableResult (roll, fumbleTableName) {
     const fumblePackName = 'dcc-core-book.dcc-monster-fumble-tables'
     const pack = game.packs.get(fumblePackName)
     if (pack) {
-      const entry = pack.index.filter((entity) => entity.name.startsWith(fumbleTableName))
-      if (entry.length > 0) {
-        const table = await pack.getDocument(entry[0]._id)
+      // Prefix + Babele-aware: translated indexes match on originalName (#799)
+      const entry = findPackEntryByName(pack, fumbleTableName, { prefix: true })
+      if (entry) {
+        const table = await pack.getDocument(entry._id)
         const fumbleResult = table.getResultsForRoll(roll.total)
         return fumbleResult[0] || 'Unable to find fumble result'
       }
     }
 
     // Fall back to searching world tables by name
-    const worldTable = game.tables.find((entity) => entity.name.startsWith(fumbleTableName))
+    const worldTable = game.tables.find((entity) => docNameMatches(entity, fumbleTableName, { prefix: true }))
     if (worldTable) {
       const fumbleResult = worldTable.getResultsForRoll(roll.total)
       return fumbleResult[0] || 'Unable to find fumble result'

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -74,6 +74,38 @@ export function getMercurialSpecial (tableResult) {
 }
 
 /**
+ * Names a document can be looked up under in a translated (Babele) world:
+ * the display name plus the untranslated original that Babele records in
+ * `flags.babele.originalName`. Compendium content ships named in English,
+ * so any lookup that reconstructs a table name from a document's name must
+ * try the original name too — the display name alone never matches once
+ * Babele has translated either side of the comparison (issue #799).
+ *
+ * @param {Object} doc - a Document (or plain object in tests)
+ * @returns {Array<String>} unique candidate names, display name first
+ */
+export function getNameCandidates (doc) {
+  return [...new Set([doc?.name, doc?.flags?.babele?.originalName].filter(Boolean))]
+}
+
+/**
+ * Find a compendium index entry by name, tolerating Babele translation on
+ * the entry side. Babele's translated indexes carry the untranslated name
+ * (`originalName` on the entry, or under `flags.babele`), so a translated
+ * table still matches its English name and vice versa.
+ *
+ * @param {Object} pack - a CompendiumCollection (or stub in tests)
+ * @param {String|Array<String>} names - candidate name(s) to match
+ * @returns {Object|null} the matching index entry, or null
+ */
+export function findPackEntryByName (pack, names) {
+  const candidates = Array.isArray(names) ? names : [names]
+  return pack?.index?.find?.((entry) =>
+    [entry?.name, entry?.originalName, entry?.flags?.babele?.originalName]
+      .some((name) => name && candidates.includes(name))) ?? null
+}
+
+/**
  * Wrap a dcc-core-lib mercurial-effect description in HTML paragraphs.
  * The lib joins expanded (roll-again) sub-effect descriptions with a
  * plain `\n\n` (it is renderer-agnostic); browsers collapse that to a

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -82,7 +82,8 @@ export function getMercurialSpecial (tableResult) {
  * Babele has translated either side of the comparison (issue #799).
  *
  * @param {Object} doc - a Document (or plain object in tests)
- * @returns {Array<String>} unique candidate names, display name first
+ * @returns {Array<String>} unique candidate names (no priority implied —
+ *   {@link findPackEntryByName} matches in pack index order)
  */
 export function getNameCandidates (doc) {
   return [...new Set([doc?.name, doc?.flags?.babele?.originalName].filter(Boolean))]


### PR DESCRIPTION
## Summary

- Fixes the manifestation lookup failing for every Babele-translated spell: `rollManifestation` reconstructed `` `${this.name} Manifestation` `` from the translated item name plus a hardcoded English word and exact-matched it against the (untranslated) pack index, so `"Schlaf Manifestation"` never matched `"Sleep Manifestation"`.
- The name-based fallback is now translation-tolerant on **both** sides: candidates are built from the display name *and* the untranslated original Babele records in `flags.babele.originalName`, and pack index entries match on their original names too (new shared helpers `docNameMatches` / `getNameCandidates` / `findPackEntryByName` in `module/utilities.js`, with a `prefix` mode for `startsWith`-style lookups).
- Adds the issue's preferred durable mechanism: an explicit `system.manifestation.table` (name, id, or `RollTable.<id>`) + `system.manifestation.collection` reference on the spell's data model, resolved exactly like `system.results.table` — language-independent, wins over name reconstruction when set. A configured reference that resolves nowhere logs a console warning before falling back to the naming convention.
- **Sweeps every analogous reconstructed/exact-name table lookup in the system onto the same helpers**: patron-taint loader, both mercurial-magic paths (item-sheet + adapter cast path), the crit-table walkers (result lookup and chat-card `@UUID` link), PC and NPC fumble lookups, `getTableFromPath` (deed tables), `getSkillTable`, and the adapter disapproval loader. English-world behavior is unchanged everywhere — original names simply match in addition to display names.
- Documents the resolution order (and the advanced explicit reference) in `docs/user-guide/Creating-a-Spell.md`.
- Incidental test fix: `friendly-fire.spec.js` searched the entire world chat log for a friendly-fire card, so stale cards from earlier runs permanently broke the crit branch's "no stray shot" assertion; the search is now scoped to messages created by the attack under test.
- No version bump by request — the next release will batch this with other fixes.

Fixes #799

## Test plan

- [x] `npm run check` passes — 2299 unit tests green (27 new: both Babele asymmetries, explicit reference by collection / by `RollTable.<id>` / dangling-ref fallback, and a translated-entry regression test for every swapped lookup site plus helper edge cases)
- [x] New E2E spec (`spell-manifestation.spec.js`) passes against live Foundry v14: a spell with a translated name + `flags.babele.originalName` resolves and rolls its English-named table; an explicit `system.manifestation.table` reference resolves a table sharing no name with the spell
- [x] Full `browser-tests/e2e` Playwright suite green — 273 passed (includes the crit/fumble/deed chat-card paths the lookup sweep touches)
- [x] Sibling modules checked: xcc/mcc-classes only read `system.manifestation` for chat display — additive fields are harmless

## Follow-up (out of scope here)

- `dcc-core-book` could stamp `system.manifestation.table`/`.collection` on its spells (and ship Babele mappings for the side-effect packs) to use the explicit path; the name fallback already fixes the reported bug without data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)