### PR TITLE
docs: version.txt bump must always be its own commit on main

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,5 +1,5 @@
 ---
-description: "Create a pull request for the DCC system. Handles branch verify, i18n translation, version bump, checks, simplify, commit, push, create/update PR, review, auto-fix."
+description: "Create a pull request for the DCC system. Handles branch verify, i18n translation, checks, simplify, commit, push, create/update PR, review, auto-fix. No version bump — that happens on main at release time."
 argument-hint: "optional: base branch (default: main)"
 ---
 
@@ -25,13 +25,22 @@ If any `lang/*.json` files have been modified (check `git diff --name-only main.
 
 If NO lang files were modified in the diff, check whether any new `game.i18n.localize()` or `game.i18n.format()` calls were added in changed JS/HBS files that reference keys not present in `lang/en.json`. If so, add the missing keys to `en.json` and translate to all other languages.
 
-## Step 3: Version Bump
+## Step 3: Version Bump — NOT in the PR
 
-Read `version.txt` to get the current version (format: `MAJOR.MINOR.PATCH`).
+Do **NOT** change `version.txt` in the PR. The bump always lands on `main` as
+its **own commit**, after the PR merges (that's the `/release` skill's job).
 
-- Increment the **patch** version (e.g., `0.66.39` → `0.66.40`).
-- Write the new version to `version.txt` (just the version number, no `v` prefix, with a trailing newline).
-- Do NOT update `system.json` or `package.json` — the GitHub Action handles that from `version.txt`.
+Why: PRs are squash-merged, so a bump inside the PR gets folded into the
+feature commit. The `foundry-release-action` builds release notes from commits
+since the last release but **excludes the commit that carries the
+`version.txt` change** — so the PR vanishes from its own release notes (this
+bit #849 in v0.70.35 and #852 in v0.70.37).
+
+If the diff already touches `version.txt`, revert that change before
+committing and mention it in the final summary.
+
+- Never update `system.json` or `package.json` versions either — the GitHub
+  Action derives them from `version.txt`.
 
 ## Step 4: Pre-Flight Checks
 
@@ -76,7 +85,7 @@ If a dependent module references something that was changed, **STOP** and report
 3. Recommended commit ordering:
   - Feature/fix commits first
   - i18n translation commits (e.g., `chore: translate new i18n keys to all languages`)
-  - Version bump commit last (e.g., `chore: bump version to X.Y.Z`)
+  - No version bump commit — `version.txt` is bumped on `main` after the merge (Step 3)
 4. Stage and commit each group separately. Use `git add <specific files>` — avoid `git add -A`.
 5. End each commit message with: `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
 
@@ -131,7 +140,7 @@ Output a structured summary:
 ```
 [PR SUMMARY]
 PR URL: <url>
-Version: <old> → <new>
+Version: unchanged (bump happens on main at release time)
 i18n: <count> keys added/removed across <count> language files
 Commits: <count> (<original> original + <fix> fixes)
 Issues fixed: <count>

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -18,12 +18,17 @@ Execute these steps in order:
   ```
 - If already on main, confirm with user before proceeding
 
-## 2. Update version.txt
+## 2. Update version.txt — always its own commit on main
 
 - Read current version from `version.txt`
 - Increment the final number (e.g., 0.66.27 → 0.66.28)
 - Write new version to `version.txt`
-- Commit: `Update version.txt`
+- Commit: `Update version.txt` — the commit must contain **only** the
+  `version.txt` change, and it happens **on `main` after the PR merges**,
+  never inside a feature PR. Squash-merge folds an in-PR bump into the
+  feature commit, and `foundry-release-action` excludes the bump-carrying
+  commit when generating release notes — the feature then vanishes from its
+  own release notes (this bit #849 in v0.70.35 and #852 in v0.70.37).
 - Push to main
 
 ## 3. Wait for GitHub Actions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,15 @@ rule. They apply only to the scoped context described.
   to in that session. Default: stop at the draft and hand off. See
   `docs/dev/RELEASE_PROCESS.md` and the `/release` skill.
 
+- **The `version.txt` bump is always its own commit on `main`, never part
+  of a feature PR.** PRs are squash-merged, so an in-PR bump gets folded
+  into the feature commit — and `foundry-release-action` excludes the
+  bump-carrying commit when generating release notes, so the feature
+  vanishes from its own release notes (bit #849 in v0.70.35 and #852 in
+  v0.70.37). Do not touch `version.txt` on a feature branch; bump it in a
+  standalone `Update version.txt` commit on `main` at release time (the
+  `/release` flow).
+
 ## Documentation
 
 ### Developer Guides

--- a/docs/dev/RELEASE_PROCESS.md
+++ b/docs/dev/RELEASE_PROCESS.md
@@ -19,7 +19,13 @@ For automated release process:
 1. Ensure you run `npm run tojson' to copy the data out of levelDB files and into JSON, since LevelDB files are not checked in
 1. Merge all changes into main
 1. Commit `version.txt` File with new release version number in it (no 'v')
-   — this is the **only** file you hand-edit for a release. The
+   — **always as its own commit directly on `main`, containing only the
+   `version.txt` change, after the PRs have merged.** Never bump
+   `version.txt` inside a feature PR: squash-merge folds the bump into the
+   feature commit, and `foundry-release-action` skips the bump-carrying
+   commit when generating release notes, so the feature disappears from its
+   own release notes (this happened to #849 in v0.70.35 and #852 in
+   v0.70.37). This is the **only** file you hand-edit for a release. The
    `Create GitHub Release` workflow syncs `package.json` **and**
    `package-lock.json` to that version (via `npm version --no-git-tag-version`)
    before the release action rewrites `system.json` and commits the lot, so the


### PR DESCRIPTION
## Summary
- The `foundry-release-action` builds release notes from commits since the last release but **excludes the commit that carries the `version.txt` change**. With squash merges, a bump inside a feature PR gets folded into the feature commit — so the feature disappears from its own release notes. This bit #849 (missing from v0.70.35, showed up late in v0.70.36) and #852 (missing from v0.70.37).
- `/pr` skill: Step 3 now says do NOT touch `version.txt` in a PR (and revert it if present); commit-ordering and summary template updated to match.
- `/release` skill: Step 2 now requires the bump as a standalone `Update version.txt` commit on `main` after the PR merges.
- `docs/dev/RELEASE_PROCESS.md` + `CLAUDE.md`: same rule with the why.

## Test plan
- [x] Docs-only change — no code paths affected; `npm test` green via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)