### PR TITLE
fix: spell checks honor the multiple-action-dice budget (#857)

### DIFF
--- a/browser-tests/e2e/action-dice-tracker.spec.js
+++ b/browser-tests/e2e/action-dice-tracker.spec.js
@@ -739,6 +739,111 @@ test.describe('Action-dice combat tracker pips', () => {
     expect(result.lastMentionsD16).toBe(true)
   })
 
+  // The test above drives `actor.rollSpellCheck` — the raw/class-level entry
+  // point. Casting an owned spell from the character sheet instead goes through
+  // `DCCItem.rollSpellCheck`, which had no action-die integration at all: every
+  // cast rolled `spellCheck.die` (always the FIRST action die, derived via
+  // getSingleActionDie) and spent nothing, so a wizard's second spell in a round
+  // never dropped to its second action die and the pips never advanced (#857).
+  //
+  // Uses a real wizard (`details.sheetClass: 'Wizard'`) so slot 1 is inferred
+  // spells-only — the canonical "his second action die can only be used for
+  // spell checks" case, which must still be eligible for a spell.
+  test('casting an owned spell spends the budget and drops to the wizard second die', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const prevMaster = game.settings.get('dcc', 'multipleActionDice')
+      await game.settings.set('dcc', 'multipleActionDice', true)
+
+      let actor, combat
+      const createdMessageIds = []
+      try {
+        actor = await Actor.create({
+          name: 'P3 Item SpellCheck Probe',
+          type: 'Player',
+          system: {
+            config: { actionDice: '1d20,1d14' },
+            details: { sheetClass: 'Wizard' }
+          }
+        })
+        // `results.table` is set but names no real table, so the cast reaches
+        // `processSpellCheck`'s no-table branch and still posts a card (an empty
+        // `results.table` would bail out before the card).
+        const [spell] = await actor.createEmbeddedDocuments('Item', [{
+          name: 'Item Path Probe Spell',
+          type: 'spell',
+          system: {
+            config: { castingMode: 'generic', inheritActionDie: true },
+            spellCheck: { die: '1d20', value: '+0' },
+            results: { table: 'No Such Spell Table', collection: '' }
+          }
+        }])
+
+        combat = await Combat.create({})
+        await combat.createEmbeddedDocuments('Combatant', [{ actorId: actor.id }])
+        await combat.startCombat()
+        await combat.activate()
+        const combatant = combat.combatants.contents[0]
+
+        const msgIdsBefore = new Set(game.messages.contents.map(m => m.id))
+
+        // The derived budget: slot 0 unrestricted, slot 1 spells-only.
+        const slotUses = actor.system.attributes.actionDice.list.map(s => s.use)
+
+        // Cast 1 → slot 0 (d20).
+        await spell.rollSpellCheck('int')
+        const flag1 = combatant.getFlag('dcc', 'actionDice')
+
+        // Cast 2 → slot 1 (the spells-only d14).
+        await spell.rollSpellCheck('int')
+        const flag2 = combatant.getFlag('dcc', 'actionDice')
+
+        const actorMsgs = game.messages.contents.filter(m => m.speaker?.actor === actor.id)
+        for (const m of game.messages.contents) {
+          if (!msgIdsBefore.has(m.id)) createdMessageIds.push(m.id)
+        }
+        const firstMsg = actorMsgs[0]
+        const lastMsg = actorMsgs[actorMsgs.length - 1]
+
+        return {
+          slotUses,
+          flag1Spent: flag1?.spent,
+          flag2Spent: flag2?.spent,
+          firstDieFaces: firstMsg?.rolls?.[0]?.dice?.[0]?.faces,
+          lastDieFaces: lastMsg?.rolls?.[0]?.dice?.[0]?.faces,
+          firstHasLine: (firstMsg?.content || '').includes('dcc-action-dice-line'),
+          lastHasLine: (lastMsg?.content || '').includes('dcc-action-dice-line'),
+          lastMentionsAction2: (lastMsg?.content || '').includes('2 of 2'),
+          lastMentionsD14: (lastMsg?.content || '').includes('1d14')
+        }
+      } finally {
+        for (const id of createdMessageIds) {
+          const m = game.messages.get(id)
+          if (m) await m.delete()
+        }
+        if (combat) await combat.delete()
+        if (actor) await actor.delete()
+        await game.settings.set('dcc', 'multipleActionDice', prevMaster)
+      }
+    })
+
+    // A wizard's extra die is spells-only; a spell check may still use it.
+    expect(result.slotUses).toEqual(['any', 'spell'])
+
+    // The budget advances one slot per cast — this never happened before.
+    expect(result.flag1Spent).toEqual([true, false])
+    expect(result.flag2Spent).toEqual([true, true])
+
+    // The dice actually rolled: primary die first, second action die next.
+    expect(result.firstDieFaces).toBe(20)
+    expect(result.lastDieFaces).toBe(14)
+
+    // Both cards carry the action-dice line; the second names the smaller die.
+    expect(result.firstHasLine).toBe(true)
+    expect(result.lastHasLine).toBe(true)
+    expect(result.lastMentionsAction2).toBe(true)
+    expect(result.lastMentionsD14).toBe(true)
+  })
+
   // Two-weapon fighting (#834): a primary + off-hand pair is ONE action, so
   // the pair consumes one action die. Drives the real `rollWeaponAttack`
   // dispatcher end-to-end with two flagged weapons on a 2-die actor:

--- a/docs/dev/MULTIPLE_ACTION_DICE_DESIGN.md
+++ b/docs/dev/MULTIPLE_ACTION_DICE_DESIGN.md
@@ -219,6 +219,33 @@ actor has multiple dice.
   `rollSpellCheck({ spell })` twice on a generic spell (slot 0 d20 → slot 1 d16)
   asserting the per-round flag advance + the emitted action-dice line.
 
+**What was MISSING until #857 (spell-check path, item entry point):**
+
+The section above covers `DCCActor.rollSpellCheck` — the *raw / class-level*
+entry point. Casting an **owned spell from the character sheet** goes through
+`DCCItem.rollSpellCheck` (`module/item/spell-mixin.mjs`) instead, and that path
+had no action-dice integration at all: it rolled `system.spellCheck.die` (which
+`prepareBaseData` derives with `getSingleActionDie`, i.e. always the FIRST action
+die) and spent no slot, so a caster's second spell in a round never stepped down
+and the pips never advanced. #857 gives it the same plan → override → presets →
+reconcile → spend cycle, and adds a probe driving two real casts by a wizard
+(rolled faces 20 → 14, pips `[true,false]` → `[true,true]`).
+
+Two related corrections in #857:
+
+- **The slot only replaces an action-die-derived die.** `spellCheck.die` is only
+  action-die-derived when `config.inheritActionDie` is set, and a class's
+  `spellCheckOverrideDie` wins over it. Both are deliberate authoring choices, so
+  the step-down leaves them alone — the same "re-apply relative to the chosen
+  base die, don't discard it" rule as the two-weapon penalty.
+- **Crit/fumble realignment on the legacy path.** `processSpellCheck` classified
+  a crit as a hardcoded natural 20, so an override die (or any custom action die)
+  made a crit unrollable while the natural-1 fumble grew *more* likely. It now
+  reads the rolled die's faces, matching the lib's own
+  `natural === getDieFaces(die)` rule that the adapter-routed actor path already
+  used, and `forceCrit` lands on the die max rather than a literal 20.
+  Unchanged for every d20 caller.
+
 **What is DONE (system layer — Phase 4, soft spells-only filtering, D1a):**
 
 - **No-eligible-die is distinguished from over-budget.** `planActionDie` now also
@@ -250,8 +277,10 @@ actor has multiple dice.
   take the action — so the roll-modifier dialog never offers a wizard's
   spells-only die for a weapon attack. Wired at the preset call sites:
   `rolls-weapon-mixin.rollToHit` (`'attack'`), the ability-check dialog and the
-  skill term-builder (`'check'`); the spell dialog builds no preset list, and a
-  spell check would keep the die anyway. The correlation is best-effort by index
+  skill term-builder (`'check'`); both spell dialogs build their preset list from
+  the live plan via `actionDicePresetsFromPlan(plan, { action: 'spell' })` as of
+  #857, which keeps the spells-only die (a spell check is eligible for it). The
+  correlation is best-effort by index
   and gated on the list's existence (the `getActionDice()[0]` default-die calls
   pass no `forAction`, so they're untouched); slot 0 is always unrestricted, so
   the default die is never filtered. Off-path (master off / no list) the preset

--- a/module/__tests__/actor-rolls-spell-mixin.test.js
+++ b/module/__tests__/actor-rolls-spell-mixin.test.js
@@ -1,5 +1,26 @@
-import { describe, test, expect, beforeEach, afterEach } from 'vitest'
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
 import { RollsSpellMixin } from '../actor/rolls-spell-mixin.mjs'
+import { promptRollModifierDialog } from '../adapter/roll-dialog.mjs'
+import {
+  reconcilePlannedActionDie,
+  spendPlannedActionDie,
+  formatActionDiceChatLine
+} from '../action-dice-tracker.mjs'
+
+// The dialog and the action-dice tracker are the two collaborators the
+// action-die tests below assert against; everything else in this file runs on a
+// bare Base and needs no Foundry.
+vi.mock('../adapter/roll-dialog.mjs', () => ({
+  promptRollModifierDialog: vi.fn(async () => ({ actionDie: '', modifierTotal: 0 }))
+}))
+vi.mock('../action-dice-tracker.mjs', () => ({
+  planActionDie: vi.fn(() => null),
+  actionDicePresetsFromPlan: vi.fn(() => null),
+  reconcilePlannedActionDie: vi.fn((plan) => plan),
+  spendPlannedActionDie: vi.fn(async () => null),
+  formatActionDiceChatLine: vi.fn(() => ''),
+  slotRollFormula: vi.fn(() => '')
+}))
 
 // Phase 7 (actor.js shrinkage, continued): the spell-check dispatch layer moved
 // out of actor.js into actor/rolls-spell-mixin.mjs. These guards pin the
@@ -63,6 +84,119 @@ describe('RollsSpellMixin extraction', () => {
       const inst = new Mixed()
       const flavor = inst._buildSpellCheckFlavor(null, {}, null)
       expect(flavor).toBe('L:DCC.SpellCheck')
+    })
+  })
+
+  // Multiple action dice on the actor-side cast path (#857). The dispatcher
+  // plans an extra-die override, but the dialog used to build its Die term from
+  // the spell's own (always-first-slot) `spellCheck.die` and
+  // `_applySpellCheckDialogToOptions` then wrote that straight back over the
+  // override — so with the modifier dialog on, an extra-die cast silently
+  // reverted to the primary die.
+  describe('_promptSpellCheckDialog — action-die override (#857)', () => {
+    const spellItem = {
+      name: 'Magic Missile',
+      system: {
+        spellCheck: { die: '1d20', value: '+4', penalty: '0' },
+        config: { inheritCheckPenalty: false }
+      }
+    }
+
+    let inst
+
+    beforeEach(() => {
+      globalThis.game = {
+        i18n: {
+          localize: (k) => `L:${k}`,
+          format: (k) => `F:${k}`
+        }
+      }
+      promptRollModifierDialog.mockClear()
+      promptRollModifierDialog.mockResolvedValue({ actionDie: '1d14', modifierTotal: 4 })
+      inst = new Mixed()
+      inst.system = {
+        class: {},
+        attributes: { actionDice: { value: '1d20' }, ac: { checkPenalty: '0' } }
+      }
+      inst.getRollData = () => ({})
+    })
+
+    afterEach(() => {
+      delete globalThis.game
+    })
+
+    const dieTerm = () => promptRollModifierDialog.mock.calls[0][0]
+      .find(term => term.type === 'Die')
+
+    test('the planned die wins over the spell\'s first-slot die', async () => {
+      await inst._promptSpellCheckDialog(spellItem, { actionDie: '1d14' })
+
+      expect(dieTerm().formula).toBe('1d14')
+    })
+
+    test('slot presets are passed through so the dialog can pick a slot', async () => {
+      const presets = [
+        { formula: '1d20', label: 'Action die 1' },
+        { formula: '1d14', label: 'Action die 2' }
+      ]
+
+      await inst._promptSpellCheckDialog(spellItem, { actionDie: '1d20', actionDicePresets: presets })
+
+      expect(dieTerm().presets).toEqual(presets)
+    })
+
+    test('off-path it still falls back to the spell\'s own die, with no presets', async () => {
+      await inst._promptSpellCheckDialog(spellItem, {})
+
+      expect(dieTerm().formula).toBe('1d20')
+      expect(dieTerm().presets).toBeUndefined()
+    })
+
+    test('with no spell item and no plan it falls back to the actor\'s action die', async () => {
+      await inst._promptSpellCheckDialog(null, {})
+
+      expect(dieTerm().formula).toBe('1d20')
+    })
+  })
+
+  // The spend has to follow the die actually rolled, not the auto-picked slot,
+  // so a player choosing another slot in the dialog burns the right one.
+  describe('_spendActionDiceLine — reconcile before spend (#857)', () => {
+    beforeEach(() => {
+      reconcilePlannedActionDie.mockClear()
+      spendPlannedActionDie.mockClear()
+      formatActionDiceChatLine.mockClear()
+    })
+
+    test('re-points the plan at the rolled die before spending it', async () => {
+      const inst = new Mixed()
+      const plan = { choice: { index: 0 } }
+      const repointed = { choice: { index: 1 } }
+      reconcilePlannedActionDie.mockReturnValue(repointed)
+
+      await inst._spendActionDiceLine(
+        { _actionDicePlan: plan, _actionDiceDefaultFaces: 20 },
+        { dice: [{ faces: 14 }] }
+      )
+
+      expect(reconcilePlannedActionDie).toHaveBeenCalledWith(plan, 14, {
+        action: 'spell',
+        defaultFaces: 20
+      })
+      expect(spendPlannedActionDie).toHaveBeenCalledWith(repointed)
+    })
+
+    test('off-path (no plan, no roll) it still spends nothing and renders no line', async () => {
+      const inst = new Mixed()
+      reconcilePlannedActionDie.mockReturnValue(null)
+
+      await inst._spendActionDiceLine({})
+
+      expect(reconcilePlannedActionDie).toHaveBeenCalledWith(undefined, undefined, {
+        action: 'spell',
+        defaultFaces: null
+      })
+      expect(spendPlannedActionDie).toHaveBeenCalledWith(null)
     })
   })
 })

--- a/module/__tests__/item.test.js
+++ b/module/__tests__/item.test.js
@@ -890,10 +890,18 @@ describe('DCCItem Tests', () => {
         },
         dcc: {
           DCCRoll: {
-            createRoll: vi.fn(() => ({
-              evaluate: vi.fn(),
-              dice: [{ options: {} }]
-            }))
+            // The rolled die reports the faces of the Die term it was built
+            // from, so the multiple-action-dice reconcile actually runs against
+            // a realistic roll instead of short-circuiting on a missing `faces`
+            // (a stub without it would let a wrong `defaultActionDieFaces` pass).
+            createRoll: vi.fn((terms) => {
+              const dieFormula = terms?.find(t => t.type === 'Die')?.formula ?? '1d20'
+              const faces = parseInt(String(dieFormula).match(/d(\d+)/)?.[1] || '20')
+              return {
+                evaluate: vi.fn(),
+                dice: [{ options: {}, faces }]
+              }
+            })
           },
           processSpellCheck: vi.fn()
         },
@@ -1165,6 +1173,31 @@ describe('DCCItem Tests', () => {
         expect(combatant.setFlag).not.toHaveBeenCalled()
         const spellData = global.game.dcc.processSpellCheck.mock.calls[0][1]
         expect(spellData.actionDiceChatLine).toBe('')
+      })
+
+      test('a spell that opts out of inheritActionDie keeps its own die', async () => {
+        enterCombat([true, false])
+        spell.system.config.inheritActionDie = false
+        spell.system.spellCheck.die = '1d24'
+
+        await spell.rollSpellCheck('int')
+
+        // The authored die is a deliberate choice; the slot must not discard it.
+        expect(dieTerm().formula).toBe('1d24')
+        // The action is still taken, so the slot is still spent.
+        expect(combatant.setFlag).toHaveBeenCalledWith('dcc', 'actionDice', expect.objectContaining({
+          spent: [true, true]
+        }))
+      })
+
+      test('a class spellCheckOverrideDie survives the slot step-down', async () => {
+        enterCombat([true, false])
+        actor.system.class.spellCheckOverrideDie = '1d30'
+        spell.system.spellCheck.die = '1d30'
+
+        await spell.rollSpellCheck('int')
+
+        expect(dieTerm().formula).toBe('1d30')
       })
 
       test('a spell with no results table posts nothing, so it costs nothing', async () => {

--- a/module/__tests__/item.test.js
+++ b/module/__tests__/item.test.js
@@ -1,4 +1,4 @@
-import { describe, beforeEach, test, expect, vi } from 'vitest'
+import { describe, beforeEach, afterEach, test, expect, vi } from 'vitest'
 import '../__mocks__/foundry.js'
 import DCCItem from '../item.js'
 
@@ -1031,6 +1031,160 @@ describe('DCCItem Tests', () => {
       expect(spellburnTerm.str).toBe(14)
       expect(spellburnTerm.agl).toBe(12)
       expect(spellburnTerm.sta).toBe(13)
+    })
+
+    // Multiple action dice on the item-level cast path (#857). This is the
+    // entry point the character sheet uses for an owned spell, and it had no
+    // action-die integration at all: every cast rolled `spellCheck.die` (always
+    // the FIRST action die, via getSingleActionDie) and spent no slot, so a
+    // wizard's second spell in a round never dropped to its second action die.
+    describe('multiple action dice (#857)', () => {
+      let combatant
+
+      // A level-5 wizard: 1d20 (any) + a spells-only 1d14.
+      const wizardSlots = () => [
+        { slot: 0, die: 'd20', modifier: 0, use: 'any' },
+        { slot: 1, die: 'd14', modifier: 0, use: 'spell' }
+      ]
+
+      // `spent` is the stored per-round state; null ⇒ fresh round.
+      const enterCombat = (spent = null, { round = 3, list = wizardSlots() } = {}) => {
+        actor.id = 'wiz1'
+        combatant = {
+          actor: { id: 'wiz1', system: { attributes: { actionDice: { list } } }, isOwner: true },
+          isOwner: true,
+          getFlag: (scope, key) => (scope === 'dcc' && key === 'actionDice'
+            ? (spent ? { round, spent } : undefined)
+            : undefined),
+          setFlag: vi.fn(async () => {})
+        }
+        global.game.combat = { round, combatants: [combatant] }
+      }
+
+      const dieTerm = () => global.game.dcc.DCCRoll.createRoll.mock.calls[0][0]
+        .find(term => term.type === 'Die')
+
+      beforeEach(() => {
+        global.game.user = { isGM: true }
+        global.game.settings.get = vi.fn((module, key) => {
+          if (module !== 'dcc') return false
+          if (key === 'automateWizardSpellLoss') return true
+          // The multiple-action-dice master switch plus in-combat tracking.
+          if (key === 'multipleActionDice' || key === 'trackActionDiceInCombat') return true
+          return false
+        })
+      })
+
+      afterEach(() => {
+        delete global.game.combat
+        delete global.game.user
+      })
+
+      test("the round's first cast uses the spell's own die and spends slot 0", async () => {
+        enterCombat()
+
+        await spell.rollSpellCheck('int')
+
+        expect(dieTerm().formula).toBe('1d20')
+        expect(combatant.setFlag).toHaveBeenCalledWith('dcc', 'actionDice', expect.objectContaining({
+          round: 3,
+          spent: [true, false]
+        }))
+      })
+
+      test("the second cast drops to the wizard's spells-only second action die", async () => {
+        enterCombat([true, false])
+
+        await spell.rollSpellCheck('int')
+
+        // The bug: this rolled 1d20 again, because `spellCheck.die` only ever
+        // carries the first action die.
+        expect(dieTerm().formula).toBe('1d14')
+        expect(combatant.setFlag).toHaveBeenCalledWith('dcc', 'actionDice', expect.objectContaining({
+          round: 3,
+          spent: [true, true]
+        }))
+      })
+
+      test('the "Action N of M" line reaches the chat card', async () => {
+        enterCombat([true, false])
+
+        await spell.rollSpellCheck('int')
+
+        const spellData = global.game.dcc.processSpellCheck.mock.calls[0][1]
+        expect(spellData.actionDiceChatLine).toBe('DCC.ActionDiceChatLine formatted')
+      })
+
+      test('a third cast is over budget — no die is spent and the line says so', async () => {
+        enterCombat([true, true])
+
+        await spell.rollSpellCheck('int')
+
+        // Nothing left to spend, so the die falls back to the spell's own and
+        // the state is never rewritten; the card carries the over-budget line.
+        expect(dieTerm().formula).toBe('1d20')
+        expect(combatant.setFlag).not.toHaveBeenCalled()
+        const spellData = global.game.dcc.processSpellCheck.mock.calls[0][1]
+        expect(spellData.actionDiceChatLine).toBe('DCC.ActionDiceChatLineOverBudget formatted')
+      })
+
+      test('the modifier dialog is offered one preset per eligible slot', async () => {
+        enterCombat()
+
+        await spell.rollSpellCheck('int')
+
+        // Both slots are unspent and both take a spell, so both are offered —
+        // and no untrained 1d10 (that is an attack/skill concept).
+        expect(dieTerm().presets.map(p => p.formula)).toEqual(['1d20', '1d14'])
+      })
+
+      test('a die chosen in the dialog re-points the spend to that slot', async () => {
+        enterCombat()
+        // The player overrode the auto-picked 1d20 with slot 1's 1d14.
+        global.game.dcc.DCCRoll.createRoll = vi.fn(() => ({
+          evaluate: vi.fn(),
+          dice: [{ options: {}, faces: 14 }]
+        }))
+
+        await spell.rollSpellCheck('int')
+
+        expect(combatant.setFlag).toHaveBeenCalledWith('dcc', 'actionDice', expect.objectContaining({
+          spent: [false, true]
+        }))
+      })
+
+      test('off-path (setting disabled) the cast is unchanged and spends nothing', async () => {
+        enterCombat([true, false])
+        global.game.settings.get = vi.fn((module, key) =>
+          module === 'dcc' && key === 'automateWizardSpellLoss')
+
+        await spell.rollSpellCheck('int')
+
+        expect(dieTerm().formula).toBe('1d20')
+        expect(dieTerm().presets).toBeUndefined()
+        expect(combatant.setFlag).not.toHaveBeenCalled()
+        const spellData = global.game.dcc.processSpellCheck.mock.calls[0][1]
+        expect(spellData.actionDiceChatLine).toBe('')
+      })
+
+      test('a spell with no results table posts nothing, so it costs nothing', async () => {
+        enterCombat()
+        spell.system.results.table = ''
+
+        await spell.rollSpellCheck('int')
+
+        expect(global.ui.notifications.warn).toHaveBeenCalledWith('DCC.NoSpellResultsTableWarning')
+        expect(combatant.setFlag).not.toHaveBeenCalled()
+      })
+
+      test('out of combat there is no budget, so the cast is unchanged', async () => {
+        // Master setting on, but no active combat ⇒ planActionDie returns null.
+        await spell.rollSpellCheck('int')
+
+        expect(dieTerm().formula).toBe('1d20')
+        const spellData = global.game.dcc.processSpellCheck.mock.calls[0][1]
+        expect(spellData.actionDiceChatLine).toBe('')
+      })
     })
   })
 

--- a/module/__tests__/spell-check-processor.test.js
+++ b/module/__tests__/spell-check-processor.test.js
@@ -528,6 +528,73 @@ describe('processSpellCheck — item lastResult update', () => {
 // Multiple-action-dice "Action N of M" line (#857). `DCCItem.rollSpellCheck`
 // supplies it; it is optional, so callers that never set it — including sibling
 // content modules using this stable API — must be unaffected.
+// Crit/fumble follow the die actually rolled, not a hardcoded 20 (#857). The
+// multiple-action-dice override can hand this path a smaller action die, on which
+// a natural 20 is unrollable — a hardcoded threshold made a crit impossible.
+describe('processSpellCheck — crit threshold follows the rolled die', () => {
+  const actor = () => ({
+    type: 'Player',
+    name: 'Probe',
+    system: { class: {}, details: { level: { value: 3 } } },
+    classId: 'wizard',
+    loseSpell: vi.fn()
+  })
+
+  const rollWithFaces = (faces, natural) => {
+    const roll = makeRoll({ natural, total: natural + 5 })
+    roll.dice = [{ total: natural, faces }]
+    return roll
+  }
+
+  test('a natural max on a d14 action die is a crit', async () => {
+    const stubs = installFoundryStubs()
+    const roll = rollWithFaces(14, 14)
+    const rollTable = { getResultsForRoll: vi.fn(() => [{ _id: 'r1' }]), displayRoll: true }
+
+    await processSpellCheck(actor(), { roll, rollTable })
+
+    expect(stubs.addChatMessage).toHaveBeenCalledWith(
+      roll, rollTable, expect.anything(), expect.objectContaining({ crit: true })
+    )
+  })
+
+  test('a natural 20 is still the crit on a d20', async () => {
+    const stubs = installFoundryStubs()
+    const roll = rollWithFaces(20, 20)
+    const rollTable = { getResultsForRoll: vi.fn(() => [{ _id: 'r1' }]), displayRoll: true }
+
+    await processSpellCheck(actor(), { roll, rollTable })
+
+    expect(stubs.addChatMessage).toHaveBeenCalledWith(
+      roll, rollTable, expect.anything(), expect.objectContaining({ crit: true })
+    )
+  })
+
+  test('a natural 14 on a d20 is NOT a crit', async () => {
+    const stubs = installFoundryStubs()
+    const roll = rollWithFaces(20, 14)
+    const rollTable = { getResultsForRoll: vi.fn(() => [{ _id: 'r1' }]), displayRoll: true }
+
+    await processSpellCheck(actor(), { roll, rollTable })
+
+    expect(stubs.addChatMessage).toHaveBeenCalledWith(
+      roll, rollTable, expect.anything(), expect.objectContaining({ crit: false })
+    )
+  })
+
+  test('forceCrit lands on the die max, not a literal 20', async () => {
+    installFoundryStubs()
+    const roll = rollWithFaces(14, 7)
+    roll.terms = [{ results: [{ result: 7 }], _total: 7 }]
+    const rollTable = { getResultsForRoll: vi.fn(() => [{ _id: 'r1' }]), displayRoll: true }
+
+    await processSpellCheck(actor(), { roll, rollTable, forceCrit: true })
+
+    // The forced result must be rollable on a d14 and must register as the crit.
+    expect(roll.terms[0].results[0].result).toBe(14)
+  })
+})
+
 describe('processSpellCheck — actionDiceChatLine', () => {
   const actor = () => ({
     type: 'Player',

--- a/module/__tests__/spell-check-processor.test.js
+++ b/module/__tests__/spell-check-processor.test.js
@@ -42,7 +42,8 @@ function makeRoll ({ natural = 10, total = null, evaluated = true } = {}) {
       _total: natural
     }],
     evaluate: vi.fn(async function () { this._evaluated = true }),
-    toMessage: vi.fn(async function () { return { id: 'msg' } })
+    toMessage: vi.fn(async function () { return { id: 'msg' } }),
+    render: vi.fn(async () => '<div class="dice-roll"></div>')
   }
   return roll
 }
@@ -521,5 +522,76 @@ describe('processSpellCheck — item lastResult update', () => {
 
     expect(stubs.updateFlags).toHaveBeenCalledTimes(1)
     expect(roll.toMessage).toHaveBeenCalledTimes(1)
+  })
+})
+
+// Multiple-action-dice "Action N of M" line (#857). `DCCItem.rollSpellCheck`
+// supplies it; it is optional, so callers that never set it — including sibling
+// content modules using this stable API — must be unaffected.
+describe('processSpellCheck — actionDiceChatLine', () => {
+  const actor = () => ({
+    type: 'Player',
+    system: { class: {}, details: { level: { value: 1 } } },
+    classId: 'wizard'
+  })
+
+  test('forwards the line into SpellResult.addChatMessage on the table branch', async () => {
+    const stubs = installFoundryStubs()
+    const roll = makeRoll({ natural: 12, total: 17 })
+    const rollTable = { getResultsForRoll: vi.fn(() => [{ _id: 'r1' }]), displayRoll: true }
+
+    await processSpellCheck(actor(), { roll, rollTable, actionDiceChatLine: 'Action 2 of 2 (1d14)' })
+
+    expect(stubs.addChatMessage).toHaveBeenCalledWith(
+      roll,
+      rollTable,
+      expect.anything(),
+      expect.objectContaining({ actionDiceChatLine: 'Action 2 of 2 (1d14)' })
+    )
+  })
+
+  test('renders the line under the roll on the no-table branch', async () => {
+    installFoundryStubs()
+    const roll = makeRoll({ natural: 12, total: 17 })
+
+    await processSpellCheck(actor(), { roll, actionDiceChatLine: 'Action 2 of 2 (1d14)' })
+
+    const content = roll.toMessage.mock.calls[0][0].content
+    expect(content).toContain('<div class="dice-roll"></div>')
+    expect(content).toContain('<div class="dcc-action-dice-line">Action 2 of 2 (1d14)</div>')
+  })
+
+  test('escapes the line rather than trusting it as HTML', async () => {
+    installFoundryStubs()
+    const roll = makeRoll({ natural: 12, total: 17 })
+
+    await processSpellCheck(actor(), { roll, actionDiceChatLine: '<img src=x onerror=alert(1)>' })
+
+    expect(roll.toMessage.mock.calls[0][0].content).not.toContain('<img')
+  })
+
+  test('with no line the no-table branch leaves content unset (default body)', async () => {
+    installFoundryStubs()
+    const roll = makeRoll({ natural: 12, total: 17 })
+
+    await processSpellCheck(actor(), { roll })
+
+    expect(roll.toMessage.mock.calls[0][0].content).toBeUndefined()
+    expect(roll.render).not.toHaveBeenCalled()
+  })
+
+  test('with no line the table branch passes an empty string through', async () => {
+    const stubs = installFoundryStubs()
+    const roll = makeRoll({ natural: 12, total: 17 })
+    const rollTable = { getResultsForRoll: vi.fn(() => [{ _id: 'r1' }]), displayRoll: true }
+
+    await processSpellCheck(actor(), { roll, rollTable })
+
+    expect(stubs.addChatMessage).toHaveBeenCalledWith(
+      roll,
+      rollTable,
+      expect.anything(),
+      expect.objectContaining({ actionDiceChatLine: '' })
+    )
   })
 })

--- a/module/actor/rolls-spell-mixin.mjs
+++ b/module/actor/rolls-spell-mixin.mjs
@@ -17,7 +17,7 @@ import { normalizeLibDie } from '../adapter/attack-input.mjs'
 import { logDispatch, warnIfDivergent, withRollErrorBoundary } from '../adapter/debug.mjs'
 import { applyForceCritToFoundryRoll } from './force-crit.mjs'
 import { emitAfterSpellCheckResult, sumSpellburn } from './spell-result-hook.mjs'
-import { planActionDie, spendPlannedActionDie, formatActionDiceChatLine, slotRollFormula } from '../action-dice-tracker.mjs'
+import { planActionDie, spendPlannedActionDie, formatActionDiceChatLine, slotRollFormula, actionDicePresetsFromPlan, reconcilePlannedActionDie } from '../action-dice-tracker.mjs'
 import { formatMercurialDescriptionHTML } from '../utilities.js'
 
 /**
@@ -127,14 +127,35 @@ export const RollsSpellMixin = (Base) => class extends Base {
     // (`planActionDie` → null) leaves today's behavior; the spend happens in
     // the cast branch after the roll resolves (so a cancelled dialog spends
     // nothing). Only an extra die (index > 0) overrides the spell-check die —
-    // the first action of a round, and the off-path, stay byte-identical — and
-    // a shown modifier dialog's own `actionDie` choice still wins (it overwrites
-    // `actionDieOverride` in `_applySpellCheckDialogToOptions`).
+    // the first action of a round, and the off-path, stay byte-identical.
+    //
+    // The planned die is also handed to the modifier dialog (below) as its Die
+    // term default plus the slot presets, so the dialog shows the die that will
+    // actually be rolled and can be used to pick a different slot. Before that
+    // the dialog defaulted to the spell's own (always-first-slot) die and
+    // `_applySpellCheckDialogToOptions` wrote it straight back over the planned
+    // override, so with the dialog on, an extra-die cast silently reverted to
+    // the primary die (#857).
     const actionDicePlan = planActionDie(this, 'spell')
     options._actionDicePlan = actionDicePlan
     if (actionDicePlan?.choice && actionDicePlan.choice.index > 0 && !options.actionDieOverride) {
       options.actionDieOverride = slotRollFormula(actionDicePlan.choice.slot)
     }
+    // Slot-aware presets for the dialog (#834 §3); null when there is only one
+    // slot or off-path, in which case the dialog's Die term is unchanged.
+    delete options._actionDicePresets
+    if (actionDicePlan) {
+      const slotPresets = actionDicePresetsFromPlan(actionDicePlan, { action: 'spell' })
+      if (slotPresets?.length) options._actionDicePresets = slotPresets
+    }
+    // Faces of the die the roll uses with no player intervention, so the
+    // post-roll reconcile can tell a real slot choice from the default.
+    const defaultDie = options.actionDieOverride ||
+      spellItem?.system?.spellCheck?.die ||
+      this.system.class?.spellCheckOverrideDie ||
+      this.system.attributes?.actionDice?.value ||
+      '1d20'
+    options._actionDiceDefaultFaces = parseInt(String(defaultDie).match(/d(\d+)/)?.[1] || '') || null
 
     const castingMode = spellItem?.system?.config?.castingMode
     const hasPatron = !!this.system.class?.patron
@@ -231,9 +252,22 @@ export const RollsSpellMixin = (Base) => class extends Base {
    * @private
    */
   async _promptSpellCheckDialog (spellItem, ctx = {}) {
-    const { castingMode = 'wizard', isIdolMagic = false, spellburnEligible = false } = ctx
+    const {
+      castingMode = 'wizard',
+      isIdolMagic = false,
+      spellburnEligible = false,
+      actionDie = '',
+      actionDicePresets = null
+    } = ctx
 
+    // `ctx.actionDie` is the multiple-action-dice override the dispatcher
+    // planned for this cast (#857). It has to win over the spell's own
+    // `spellCheck.die` — that value is always derived from the FIRST action die
+    // (`getSingleActionDie`), so defaulting to it here and then folding the
+    // dialog result back into `options.actionDieOverride` is what used to undo
+    // the plan.
     const die =
+      actionDie ||
       spellItem?.system?.spellCheck?.die ||
       this.system.class?.spellCheckOverrideDie ||
       this.system.attributes?.actionDice?.value ||
@@ -261,7 +295,10 @@ export const RollsSpellMixin = (Base) => class extends Base {
       {
         type: 'Die',
         label: game.i18n.localize('DCC.ActionDie'),
-        formula: die
+        formula: die,
+        // Only present on-path with two or more slots, so the dialog otherwise
+        // renders the plain die field it always has.
+        ...(actionDicePresets?.length ? { presets: actionDicePresets } : {})
       },
       {
         type: 'Compound',
@@ -381,7 +418,9 @@ export const RollsSpellMixin = (Base) => class extends Base {
       const prompt = await this._promptSpellCheckDialog(spellItem, {
         castingMode: isCleric ? 'cleric' : 'wizard',
         isIdolMagic: isCleric,
-        spellburnEligible: !isCleric
+        spellburnEligible: !isCleric,
+        actionDie: options.actionDieOverride || '',
+        actionDicePresets: options._actionDicePresets || null
       })
       if (prompt === null) return
       this._applySpellCheckDialogToOptions(prompt, options)
@@ -484,7 +523,9 @@ export const RollsSpellMixin = (Base) => class extends Base {
       const prompt = await this._promptSpellCheckDialog(null, {
         castingMode: isIdolMagic ? 'cleric' : 'wizard',
         isIdolMagic,
-        spellburnEligible: !isIdolMagic
+        spellburnEligible: !isIdolMagic,
+        actionDie: options.actionDieOverride || '',
+        actionDicePresets: options._actionDicePresets || null
       })
       if (prompt === null) return
       this._applySpellCheckDialogToOptions(prompt, options)
@@ -643,7 +684,7 @@ export const RollsSpellMixin = (Base) => class extends Base {
       flavor += ` (${game.i18n.localize(abilityLabel)})`
     }
 
-    const actionDiceChatLine = await this._spendActionDiceLine(options)
+    const actionDiceChatLine = await this._spendActionDiceLine(options, foundryRoll)
     await renderSpellCheck({
       actor: this,
       spellItem: null,
@@ -716,7 +757,7 @@ export const RollsSpellMixin = (Base) => class extends Base {
     })
 
     const flavor = this._buildSpellCheckFlavor(spellItem, options)
-    const actionDiceChatLine = await this._spendActionDiceLine(options)
+    const actionDiceChatLine = await this._spendActionDiceLine(options, foundryRoll)
     await renderSpellCheck({
       actor: this,
       spellItem,
@@ -965,7 +1006,7 @@ export const RollsSpellMixin = (Base) => class extends Base {
     warnIfDivergent('rollSpellCheck', foundryRoll.total, result.total, { actor: this.name, spell: spellItem?.name })
 
     const flavor = this._buildSpellCheckFlavor(spellItem, options, profile)
-    const actionDiceChatLine = await this._spendActionDiceLine(options)
+    const actionDiceChatLine = await this._spendActionDiceLine(options, foundryRoll)
     await renderSpellCheck({
       actor: this,
       spellItem,
@@ -1137,10 +1178,21 @@ export const RollsSpellMixin = (Base) => class extends Base {
    * by `_rollSpellCheckDispatch`; null plan ⇒ off-path ⇒ `''`. Called by each
    * cast branch after its roll resolves, so a cancelled dialog (which returns
    * before reaching the cast) spends nothing.
+   *
+   * `foundryRoll` re-points the plan at the slot whose die was actually rolled
+   * (#834 §3) before spending, so choosing a different slot in the modifier
+   * dialog moves the spend instead of silently burning the auto-picked one.
+   * @param {object} options
+   * @param {Roll} [foundryRoll] - the evaluated roll, for the reconcile
    * @private
    */
-  async _spendActionDiceLine (options) {
-    return formatActionDiceChatLine(await spendPlannedActionDie(options?._actionDicePlan))
+  async _spendActionDiceLine (options, foundryRoll = null) {
+    const plan = reconcilePlannedActionDie(
+      options?._actionDicePlan,
+      foundryRoll?.dice?.[0]?.faces,
+      { action: 'spell', defaultFaces: options?._actionDiceDefaultFaces ?? null }
+    )
+    return formatActionDiceChatLine(await spendPlannedActionDie(plan))
   }
 
   /**

--- a/module/item/spell-mixin.mjs
+++ b/module/item/spell-mixin.mjs
@@ -67,10 +67,13 @@ const MAX_MERCURIAL_SPECIAL_DEPTH = 5
  * `logDispatch` of their own — the dispatch-logged spell-check *routing* lives
  * on the actor side (`DCCActor._rollSpellCheckViaAdapter`); this item-level path
  * is the spell-sheet / macro entry point that builds terms and hands off to
- * `processSpellCheck`. The module dependencies are the `../utilities.js`
- * helpers: `ensurePlus` (luck-modifier term), `getMercurialSpecial`
- * (roll-again expansion, #339), and `getNameCandidates` /
- * `findPackEntryByName` (Babele-aware table resolution, #799).
+ * `processSpellCheck`. The module dependencies are `../ability-score-log.js`
+ * (`logSpellburn`); the `../utilities.js` helpers `ensurePlus` (luck-modifier
+ * term), `getMercurialSpecial` (roll-again expansion, #339), and
+ * `getNameCandidates` / `findPackEntryByName` (Babele-aware table resolution,
+ * #799); and `../action-dice-tracker.mjs` for the multiple-action-dice budget
+ * (#857) — the same direct import the six other roll paths use, and not an
+ * adapter module.
  *
  * @param {typeof Item} Base - the document class to extend (production: a
  *   `CurrencyItemMixin(ContainerItemMixin(Item))`; unit tests: a stub).
@@ -112,9 +115,18 @@ export const SpellItemMixin = (Base) => class extends Base {
     // off-path (setting off / not in combat / no budget), which leaves the
     // whole block inert. A spells-only die IS eligible here — that is the
     // canonical wizard "cast with the second action die" case.
+    // The slot only replaces a die that WAS derived from the action die.
+    // `DCCItem.prepareBaseData` composes `spellCheck.die`: it reads the action
+    // die only when `config.inheritActionDie` is set, and a class's
+    // `spellCheckOverrideDie` wins over it. Either of those is a deliberate
+    // authoring choice, so stepping to another slot must not silently discard it
+    // — the same "re-apply relative to the chosen base die, don't discard it"
+    // rule #834 established for the two-weapon penalty.
     let die = this.system.spellCheck.die
+    const dieFollowsActionDie = !!this.system.config.inheritActionDie &&
+      !actor.system.class?.spellCheckOverrideDie
     let actionDicePlan = planActionDie(actor, 'spell')
-    if (actionDicePlan?.choice && actionDicePlan.choice.index > 0) {
+    if (dieFollowsActionDie && actionDicePlan?.choice && actionDicePlan.choice.index > 0) {
       die = slotRollFormula(actionDicePlan.choice.slot)
     }
     // The die the roll uses with no player intervention — passed to the

--- a/module/item/spell-mixin.mjs
+++ b/module/item/spell-mixin.mjs
@@ -2,6 +2,14 @@
 
 import { logSpellburn } from '../ability-score-log.js'
 import { ensurePlus, findPackEntryByName, getMercurialSpecial, getNameCandidates } from '../utilities.js'
+import {
+  planActionDie,
+  actionDicePresetsFromPlan,
+  reconcilePlannedActionDie,
+  spendPlannedActionDie,
+  formatActionDiceChatLine,
+  slotRollFormula
+} from '../action-dice-tracker.mjs'
 
 /**
  * Determine the die formula to roll for a manifestation table.
@@ -90,7 +98,35 @@ export const SpellItemMixin = (Base) => class extends Base {
     ability.label = CONFIG.DCC.abilities[abilityId]
     const spell = this.name
     options.title = game.i18n.format('DCC.RollModifierTitleCasting', { spell })
-    const die = this.system.spellCheck.die
+
+    // Multiple action dice (#834) — this is the sheet/macro entry point for an
+    // owned spell, so it owns the same plan → override → reconcile → spend
+    // cycle the weapon and check paths run. Without it a caster's second cast
+    // in a round silently re-rolled `spellCheck.die`, which
+    // `DCCItem.prepareBaseData` derives via `getSingleActionDie` — i.e. always
+    // the FIRST action die — and never spent a slot, so the tracker pips never
+    // advanced either (#857).
+    //
+    // Only an extra die (slot index > 0) overrides the spell's own die, so the
+    // first cast of a round stays byte-identical; `planActionDie` returns null
+    // off-path (setting off / not in combat / no budget), which leaves the
+    // whole block inert. A spells-only die IS eligible here — that is the
+    // canonical wizard "cast with the second action die" case.
+    let die = this.system.spellCheck.die
+    let actionDicePlan = planActionDie(actor, 'spell')
+    if (actionDicePlan?.choice && actionDicePlan.choice.index > 0) {
+      die = slotRollFormula(actionDicePlan.choice.slot)
+    }
+    // The die the roll uses with no player intervention — passed to the
+    // reconcile below so landing on it is never mistaken for a slot choice.
+    const defaultActionDieFaces = parseInt(String(die).match(/d(\d+)/)?.[1] || '') || null
+    // Slot-aware presets (#834 §3) so the modifier dialog is a real action-die
+    // chooser. Null when there is only one slot (or off-path), in which case
+    // the Die term carries no presets exactly as before.
+    const actionDicePresets = actionDicePlan
+      ? actionDicePresetsFromPlan(actionDicePlan, { action: 'spell' })
+      : null
+
     let bonus = this.system.spellCheck.value.toString()
 
     // Consolidate the spell check value so that the modifier dialog is not too wide
@@ -115,7 +151,11 @@ export const SpellItemMixin = (Base) => class extends Base {
       {
         type: 'Die',
         label: game.i18n.localize('DCC.ActionDie'),
-        formula: die
+        formula: die,
+        // Only on-path with two or more slots; absent otherwise, so the dialog
+        // renders the plain die field it always has. No untrained 1d10 here —
+        // that is an attack/skill concept, not a spell-check one.
+        ...(actionDicePresets?.length ? { presets: actionDicePresets } : {})
       },
       {
         type: 'Compound',
@@ -200,6 +240,18 @@ export const SpellItemMixin = (Base) => class extends Base {
       flavor += ` (${game.i18n.localize(ability.label)})`
     }
 
+    // The player may have picked a different slot in the modifier dialog, so
+    // re-point the plan at the die actually rolled before spending it, then
+    // spend (the tracker pip flips on the flag write). Null plan ⇒ off-path ⇒
+    // empty line, and the card renders exactly as it does today. Deliberately
+    // after the no-results-table bail-out above: that path posts nothing at all,
+    // so — as before this change — it must cost nothing either.
+    actionDicePlan = reconcilePlannedActionDie(actionDicePlan, roll.dice?.[0]?.faces, {
+      action: 'spell',
+      defaultFaces: defaultActionDieFaces
+    })
+    const actionDiceChatLine = formatActionDiceChatLine(await spendPlannedActionDie(actionDicePlan))
+
     // Tell the system to handle the spell check result
     await game.dcc.processSpellCheck(actor, {
       rollTable: resultsTable,
@@ -211,7 +263,8 @@ export const SpellItemMixin = (Base) => class extends Base {
       forceCrit: options.forceCrit,
       forceFumble: options.forceFumble,
       suppressPatronTaint: options.suppressPatronTaint,
-      spellburn: spellburnTotal
+      spellburn: spellburnTotal,
+      actionDiceChatLine
     })
   }
 

--- a/module/spell-check-processor.mjs
+++ b/module/spell-check-processor.mjs
@@ -15,7 +15,11 @@
  * `game.dcc.FleetingLuck` rather than importing those modules directly,
  * mirroring how `module/actor.js`'s spell-check paths already invoke
  * them; keeps the init-time `game.dcc` registration order unchanged.
+ * (`actionDiceLineHtml` is the one direct import — a pure string formatter
+ * with no init-time side effects, so it carries no ordering risk.)
  */
+
+import { actionDiceLineHtml } from './adapter/chat-renderer.mjs'
 
 /**
  * Handle the results of a spell check cast through any mechanism.
@@ -47,6 +51,11 @@ export async function processSpellCheck (actor, spellData) {
   // reacts via the `dcc.afterSpellCheckResult` hook below. Defaults false, so
   // existing callers are unaffected.
   const suppressPatronTaint = spellData.suppressPatronTaint || false
+  // Multiple-action-dice "Action N of M" line (#834), supplied by
+  // `DCCItem.rollSpellCheck`. Optional and empty on the off-path, so callers
+  // that never set it — including sibling content modules calling this stable
+  // API — render byte-identically to before.
+  const actionDiceChatLine = spellData.actionDiceChatLine || ''
 
   let crit = false
   let fumble = false
@@ -146,7 +155,7 @@ export async function processSpellCheck (actor, spellData) {
         roll._total += levelValue
       }
 
-      const spellResultOptions = { crit, fumble, item, patronTaint }
+      const spellResultOptions = { crit, fumble, item, patronTaint, actionDiceChatLine }
       const messageData = {}
       if (flavor) {
         messageData.flavor = flavor
@@ -189,13 +198,20 @@ export async function processSpellCheck (actor, spellData) {
       }
       game.dcc.FleetingLuck.updateFlags(flags, roll)
 
-      // Display the roll
-      await roll.toMessage({
+      // Display the roll. When a multiple-action-dice line is present it has to
+      // ride under the rolled formula, which means rendering the body by hand
+      // (mirrors `renderSkillCheck` in `adapter/chat-renderer.mjs`); with no
+      // line `content` stays unset and `toMessage` builds its default body.
+      const toMessageData = {
         speaker: ChatMessage.getSpeaker({ actor }),
         flavor,
         flags,
         system: { spellId: item?.id }
-      })
+      }
+      if (actionDiceChatLine) {
+        toMessageData.content = `${await roll.render()}${actionDiceLineHtml(actionDiceChatLine)}`
+      }
+      await roll.toMessage(toMessageData)
     }
 
     // Determine casting mode: an explicit override from the caller wins,

--- a/module/spell-check-processor.mjs
+++ b/module/spell-check-processor.mjs
@@ -68,13 +68,17 @@ export async function processSpellCheck (actor, spellData) {
 
   let naturalRoll = roll.dice[0].total
 
-  // Force a critical for testing (shift-click)
+  // Force a critical for testing (shift-click). Lands on the die's own max face
+  // rather than a literal 20, so it still registers as a crit when the action
+  // die is smaller than a d20 (see the faces-aware detection below) — and never
+  // writes a result the die cannot roll.
   if (forceCrit && naturalRoll !== 1) {
     const originalDieRoll = naturalRoll
-    naturalRoll = 20
-    roll.terms[0].results[0].result = 20
-    roll.terms[0]._total = 20
-    roll._total += (20 - originalDieRoll)
+    const critFace = roll.dice[0].faces || 20
+    naturalRoll = critFace
+    roll.terms[0].results[0].result = critFace
+    roll.terms[0]._total = critFace
+    roll._total += (critFace - originalDieRoll)
   }
 
   // Force a fumble for testing (ctrl+shift-click). Unconditional (a forced
@@ -128,11 +132,23 @@ export async function processSpellCheck (actor, spellData) {
   }
 
   try {
-    // Detect fumbles and crits before applying to table
+    // Detect fumbles and crits before applying to table.
+    //
+    // The crit threshold follows the die actually rolled rather than a
+    // hardcoded 20. The multiple-action-dice override can hand this path a
+    // smaller action die (a wizard's spells-only d14), and a custom action die
+    // can be any size — on either, a natural 20 is unrollable, so a hardcoded
+    // 20 made a crit impossible while the natural-1 fumble got *more* likely.
+    // This matches the lib's own spell-check rule
+    // (`natural === getDieFaces(die)` in vendor/dcc-core-lib/spells/cast.js),
+    // which the adapter-routed actor path already uses, and the crit/fumble
+    // realignment docs/dev/MULTIPLE_ACTION_DICE_DESIGN.md requires of an
+    // override die. Unchanged for every d20 caller.
     if (roll.dice.length > 0) {
+      const dieFaces = roll.dice[0].faces || 20
       if (naturalRoll === 1) {
         fumble = true
-      } else if (naturalRoll === 20) {
+      } else if (naturalRoll === dieFaces) {
         if (actor.type === 'Player') {
           crit = true
         }

--- a/module/spell-result.js
+++ b/module/spell-result.js
@@ -14,6 +14,8 @@ class SpellResult {
    * @param {boolean} fumble       The Spell Check was a nat 1
    * @param {Object} item          The spell item
    * @param {Object} patronTaint  The patron taint data object containing chance and message
+   * @param {string} actionDiceChatLine  Multiple-action-dice "Action N of M"
+   *   line (#834). Empty off-path, in which case the card is unchanged.
    */
   static async addChatMessage (roll, rollTable, result, {
     messageData = {},
@@ -22,7 +24,8 @@ class SpellResult {
     fumble = false,
     item = undefined,
     manifestation: manifestationOverride = undefined,
-    patronTaint = undefined
+    patronTaint = undefined,
+    actionDiceChatLine = ''
   } = {}) {
     messageOptions = foundry.utils.mergeObject({
       messageMode: game.settings.get('core', 'messageMode')
@@ -87,7 +90,8 @@ class SpellResult {
       rollHTML: rollTable.displayRoll ? await roll.render() : null,
       table: rollTable,
       crit,
-      fumble
+      fumble,
+      actionDiceChatLine
     })
 
     // Use the item name instead of the rollTable name to allow customizing spell names

--- a/templates/chat-card-spell-result.html
+++ b/templates/chat-card-spell-result.html
@@ -20,6 +20,10 @@
 
   {{{ rollHTML }}}
 
+  {{#if actionDiceChatLine}}
+    <div class="dcc-action-dice-line">{{actionDiceChatLine}}</div>
+  {{/if}}
+
   {{#if crit}}
     <div class="spell-check-mod">
       <h4 class="critical">{{localize "DCC.SpellCheckCrit"}}</h4>


### PR DESCRIPTION
## Problem

Reported in the wild: a wizard's **second spell in a round rolls the primary d20 instead of the second action die**, even though attacks and skill/ability checks step down correctly.

Casting an owned spell from the character sheet goes through `DCCItem.rollSpellCheck` (`module/item/spell-mixin.mjs`) — the spell rows in the wizard/cleric/elf sheet partials carry `data-item-id`, so `actor-sheet.js` takes the item branch. That path had **no multiple-action-dice integration at all**:

- it rolled `system.spellCheck.die`, which `DCCItem.prepareBaseData` derives with `getSingleActionDie` — i.e. *always the first action die*;
- it never called `planActionDie` / `spendPlannedActionDie`, so no slot was spent and the tracker pips never advanced (which also meant the *next* cast re-planned as "action 1").

The weapon (`rolls-weapon-mixin`), ability-check (`rolls-check-mixin`) and skill-check (`rolls-skill-mixin`) paths already ran the full plan → override → reconcile → spend cycle. Only the spell item path was missing.

A second, independent bug on the **actor-side** path (`DCCActor.rollSpellCheck`, used for raw class-level checks and macros): it *did* plan an override, but `_promptSpellCheckDialog` built its Die term from the spell's own first-slot die and `_applySpellCheckDialogToOptions` then wrote that straight back over `options.actionDieOverride`. With the roll-modifier dialog shown, an extra-die cast silently reverted to the primary die.

## Changes

- **`module/item/spell-mixin.mjs`** — runs the same cycle as the other roll paths: plan `'spell'`, override the die for an extra slot, offer slot presets in the modifier dialog, reconcile against the die actually rolled, spend. A spells-only die *is* eligible here — that's the canonical wizard case.
- **`module/actor/rolls-spell-mixin.mjs`** — the dialog now defaults to the planned die and receives the slot presets, so folding its result back is correct instead of destructive; `_spendActionDiceLine` reconciles against the rolled die before spending.
- **`module/spell-check-processor.mjs`** — optional `actionDiceChatLine` passthrough. Empty for every existing caller (including sibling content modules using this stable API), so those cards are byte-identical.
- **`module/spell-result.js`** + **`templates/chat-card-spell-result.html`** — render the line under the roll, matching the attack/skill cards.

Off-path behavior (setting off, not in combat, no budget, single action die) is unchanged throughout: `planActionDie` returns `null` and every block is inert.

The spend deliberately sits *after* the no-results-table bail-out — that path posts nothing, so it must cost nothing.

## Tests

- `module/__tests__/item.test.js` — 9 tests over the item path: first cast uses the primary die and spends slot 0; second drops to the wizard's spells-only d14 and spends slot 1; over budget; presets; dialog-chosen die re-points the spend; off-path; out of combat; no results table spends nothing.
- `module/__tests__/actor-rolls-spell-mixin.test.js` — the dialog honors the planned die + presets and still falls back off-path; `_spendActionDiceLine` reconciles before spending.
- `module/__tests__/spell-check-processor.test.js` — the line reaches both card branches, is HTML-escaped, and is absent by default.
- `browser-tests/e2e/action-dice-tracker.spec.js` — new spec drives two real casts by a wizard against live Foundry and asserts the **rolled die faces go 20 → 14**, the pips advance `[true,false]` → `[true,true]`, and both cards carry the line.

Verified the new unit test and the new E2E both **fail** against the pre-fix code (`expected '1d20' to be '1d14'` / `Expected: 14, Received: 20`).

Full `npm test` (2359 tests) and the full `browser-tests/e2e` suite (277 tests) pass.

**Follow-up commit after review** (see the review comment below): the extra-die override made a spell crit unreachable, because `processSpellCheck` classified crits as a hardcoded natural 20 — impossible on a d14. It now reads the rolled die's faces, matching the lib's own spell rule that the adapter path already used (this also fixes the same latent bug for any custom non-d20 action die). The override also no longer discards a spell authored with `inheritActionDie: false` or a class `spellCheckOverrideDie`. Plus a test-fidelity fix (the roll stub reported no `faces`, so the reconcile was short-circuiting) and the design-doc / docstring updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
