### PR TITLE
fix: dragged macros no longer show the actor id in the macro name

### DIFF
--- a/module/__tests__/macros.test.js
+++ b/module/__tests__/macros.test.js
@@ -379,6 +379,45 @@ describe('createDCCMacro dispatcher', () => {
     expect(globalThis.game.user.assignHotbarMacro).toHaveBeenCalledOnce()
   })
 
+  test('creates the macro with the clean factory name — no actorId suffix (#876)', async () => {
+    await createDCCMacro({
+      type: 'Weapon',
+      actorId: 'A1',
+      data: {},
+      system: { weapon: { _id: 'W1', type: 'weapon', name: 'Longsword', img: 'longsword.webp' } }
+    }, 1)
+    expect(globalThis.Macro.create).toHaveBeenCalledOnce()
+    const created = globalThis.Macro.create.mock.calls[0][0]
+    expect(created.name).toBe('Longsword')
+    expect(created.name).not.toContain('A1')
+    // Per-actor uniqueness lives in the command, not the name
+    expect(created.command).toContain('"A1"')
+  })
+
+  test('same-named weapons from different actors still get distinct macros', async () => {
+    const drop = (actorId) => ({
+      type: 'Weapon',
+      actorId,
+      data: {},
+      system: { weapon: { _id: 'W1', type: 'weapon', name: 'Longsword', img: 'longsword.webp' } }
+    })
+    await createDCCMacro(drop('A1'), 1)
+    // Simulate the first macro now existing in the world
+    const first = await globalThis.Macro.create.mock.results[0].value
+    globalThis.game.macros.contents = [first]
+
+    // Same actor again: reused, no second create
+    await createDCCMacro(drop('A1'), 2)
+    expect(globalThis.Macro.create).toHaveBeenCalledOnce()
+
+    // Different actor: command differs, so a new macro is created
+    await createDCCMacro(drop('A2'), 3)
+    expect(globalThis.Macro.create).toHaveBeenCalledTimes(2)
+    const second = globalThis.Macro.create.mock.calls[1][0]
+    expect(second.name).toBe('Longsword')
+    expect(second.command).toContain('"A2"')
+  })
+
   test('returns true for Macro drops to let Foundry handle them', async () => {
     const result = await createDCCMacro({ type: 'Macro', data: {} }, 1)
     expect(result).toBe(true)

--- a/module/__tests__/macros.test.js
+++ b/module/__tests__/macros.test.js
@@ -99,7 +99,7 @@ function installFoundryStubs ({ i18n = {}, dcc = {}, settings = {}, actors = {},
   }
   globalThis.ChatMessage = { getSpeaker: vi.fn(() => ({ token: null, actor: null })) }
   globalThis.ui = { notifications: { warn: vi.fn(() => 'warn-result') } }
-  globalThis.Macro = { create: vi.fn(async (cfg) => ({ ...cfg, id: 'created-id' })) }
+  globalThis.Macro = { create: vi.fn(async (cfg) => ({ ...cfg, id: 'created-id', isAuthor: true })) }
 }
 
 beforeEach(() => {
@@ -434,12 +434,21 @@ describe('createDCCMacro dispatcher', () => {
   })
 
   test('reuses an existing macro when name and command match', async () => {
-    const existing = { id: 'existing-id', name: 'loc:DCC.Initiative', command: "const _actor = game.dcc.getMacroActor('A1'); if (_actor) { _actor.rollInit(event, token) }" }
+    const existing = { id: 'existing-id', name: 'loc:DCC.Initiative', command: "const _actor = game.dcc.getMacroActor('A1'); if (_actor) { _actor.rollInit(event, token) }", isAuthor: true }
     globalThis.game.macros.contents = [existing]
     const result = await createDCCMacro({ type: 'Initiative', actorId: 'A1', data: {} }, 1)
     expect(result).toBe(false)
     expect(globalThis.Macro.create).not.toHaveBeenCalled()
     expect(globalThis.game.user.assignHotbarMacro).toHaveBeenCalledWith(existing, 1)
+  })
+
+  test('does not reuse a matching macro authored by another user', async () => {
+    const existing = { id: 'other-users-id', name: 'loc:DCC.Initiative', command: "const _actor = game.dcc.getMacroActor('A1'); if (_actor) { _actor.rollInit(event, token) }", isAuthor: false }
+    globalThis.game.macros.contents = [existing]
+    const result = await createDCCMacro({ type: 'Initiative', actorId: 'A1', data: {} }, 1)
+    expect(result).toBe(false)
+    expect(globalThis.Macro.create).toHaveBeenCalledOnce()
+    expect(globalThis.game.user.assignHotbarMacro).not.toHaveBeenCalledWith(existing, 1)
   })
 })
 

--- a/module/macros.mjs
+++ b/module/macros.mjs
@@ -334,11 +334,13 @@ export async function createDCCMacro (data, slot) {
   // Call the appropriate function to generate a macro
   const macroData = MACRO_FACTORIES[data.type](data, slot)
   if (macroData) {
-    // Create or reuse existing macro
+    // Create or reuse existing macro. The command embeds the actor id, so
+    // matching on name + command keeps per-actor macros distinct without
+    // polluting the visible name.
     let macro = game.macros.contents.find(m => (m.name === macroData.name) && (m.command === macroData.command))
     if (!macro) {
       macro = await Macro.create({
-        name: `${macroData.name}-${data.actorId}`,
+        name: macroData.name,
         type: 'script',
         img: macroData.img,
         command: macroData.command,

--- a/module/macros.mjs
+++ b/module/macros.mjs
@@ -336,8 +336,9 @@ export async function createDCCMacro (data, slot) {
   if (macroData) {
     // Create or reuse existing macro. The command embeds the actor id, so
     // matching on name + command keeps per-actor macros distinct without
-    // polluting the visible name.
-    let macro = game.macros.contents.find(m => (m.name === macroData.name) && (m.command === macroData.command))
+    // polluting the visible name. Only reuse macros this user authored —
+    // players may not be able to execute another user's script macro.
+    let macro = game.macros.contents.find(m => (m.name === macroData.name) && (m.command === macroData.command) && m.isAuthor)
     if (!macro) {
       macro = await Macro.create({
         name: macroData.name,


### PR DESCRIPTION
Fixes #876

## Summary
- Hotbar macros created from sheet drags (weapons, abilities, saves, etc.) were named `<name>-<actorId>`, exposing the raw actor id in the hotbar (e.g. `Longsword-aBcDeF1234567890`). They are now created with the clean display name.
- Per-actor uniqueness is unaffected: the macro **command** embeds the actor id, and the reuse lookup matches on name **and** command, so same-named weapons from different actors still get distinct macros.
- This also fixes a latent duplicate-macro bug: the reuse lookup searched for the clean name while macros were created with the suffixed name, so it never matched and every drop created a new macro document.
- Reuse is additionally restricted to macros the current user authored (`isAuthor`), so a player can never be handed a GM-authored script macro they lack permission to execute.

Note for existing worlds: previously created `Name-actorId` macros are left in place (old hotbar slots keep working); re-dropping creates a clean-named macro alongside them.

## Test plan
- [x] New unit test: created macro uses the clean factory name with no actorId suffix
- [x] New unit test: same weapon re-dropped by the same actor reuses the existing macro; same-named weapon from a different actor creates a distinct macro
- [x] New unit test: a matching macro authored by another user is not reused
- [x] `npm run check` green (format, scss, 2399 tests, compare-lang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)