### PR TITLE
fix: stop nightly audit workflow opening version-only PRs

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -53,8 +53,14 @@ jobs:
 
       - name: Check for lockfile changes
         id: changes
+        # -I ignores hunks whose only changes are the lockfile's own root
+        # "version" fields. If the release process leaves package-lock.json's
+        # version behind package.json's, `npm audit fix` re-syncs it, which is
+        # not a security fix and must not open a PR (#877). Real audit fixes
+        # always touch "resolved"/"integrity" lines too, so they still trip
+        # the filter.
         run: |
-          if git diff --quiet -- package.json package-lock.json browser-tests/e2e/package.json browser-tests/e2e/package-lock.json; then
+          if git diff --quiet -I '^[[:space:]]*"version": ' -- package.json package-lock.json browser-tests/e2e/package.json browser-tests/e2e/package-lock.json; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dcc",
-  "version": "0.70.39",
+  "version": "0.70.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dcc",
-      "version": "0.70.39",
+      "version": "0.70.40",
       "license": "MIT",
       "devDependencies": {
         "@foundryvtt/foundryvtt-cli": "^3.0.4",


### PR DESCRIPTION
Fixes #877

## Summary
Root cause of PR #869: the post-release `foundry-manifest-update-action` commit (`Release vX.Y.Z`) bumps `package.json`'s version but never touches `package-lock.json`, so the lock file's two root `version` fields drift a release behind. The nightly `npm audit fix` then re-syncs those fields, and the workflow saw the non-empty diff as a security fix and opened a PR containing nothing but the version sync.

Three-part fix:
- **This PR (workflow):** the change-detection `git diff` now ignores hunks that only touch `"version":` lines (`-I '^[[:space:]]*"version": '`). Real audit fixes always touch `resolved`/`integrity` lines too, so they still open a PR — verified both directions against the live lock file.
- **This PR (repair):** syncs `package-lock.json` to 0.70.40 so the nightly run stops seeing the drift immediately.
- **Companion PR:** foundryvtt-dcc/foundry-manifest-update-action#3 fixes the root cause so future release commits sync the lock file too.

## Test plan
- [x] With only the version drift present, `git diff --quiet -I ...` reports no change (workflow would skip the PR)
- [x] With a simulated dependency change (integrity line), the filtered diff still reports a change
- [x] `npm test` green (2399 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)