### PR TITLE
fix: cleric natural roll in disapproval range auto-fails the spell result card

### DIFF
--- a/browser-tests/e2e/cleric-disapproval-failure.spec.js
+++ b/browser-tests/e2e/cleric-disapproval-failure.spec.js
@@ -1,0 +1,111 @@
+/* eslint-disable no-undef -- Browser globals used in page.evaluate */
+const { expect, createSessionTest } = require('./fixtures')
+
+/**
+ * Cleric disapproval-range auto-failure (issue #874).
+ *
+ * DCC RAW (core rulebook, cleric magic): "any natural roll within that
+ * range automatically fails ... even though a roll of 13 would normally
+ * mean success on 1st-level spells." The spell-result card previously
+ * looked up the result row by the check TOTAL, so a cleric whose
+ * disapproval range had grown could roll a natural 4 (+8 = 12), get the
+ * red auto-failure highlight on the total, and still see the successful
+ * 12-13 manifestation row — a self-contradictory card. The card must
+ * show the failure row plus the explanatory banner instead.
+ *
+ * The natural roll is forced by patching DiceTerm.prototype._roll for
+ * the duration of the cast (forceFumble only covers natural 1).
+ */
+const test = createSessionTest()
+
+/** Cast a cleric spell with a forced natural roll and capture the card. */
+const castWithNaturalFn = `async ({ disapproval, natural }) => {
+  const observed = {}
+  let actor, table
+  try {
+    table = await RollTable.create({
+      name: 'P874 Paralysis',
+      formula: '1d20',
+      results: [
+        { type: CONST.TABLE_RESULT_TYPES.TEXT, range: [1, 11], description: 'e2e failure row', weight: 1 },
+        { type: CONST.TABLE_RESULT_TYPES.TEXT, range: [12, 33], description: 'e2e success row', weight: 1 }
+      ]
+    })
+
+    actor = await Actor.create({
+      type: 'Player',
+      name: 'P874 Cleric',
+      system: {
+        class: { className: 'Cleric', disapproval },
+        details: { sheetClass: 'Cleric' }
+      }
+    })
+    await actor.update({ 'system.class.spellCheckOverride': '+8' })
+    const [spell] = await actor.createEmbeddedDocuments('Item', [{
+      type: 'spell',
+      name: 'P874 Paralysis',
+      system: {
+        level: 1,
+        config: { castingMode: 'cleric' },
+        results: { table: 'P874 Paralysis', collection: '' }
+      }
+    }])
+
+    const proto = foundry.dice.terms.DiceTerm.prototype
+    const origRoll = proto._roll
+    proto._roll = async function () { return natural }
+    try {
+      await spell.rollSpellCheck()
+    } finally {
+      proto._roll = origRoll
+    }
+
+    // The spell-result ChatMessage.create is awaited by rollSpellCheck, but
+    // poll briefly anyway to dodge any render race (see e2e-chat-message-race).
+    for (let i = 0; i < 40; i++) {
+      const message = game.messages.contents[game.messages.contents.length - 1]
+      if (message?.getFlag('dcc', 'SpellCheck')) {
+        observed.content = message.content
+        const roll = message.rolls?.[0]
+        observed.natural = roll?.dice?.[0]?.total
+        observed.total = roll?.total
+        break
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    }
+  } finally {
+    if (actor) await actor.delete().catch(() => {})
+    if (table) await table.delete().catch(() => {})
+  }
+  return observed
+}`
+
+test.describe('Cleric disapproval-range auto-failure (#874)', () => {
+  test('natural roll inside the disapproval range shows the failure row and banner despite a successful total', async ({ page }) => {
+    const observed = await page.evaluate(async (castWithNaturalSrc) => {
+      // eslint-disable-next-line no-eval
+      const castWithNatural = eval(`(${castWithNaturalSrc})`)
+      return castWithNatural({ disapproval: 4, natural: 4 })
+    }, castWithNaturalFn)
+
+    expect(observed.natural).toBe(4)
+    expect(observed.total).toBe(12) // would hit the 12-33 success row by total
+    expect(observed.content).toContain('e2e failure row')
+    expect(observed.content).not.toContain('e2e success row')
+    expect(observed.content).toContain('Automatic failure! Natural roll within disapproval range.')
+  })
+
+  test('the same roll with disapproval range 1 keeps the success row and no banner', async ({ page }) => {
+    const observed = await page.evaluate(async (castWithNaturalSrc) => {
+      // eslint-disable-next-line no-eval
+      const castWithNatural = eval(`(${castWithNaturalSrc})`)
+      return castWithNatural({ disapproval: 1, natural: 4 })
+    }, castWithNaturalFn)
+
+    expect(observed.natural).toBe(4)
+    expect(observed.total).toBe(12)
+    expect(observed.content).toContain('e2e success row')
+    expect(observed.content).not.toContain('e2e failure row')
+    expect(observed.content).not.toContain('Automatic failure!')
+  })
+})

--- a/lang/cn.json
+++ b/lang/cn.json
@@ -877,6 +877,7 @@
   "DCC.SpellCheckCardMessage": "投骰法术检定",
   "DCC.SpellCheckCrit": "大成功！法术奖励×2",
   "DCC.SpellCheckCritNoTable": "大成功！自然20。",
+  "DCC.SpellCheckDisapprovalFailure": "自动失败！自然骰落在失宠范围内。",
   "DCC.SpellCheckFumble": "大失败！使用结果1。",
   "DCC.SpellCheckFailureNoTable": "失败。",
   "DCC.SpellCheckFumbleNoTable": "大失败！自然1。",

--- a/lang/de.json
+++ b/lang/de.json
@@ -877,6 +877,7 @@
   "DCC.SpellCheckCardMessage": "Würfelt einen Zauberwurf.",
   "DCC.SpellCheckCrit": "Krit! Stufenbonus x2.",
   "DCC.SpellCheckCritNoTable": "Krit! Natürliche 20.",
+  "DCC.SpellCheckDisapprovalFailure": "Automatischer Fehlschlag! Natürlicher Wurf innerhalb des Missfallensbereichs.",
   "DCC.SpellCheckFumble": "Patzer! Verwende Ergebnis 1.",
   "DCC.SpellCheckFailureNoTable": "Fehlschlag.",
   "DCC.SpellCheckFumbleNoTable": "Patzer! Natürliche 1.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -877,6 +877,7 @@
   "DCC.SpellCheckCardMessage": "Rolls a Spell Check",
   "DCC.SpellCheckCrit": "Crit! Level bonus x2.",
   "DCC.SpellCheckCritNoTable": "Crit! Natural 20.",
+  "DCC.SpellCheckDisapprovalFailure": "Automatic failure! Natural roll within disapproval range.",
   "DCC.SpellCheckFumble": "Fumble! Using result 1.",
   "DCC.SpellCheckFailureNoTable": "Failure.",
   "DCC.SpellCheckFumbleNoTable": "Fumble! Natural 1.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -877,6 +877,7 @@
   "DCC.SpellCheckCardMessage": "Realiza un chequeo de hechizo",
   "DCC.SpellCheckCrit": "¡Crítico! Bono de nivel x2.",
   "DCC.SpellCheckCritNoTable": "¡Crítico! 20 natural.",
+  "DCC.SpellCheckDisapprovalFailure": "¡Fallo automático! Tirada natural dentro del rango de desaprobación.",
   "DCC.SpellCheckFumble": "¡Fallo! Usando resultado 1.",
   "DCC.SpellCheckFailureNoTable": "Fracaso.",
   "DCC.SpellCheckFumbleNoTable": "¡Fallo! 1 natural.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -868,6 +868,7 @@
   "DCC.SpellCheckCardMessage": "Lance un teste d'incantation.",
   "DCC.SpellCheckCrit": "Critique! Bonus de niveau x2.",
   "DCC.SpellCheckCritNoTable": "Critique! 20 naturel.",
+  "DCC.SpellCheckDisapprovalFailure": "Échec automatique ! Jet naturel dans la plage de désapprobation.",
   "DCC.SpellCheckFumble": "Maladresse! utilisation du résultat 1.",
   "DCC.SpellCheckFailureNoTable": "Échec.",
   "DCC.SpellCheckFumbleNoTable": "Maladresse! 1 naturel.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -877,6 +877,7 @@
   "DCC.SpellCheckCardMessage": "Effettua una Prova d'Incantesimo",
   "DCC.SpellCheckCrit": "Successo Critico! (x2)",
   "DCC.SpellCheckCritNoTable": "Successo Critico! 20 naturale.",
+  "DCC.SpellCheckDisapprovalFailure": "Fallimento automatico! Tiro naturale entro il raggio di disapprovazione.",
   "DCC.SpellCheckFumble": "Fallimento Critico! (1)",
   "DCC.SpellCheckFailureNoTable": "Fallimento.",
   "DCC.SpellCheckFumbleNoTable": "Fallimento Critico! 1 naturale.",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -877,6 +877,7 @@
   "DCC.SpellCheckCardMessage": "Rzuca Rzut na Czary",
   "DCC.SpellCheckCrit": "Krytyk! Bonus poziomu x2.",
   "DCC.SpellCheckCritNoTable": "Krytyk! Naturalny 20.",
+  "DCC.SpellCheckDisapprovalFailure": "Automatyczna porażka! Naturalny rzut w zakresie dezaprobaty.",
   "DCC.SpellCheckFumble": "Potknięcie! Używa wyniku 1.",
   "DCC.SpellCheckFailureNoTable": "Porażka.",
   "DCC.SpellCheckFumbleNoTable": "Potknięcie! Naturalny 1.",

--- a/module/__tests__/spell-check-processor.test.js
+++ b/module/__tests__/spell-check-processor.test.js
@@ -284,6 +284,109 @@ describe('processSpellCheck — rollTable branch', () => {
   })
 })
 
+describe('processSpellCheck — cleric disapproval auto-failure (#874)', () => {
+  const makeClericItem = (id = 'c1') => ({
+    id,
+    name: 'Paralysis',
+    system: { level: 1, config: { castingMode: 'cleric' }, associatedPatron: '' },
+    update: vi.fn()
+  })
+  const makeCleric = (disapproval) => ({
+    type: 'Player',
+    system: { class: { disapproval }, details: { level: { value: 6 } } },
+    classId: 'cleric',
+    rollDisapproval: vi.fn(),
+    applyDisapproval: vi.fn()
+  })
+
+  test('natural roll inside disapproval range shows the failure row even when the total succeeds', async () => {
+    const stubs = installFoundryStubs()
+    // Natural 4 + 8 = 12 — would hit the 12-13 success row, but range 4 auto-fails per RAW
+    const roll = makeRoll({ natural: 4, total: 12 })
+    const rollTable = { getResultsForRoll: vi.fn(() => [{ text: 'row' }]) }
+    const actor = makeCleric(4)
+
+    await processSpellCheck(actor, { roll, rollTable, item: makeClericItem() })
+
+    expect(rollTable.getResultsForRoll).toHaveBeenLastCalledWith(1)
+    const opts = stubs.addChatMessage.mock.calls[0][3]
+    expect(opts.disapprovalFailure).toBe(true)
+    expect(opts.fumble).toBe(false)
+  })
+
+  test('natural roll just outside the disapproval range keeps the total-based row', async () => {
+    const stubs = installFoundryStubs()
+    const roll = makeRoll({ natural: 5, total: 13 })
+    const rollTable = { getResultsForRoll: vi.fn(() => [{ text: 'row' }]) }
+    const actor = makeCleric(4)
+
+    await processSpellCheck(actor, { roll, rollTable, item: makeClericItem() })
+
+    expect(rollTable.getResultsForRoll).toHaveBeenLastCalledWith(13)
+    expect(stubs.addChatMessage.mock.calls[0][3].disapprovalFailure).toBe(false)
+  })
+
+  test('wizard casts never auto-fail from the disapproval field', async () => {
+    const stubs = installFoundryStubs()
+    const roll = makeRoll({ natural: 4, total: 12 })
+    const rollTable = { getResultsForRoll: vi.fn(() => [{ text: 'row' }]) }
+    const item = {
+      id: 'w1',
+      name: 'Magic Missile',
+      system: { level: 1, config: { castingMode: 'wizard' }, associatedPatron: '' },
+      update: vi.fn()
+    }
+    const actor = {
+      type: 'Player',
+      system: { class: { disapproval: 4 }, details: { level: { value: 6 } } },
+      classId: 'wizard',
+      loseSpell: vi.fn()
+    }
+
+    await processSpellCheck(actor, { roll, rollTable, item })
+
+    expect(rollTable.getResultsForRoll).toHaveBeenLastCalledWith(12)
+    expect(stubs.addChatMessage.mock.calls[0][3].disapprovalFailure).toBe(false)
+  })
+
+  test('a would-be crit inside the disapproval range is an automatic failure, not a crit', async () => {
+    const stubs = installFoundryStubs()
+    const roll = makeRoll({ natural: 20, total: 28 })
+    const rollTable = { getResultsForRoll: vi.fn(() => [{ text: 'row' }]) }
+    const actor = makeCleric(20)
+
+    await processSpellCheck(actor, { roll, rollTable, item: makeClericItem() })
+
+    expect(rollTable.getResultsForRoll).toHaveBeenLastCalledWith(1)
+    const opts = stubs.addChatMessage.mock.calls[0][3]
+    expect(opts.crit).toBe(false)
+    expect(opts.disapprovalFailure).toBe(true)
+  })
+
+  test('no-table branch emits the disapproval auto-failure verdict', async () => {
+    const stubs = installFoundryStubs()
+    const roll = makeRoll({ natural: 4, total: 12 })
+    const actor = makeCleric(4)
+
+    await processSpellCheck(actor, { roll, item: makeClericItem() })
+
+    const flags = stubs.updateFlags.mock.calls[0][0]
+    expect(flags['dcc.spellResult']).toContain('DCC.SpellCheckDisapprovalFailure')
+  })
+
+  test('automation ON: auto-failure triggers rollDisapproval and applyDisapproval despite the successful total', async () => {
+    installFoundryStubs({ settings: { automateClericDisapproval: true } })
+    const roll = makeRoll({ natural: 4, total: 12 })
+    const rollTable = { getResultsForRoll: vi.fn(() => [{ text: 'row' }]) }
+    const actor = makeCleric(4)
+
+    await processSpellCheck(actor, { roll, rollTable, item: makeClericItem() })
+
+    expect(actor.rollDisapproval).toHaveBeenCalledWith(4)
+    expect(actor.applyDisapproval).toHaveBeenCalled()
+  })
+})
+
 describe('processSpellCheck — casting-mode side effects', () => {
   test('wizard automation OFF does NOT call loseSpell on failure', async () => {
     installFoundryStubs({ settings: { automateWizardSpellLoss: false } })

--- a/module/spell-check-processor.mjs
+++ b/module/spell-check-processor.mjs
@@ -131,6 +131,15 @@ export async function processSpellCheck (actor, spellData) {
     }
   }
 
+  // Determine casting mode early — the disapproval auto-failure below and
+  // the failure automation both key off it. An explicit override from the
+  // caller wins, then the item's configuration, defaulting to wizard; cleric
+  // sheets fall back to cleric for item-less checks (issue #375).
+  let castingMode = spellData.castingMode || (item ? item.system.config.castingMode : 'wizard')
+  if (!spellData.castingMode && !item && actor.classId === 'cleric') {
+    castingMode = 'cleric'
+  }
+
   try {
     // Detect fumbles and crits before applying to table.
     //
@@ -155,11 +164,26 @@ export async function processSpellCheck (actor, spellData) {
       }
     }
 
+    // DCC RAW (core rulebook p. 30, cleric magic): "any natural roll within
+    // that range automatically fails ... even though a roll of 13 would
+    // normally mean success". So a cleric whose natural roll lands inside the
+    // disapproval range fails outright — the card must show the failure row,
+    // not the success row the total would otherwise buy (#874). The chat
+    // highlight already paints the total red for these rolls (the die's
+    // `lowerThreshold` is the disapproval range); this makes the card body
+    // agree with it. Natural 1 stays a fumble; a would-be crit inside the
+    // range is still an automatic failure.
+    const disapprovalRange = parseInt(actor.system.class?.disapproval, 10) || 1
+    const disapprovalFailure = castingMode === 'cleric' && !fumble && naturalRoll <= disapprovalRange
+    if (disapprovalFailure) {
+      crit = false
+    }
+
     // Apply the roll to the table if present
     if (rollTable) {
       result = rollTable.getResultsForRoll(roll.total)
 
-      if (fumble) {
+      if (fumble || disapprovalFailure) {
         result = rollTable.getResultsForRoll(1)
       } else if (crit) {
         const levelValue = parseInt(actor.system.details.level.value)
@@ -171,7 +195,7 @@ export async function processSpellCheck (actor, spellData) {
         roll._total += levelValue
       }
 
-      const spellResultOptions = { crit, fumble, item, patronTaint, actionDiceChatLine }
+      const spellResultOptions = { crit, fumble, disapprovalFailure, item, patronTaint, actionDiceChatLine }
       const messageData = {}
       if (flavor) {
         messageData.flavor = flavor
@@ -196,6 +220,8 @@ export async function processSpellCheck (actor, spellData) {
       let spellResultHtml = ''
       if (fumble) {
         spellResultHtml = `<p class="emote-alert fumble">${game.i18n.localize('DCC.SpellCheckFumbleNoTable')}</p>`
+      } else if (disapprovalFailure) {
+        spellResultHtml = `<p class="emote-alert fumble">${game.i18n.localize('DCC.SpellCheckDisapprovalFailure')}</p>`
       } else if (crit) {
         spellResultHtml = `<p class="emote-alert critical">${game.i18n.localize('DCC.SpellCheckCritNoTable')}</p>`
       } else if (noTableSuccess) {
@@ -230,20 +256,12 @@ export async function processSpellCheck (actor, spellData) {
       await roll.toMessage(toMessageData)
     }
 
-    // Determine casting mode: an explicit override from the caller wins,
-    // then the item's configuration, defaulting to wizard. The explicit
-    // override lets custom spell-like skills opt into wizard spell loss or
-    // cleric disapproval handling (issue #375).
-    let castingMode = spellData.castingMode || (item ? item.system.config.castingMode : 'wizard')
-    if (!spellData.castingMode && !item && actor.classId === 'cleric') {
-      // Cleric sheets will use the cleric casting mode if not set by the item
-      castingMode = 'cleric'
-    }
-
-    // Spell check threshold is 10 + spell level * 2, anything below this is a failure
+    // Spell check threshold is 10 + spell level * 2, anything below this is a failure.
+    // A natural roll inside the disapproval range is an automatic failure
+    // regardless of the total (RAW — see disapprovalFailure above).
     // Items without a level field (e.g. spell-like skills) are treated as level 1
     const level = (item ? item.system.level : 1) ?? 1
-    let success = roll.total >= (10 + level * 2)
+    let success = roll.total >= (10 + level * 2) && !disapprovalFailure
 
     // Handle spell failure based on casting mode
     if (castingMode === 'wizard') {
@@ -296,6 +314,7 @@ export async function processSpellCheck (actor, spellData) {
       result,
       crit,
       fumble,
+      disapprovalFailure,
       success,
       castingMode,
       patronTaint,

--- a/module/spell-result.js
+++ b/module/spell-result.js
@@ -12,6 +12,10 @@ class SpellResult {
    * @param {Object} messageOptions  Additional options for the ChatMessage object
    * @param {boolean} crit         The Spell Check was a nat 20
    * @param {boolean} fumble       The Spell Check was a nat 1
+   * @param {boolean} disapprovalFailure  Cleric natural roll fell inside the
+   *   disapproval range — an automatic failure per RAW even when the total
+   *   would otherwise succeed (#874). The card shows the failure row plus an
+   *   explanatory banner.
    * @param {Object} item          The spell item
    * @param {Object} patronTaint  The patron taint data object containing chance and message
    * @param {string} actionDiceChatLine  Multiple-action-dice "Action N of M"
@@ -22,6 +26,7 @@ class SpellResult {
     messageOptions = {},
     crit = false,
     fumble = false,
+    disapprovalFailure = false,
     item = undefined,
     manifestation: manifestationOverride = undefined,
     patronTaint = undefined,
@@ -91,6 +96,7 @@ class SpellResult {
       table: rollTable,
       crit,
       fumble,
+      disapprovalFailure,
       actionDiceChatLine
     })
 
@@ -151,6 +157,7 @@ class SpellResult {
     const resultId = event.target.parentElement.parentElement.getAttribute('data-result-id')
     const crit = event.target.parentElement.parentElement.getAttribute('data-crit') === 'true'
     const fumble = event.target.parentElement.parentElement.getAttribute('data-fumble') === 'true'
+    const disapprovalFailure = event.target.parentElement.parentElement.getAttribute('data-disapproval-failure') === 'true'
 
     // Lookup the appropriate table
     let rollTable
@@ -180,7 +187,8 @@ class SpellResult {
         rollHTML: rollTable.displayRoll ? await this.rolls[0].render() : null,
         table: rollTable,
         crit,
-        fumble
+        fumble,
+        disapprovalFailure
       })
 
       this.update({ content: newContent })

--- a/templates/chat-card-spell-result.html
+++ b/templates/chat-card-spell-result.html
@@ -34,9 +34,14 @@
       <h4 class="fumble">{{localize "DCC.SpellCheckFumble"}}</h4>
     </div>
   {{/if}}
+  {{#if disapprovalFailure}}
+    <div class="spell-check-mod">
+      <h4 class="fumble">{{localize "DCC.SpellCheckDisapprovalFailure"}}</h4>
+    </div>
+  {{/if}}
   <ol class="table-results">
     {{#each results}}
-      <li class="table-result" data-result-id="{{ this._id }}" data-crit="{{ ../crit }}" data-fumble="{{ ../fumble }}">
+      <li class="table-result" data-result-id="{{ this._id }}" data-crit="{{ ../crit }}" data-fumble="{{ ../fumble }}" data-disapproval-failure="{{ ../disapprovalFailure }}">
         <div class="result-range">
           {{#if (gt this.range.[0] 0)}}
             <i class="fas fa-sort-up spell-shift-down" data-tooltip="{{localize 'DCC.SpellShiftDown'}}"></i>


### PR DESCRIPTION
Fixes #874

## Summary
Per DCC RAW (core rulebook, cleric magic): *"any natural roll within that range automatically fails ... even though a roll of 13 would normally mean success on 1st-level spells."*

The chat highlight already painted the total red for these rolls — the die's `lowerThreshold` is the cleric's disapproval range — but the card body looked up the result row by the check **total**. A cleric whose disapproval range had grown (e.g. to 4) rolling a natural 4 (+8 = 12) got a red total next to the successful `12-13` manifestation row: a self-contradictory card that reads as "success shown in red" (the issue screenshot, reproduced live against Foundry to confirm the mechanism).

Changes to `processSpellCheck` (the sheet/item cast path):
- A cleric natural roll inside the disapproval range (2..range — natural 1 stays a fumble) is an automatic failure: the card shows the table's **failure row** (row-1 lookup, the same mechanism as a fumble) plus an explanatory banner ("Automatic failure! Natural roll within disapproval range.", localized to all 7 languages).
- A would-be crit swallowed by the range is not a crit.
- The no-table verdict emits the same failure banner.
- `success` in the `dcc.afterSpellCheckResult` payload is false for these casts, and the payload gains `disapprovalFailure`; the GM's result-shift arrows preserve the banner.
- Disapproval **side effects** (table roll + range bump) remain gated on the `automateClericDisapproval` setting, unchanged.

Companion lib fix for the adapter path (naked casts / spell-like skills): moonloch/dcc-core-lib#15 — flows into this repo at the next vendor sync.

## Test plan
- [x] 6 new unit tests (failure row + banner, boundary natural, wizard unaffected, crit suppression, no-table verdict, automation side effects on successful-total auto-failure)
- [x] 2 new E2E tests against live Foundry: in-range natural shows failure row + banner and hides the success row; range-1 control shows the success row with no banner
- [x] Full Playwright E2E suite: 285 passed
- [x] `npm run check` green (2405 unit tests, format, scss, compare-lang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)