### PR TITLE
vendor: sync dcc-core-lib to 0.13.3 (8636ef1)

### DIFF
--- a/module/__tests__/adapter-spell-check.test.js
+++ b/module/__tests__/adapter-spell-check.test.js
@@ -710,6 +710,28 @@ test('naked spell check on a Cleric actor uses cleric profile (D4 naked)', async
   expect(messageData.flags['dcc.spellResult']).toBeDefined()
 })
 
+test('naked cleric check with the natural inside the disapproval range emits the auto-failure verdict (#874)', async () => {
+  // The lib flags `disapprovalAutoFail` when the natural lands inside the
+  // disapproval range (an automatic failure per RAW even on a successful
+  // total); the naked-verdict HTML must say why instead of the generic
+  // failure line. Range 20 swallows the mock d20's fixed natural (10),
+  // making the outcome deterministic without touching the roller.
+  rollToMessageMock.mockClear()
+
+  // noinspection JSCheckFunctionSignatures
+  const actor = new DCCActor()
+  actor.system.class.patron = ''
+  actor.system.class.className = 'Cleric'
+  actor.system.details.sheetClass = 'Cleric'
+  actor.system.class.disapproval = 20
+
+  await actor.rollSpellCheck({ abilityId: 'per' })
+
+  const [messageData] = rollToMessageMock.mock.calls[0]
+  expect(messageData.flags['dcc.spellResult']).toContain('SpellCheckDisapprovalFailure')
+  expect(messageData.flags['dcc.libResult'].fumble).toBe(false)
+})
+
 test('naked spell check honors options.checkLabel as the chat flavor base (raw-check relabel)', async () => {
   // checkLabel override: a raw (no-item) spell check rolled from
   // a class cell can carry a label override so e.g. MCC's "Mutation

--- a/module/adapter/chat-renderer.mjs
+++ b/module/adapter/chat-renderer.mjs
@@ -646,6 +646,12 @@ function buildNakedSpellResultHtml (result) {
   if (result.fumble) {
     return `<p class="emote-alert fumble">${game.i18n.localize('DCC.SpellCheckFumbleNoTable')}</p>`
   }
+  // Natural roll inside the cleric's disapproval range — an automatic
+  // failure per RAW even when the total would succeed (#874). The lib
+  // already forced the tier to the failure row; say why.
+  if (result.disapprovalAutoFail) {
+    return `<p class="emote-alert fumble">${game.i18n.localize('DCC.SpellCheckDisapprovalFailure')}</p>`
+  }
   if (result.critical) {
     return `<p class="emote-alert critical">${game.i18n.localize('DCC.SpellCheckCritNoTable')}</p>`
   }

--- a/module/vendor/dcc-core-lib/VERSION.json
+++ b/module/vendor/dcc-core-lib/VERSION.json
@@ -1,7 +1,7 @@
 {
   "name": "@moonloch/dcc-core-lib",
   "version": "0.13.3",
-  "commit": "8b4d835da3ac09490519db471b65d2c1c68aec55",
+  "commit": "8636ef15b47c83b56280c1d1495d5b6f4cabd0dc",
   "dirty": false,
-  "syncedAt": "2026-07-28T23:10:34.058Z"
+  "syncedAt": "2026-08-03T21:58:00.924Z"
 }

--- a/module/vendor/dcc-core-lib/spells/cast.js
+++ b/module/vendor/dcc-core-lib/spells/cast.js
@@ -239,17 +239,29 @@ export function castSpell(input, options = {}, events) {
         }
     }
     // Determine critical/fumble
-    const critical = natural !== undefined && natural === getDieFaces(die);
     const fumble = natural !== undefined && natural === 1;
+    // DCC RAW (core rulebook, cleric magic): "any natural roll within that
+    // range automatically fails ... even though a roll of 13 would normally
+    // mean success on 1st-level spells." A natural roll inside the caster's
+    // disapproval range is an automatic failure regardless of the total.
+    // Natural 1 is already the fumble path; this covers 2..range — including
+    // a would-be crit when the range has grown to swallow the die's max face.
+    const disapprovalAutoFail = !fumble &&
+        input.casterProfile.usesDisapproval &&
+        input.disapprovalRange !== undefined &&
+        natural !== undefined &&
+        natural <= input.disapprovalRange;
+    const critical = !disapprovalAutoFail && natural !== undefined && natural === getDieFaces(die);
     // Natural 1 on a spell check is a fumble. Per DCC RAW (core rulebook,
     // spell-check chapter), a fumble eliminates modifiers — the total used
     // for result-table lookup is exactly 1, not `natural + modifiers`. This
     // is what allows patron-spell entries like Bobugbubilz's Tadpole
     // Transformation "roll 1: Lost, failure, and patron taint" to fire for
     // high-modifier wizards; without this rule the +5 INT mod would push
-    // the effective roll off the taint row.
+    // the effective roll off the taint row. A disapproval-range natural is
+    // forced to the failure row the same way.
     let total = rollResult.total;
-    if (fumble && total !== undefined) {
+    if ((fumble || disapprovalAutoFail) && total !== undefined) {
         total = 1;
     }
     // Determine result tier
@@ -300,6 +312,7 @@ export function castSpell(input, options = {}, events) {
         modifiers,
         critical,
         fumble,
+        disapprovalAutoFail,
         spellLost,
         corruptionTriggered,
         disapprovalIncrease,

--- a/module/vendor/dcc-core-lib/spells/spell-check.js
+++ b/module/vendor/dcc-core-lib/spells/spell-check.js
@@ -381,6 +381,7 @@ function createErrorResult(spellId, error) {
         modifiers: [],
         critical: false,
         fumble: false,
+        disapprovalAutoFail: false,
         spellLost: false,
         corruptionTriggered: false,
         disapprovalIncrease: 0,

--- a/module/vendor/dcc-core-lib/spells/spell-check.test.js
+++ b/module/vendor/dcc-core-lib/spells/spell-check.test.js
@@ -518,6 +518,65 @@ describe("calculateSpellCheck", () => {
         expect(result.disapprovalResult).toBeDefined();
         expect(result.newDisapprovalRange).toBe(3); // Increased from 2
     });
+    it("auto-fails a natural roll inside the disapproval range despite a successful total (dcc#874)", () => {
+        // DCC RAW: "any natural roll within that range automatically fails ...
+        // even though a roll of 13 would normally mean success on 1st-level
+        // spells." Natural 12 + 3 modifiers = 15 → success-minor by total, but
+        // range 12 swallows it: forced to the failure row (total 1).
+        const cleric = createTestCleric();
+        if (cleric.state.classState?.cleric) {
+            cleric.state.classState.cleric.disapprovalRange = 12;
+        }
+        const result = calculateSpellCheck(cleric, {
+            spell: clericSpell,
+            resultTable: mockSpellResultTable,
+            disapprovalTable: mockDisapprovalTable,
+        }, {
+            roller: (formula) => (formula === "1d4" ? 2 : 12),
+        });
+        expect(result.disapprovalAutoFail).toBe(true);
+        expect(result.fumble).toBe(false);
+        expect(result.total).toBe(1);
+        expect(result.tier).toBe("lost");
+        expect(result.disapprovalResult).toBeDefined();
+    });
+    it("keeps the total-based result when the natural roll is just outside the disapproval range", () => {
+        const cleric = createTestCleric();
+        if (cleric.state.classState?.cleric) {
+            cleric.state.classState.cleric.disapprovalRange = 4;
+        }
+        const result = calculateSpellCheck(cleric, {
+            spell: clericSpell,
+            resultTable: mockSpellResultTable,
+            disapprovalTable: mockDisapprovalTable,
+        }, {
+            roller: () => 5,
+        });
+        expect(result.disapprovalAutoFail).toBe(false);
+        expect(result.total).toBe(8); // natural 5 + 3 modifiers, untouched
+    });
+    it("suppresses a would-be crit when the disapproval range swallows the die's max face", () => {
+        const cleric = createTestCleric();
+        if (cleric.state.classState?.cleric) {
+            cleric.state.classState.cleric.disapprovalRange = 20;
+        }
+        const result = calculateSpellCheck(cleric, {
+            spell: clericSpell,
+            resultTable: mockSpellResultTable,
+            disapprovalTable: mockDisapprovalTable,
+        }, {
+            roller: (formula) => (formula === "1d4" ? 2 : 20),
+        });
+        expect(result.critical).toBe(false);
+        expect(result.disapprovalAutoFail).toBe(true);
+        expect(result.total).toBe(1);
+    });
+    it("never flags disapprovalAutoFail for wizard casts", () => {
+        const wizard = createTestWizard();
+        const result = calculateSpellCheck(wizard, { spell: testSpell, resultTable: mockSpellResultTable }, { roller: () => 4 });
+        expect(result.disapprovalAutoFail).toBe(false);
+        expect(result.total).toBe(9); // natural 4 + 5 modifiers, untouched
+    });
     it("includes spellburn in modifiers", () => {
         const wizard = createTestWizard();
         const result = calculateSpellCheck(wizard, {
@@ -720,34 +779,34 @@ describe("castSpell with optional spellbookEntry", () => {
 // =============================================================================
 describe("isSpellCheckSuccess", () => {
     it("returns true for success tiers", () => {
-        expect(isSpellCheckSuccess({ tier: "success", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(true);
-        expect(isSpellCheckSuccess({ tier: "success-minor", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(true);
-        expect(isSpellCheckSuccess({ tier: "success-major", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(true);
-        expect(isSpellCheckSuccess({ tier: "success-critical", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(true);
+        expect(isSpellCheckSuccess({ tier: "success", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, disapprovalAutoFail: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(true);
+        expect(isSpellCheckSuccess({ tier: "success-minor", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, disapprovalAutoFail: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(true);
+        expect(isSpellCheckSuccess({ tier: "success-major", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, disapprovalAutoFail: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(true);
+        expect(isSpellCheckSuccess({ tier: "success-critical", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, disapprovalAutoFail: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(true);
     });
     it("returns false for failure tiers", () => {
-        expect(isSpellCheckSuccess({ tier: "failure", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(false);
-        expect(isSpellCheckSuccess({ tier: "lost", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(false);
+        expect(isSpellCheckSuccess({ tier: "failure", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, disapprovalAutoFail: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(false);
+        expect(isSpellCheckSuccess({ tier: "lost", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, disapprovalAutoFail: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(false);
     });
     it("returns false for error results", () => {
-        expect(isSpellCheckSuccess({ error: "test error", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(false);
+        expect(isSpellCheckSuccess({ error: "test error", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, disapprovalAutoFail: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(false);
     });
 });
 describe("isSpellCheckFailure", () => {
     it("returns true for failure tiers", () => {
-        expect(isSpellCheckFailure({ tier: "failure", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(true);
-        expect(isSpellCheckFailure({ tier: "lost", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(true);
+        expect(isSpellCheckFailure({ tier: "failure", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, disapprovalAutoFail: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(true);
+        expect(isSpellCheckFailure({ tier: "lost", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, disapprovalAutoFail: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(true);
     });
     it("returns false for success tiers", () => {
-        expect(isSpellCheckFailure({ tier: "success", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(false);
+        expect(isSpellCheckFailure({ tier: "success", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, disapprovalAutoFail: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(false);
     });
     it("returns true for error results", () => {
-        expect(isSpellCheckFailure({ error: "test error", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(true);
+        expect(isSpellCheckFailure({ error: "test error", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, disapprovalAutoFail: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false })).toBe(true);
     });
 });
 describe("getSpellCheckSummary", () => {
     it("shows error message for errors", () => {
-        const result = { error: "Something went wrong", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false };
+        const result = { error: "Something went wrong", spellId: "test", die: "d20", formula: "", modifiers: [], critical: false, fumble: false, disapprovalAutoFail: false, spellLost: false, corruptionTriggered: false, disapprovalIncrease: 0, luckBurned: 0, patronTaintChecked: false, patronTaintAcquired: false };
         expect(getSpellCheckSummary(result)).toContain("Error: Something went wrong");
     });
     it("shows roll info", () => {
@@ -761,6 +820,7 @@ describe("getSpellCheckSummary", () => {
             tier: "success",
             critical: false,
             fumble: false,
+            disapprovalAutoFail: false,
             spellLost: false,
             corruptionTriggered: false,
             disapprovalIncrease: 0,
@@ -783,6 +843,7 @@ describe("getSpellCheckSummary", () => {
             tier: "success-critical",
             critical: true,
             fumble: false,
+            disapprovalAutoFail: false,
             spellLost: false,
             corruptionTriggered: false,
             disapprovalIncrease: 0,
@@ -803,6 +864,7 @@ describe("getSpellCheckSummary", () => {
             tier: "lost",
             critical: false,
             fumble: true,
+            disapprovalAutoFail: false,
             spellLost: true,
             corruptionTriggered: false,
             disapprovalIncrease: 0,

--- a/module/vendor/dcc-core-lib/types/spells.d.ts
+++ b/module/vendor/dcc-core-lib/types/spells.d.ts
@@ -465,6 +465,15 @@ export interface SpellCastResult {
     critical: boolean;
     /** Was this a fumble (natural 1)? */
     fumble: boolean;
+    /**
+     * Did the natural roll land inside the caster's disapproval range
+     * (excluding the natural-1 fumble)? Per DCC RAW (core rulebook, cleric
+     * magic) such a roll "automatically fails ... even though a roll of 13
+     * would normally mean success", so the result-table lookup is forced to
+     * the failure row exactly like a fumble. Only ever true for profiles
+     * with `usesDisapproval` when `disapprovalRange` was provided.
+     */
+    disapprovalAutoFail: boolean;
     /** Result tier (lost, failure, success levels) */
     tier?: ResultTier;
     /** Result text from table lookup */


### PR DESCRIPTION
Vendor sync bringing in moonloch/dcc-core-lib#15 (the lib half of #874).

## Summary
- Syncs `module/vendor/dcc-core-lib/` to lib `main` @ `8636ef1` via `npm run sync-core-lib`: a natural roll inside the cleric disapproval range now auto-fails the spell check inside the lib (result-table lookup forced to the failure row, would-be crit suppressed, new required `disapprovalAutoFail` field on `SpellCastResult`).
- Adapter alignment: the naked-cast verdict (`buildNakedSpellResultHtml`) now keys off `result.disapprovalAutoFail` and shows the explicit "Automatic failure! Natural roll within disapproval range." banner instead of the generic failure line — matching the legacy-path card from #884.

## Test plan
- [x] New adapter unit test: naked cleric check with the natural inside the disapproval range emits the auto-failure verdict and no fumble flag
- [x] Full unit suite green (2406 tests)
- [x] Lib suite green upstream (1503 tests) before the sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)