### PR TITLE
fix: cleric spell-like skills roll the lower action die as a later action

### DIFF
--- a/browser-tests/e2e/action-dice-tracker.spec.js
+++ b/browser-tests/e2e/action-dice-tracker.spec.js
@@ -531,6 +531,88 @@ test.describe('Action-dice combat tracker pips', () => {
     expect(result.lastMentionsD16).toBe(true)
   })
 
+  // #873: cleric spell-like skills (Lay on Hands / Turn Unholy / divine aid)
+  // ARE spell checks per RAW, so a later action must roll that slot's lower
+  // die. The skill-TABLE branch (`_skillTableViaAdapter`) previously spent
+  // the slot but rolled the primary die again. A world table named after the
+  // localized skill label routes the built-in cleric skill through the table
+  // branch; the second roll must use 1d14 and carry the action line on the
+  // spell-result card.
+  test('cleric Lay on Hands as the second action rolls the lower slot die (#873)', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const prevMaster = game.settings.get('dcc', 'multipleActionDice')
+      await game.settings.set('dcc', 'multipleActionDice', true)
+
+      let actor, combat, table
+      const createdMessageIds = []
+      try {
+        table = await RollTable.create({
+          name: game.i18n.localize('DCC.LayOnHands'),
+          formula: '1d20',
+          results: [{ type: CONST.TABLE_RESULT_TYPES.TEXT, range: [1, 33], description: 'e2e healing row', weight: 1 }]
+        })
+
+        actor = await Actor.create({
+          name: 'P873 Cleric Probe',
+          type: 'Player',
+          system: {
+            config: { actionDice: '1d20,1d14' },
+            class: { className: 'Cleric', disapproval: 1 },
+            details: { sheetClass: 'Cleric' }
+          }
+        })
+
+        combat = await Combat.create({})
+        await combat.createEmbeddedDocuments('Combatant', [{ actorId: actor.id }])
+        await combat.startCombat()
+        await combat.activate()
+        const combatant = combat.combatants.contents[0]
+
+        const msgIdsBefore = new Set(game.messages.contents.map(m => m.id))
+
+        // Action 1 → slot 0 (d20).
+        await actor.rollSkillCheck('layOnHands')
+        const flag1 = combatant.getFlag('dcc', 'actionDice')
+        const roll1 = game.messages.contents[game.messages.contents.length - 1]?.rolls?.[0]
+
+        // Action 2 → slot 1 (d14) — the fix under test.
+        await actor.rollSkillCheck('layOnHands')
+        const flag2 = combatant.getFlag('dcc', 'actionDice')
+        const lastMessage = game.messages.contents[game.messages.contents.length - 1]
+        const roll2 = lastMessage?.rolls?.[0]
+
+        for (const m of game.messages.contents) {
+          if (!msgIdsBefore.has(m.id)) createdMessageIds.push(m.id)
+        }
+
+        return {
+          flag1Spent: flag1?.spent,
+          flag2Spent: flag2?.spent,
+          roll1Faces: roll1?.dice?.[0]?.faces ?? null,
+          roll2Faces: roll2?.dice?.[0]?.faces ?? null,
+          lastHasLine: (lastMessage?.content || '').includes('dcc-action-dice-line'),
+          lastMentionsD14: (lastMessage?.content || '').includes('1d14')
+        }
+      } finally {
+        for (const id of createdMessageIds) {
+          const m = game.messages.get(id)
+          if (m) await m.delete()
+        }
+        if (combat) await combat.delete()
+        if (actor) await actor.delete()
+        if (table) await table.delete()
+        await game.settings.set('dcc', 'multipleActionDice', prevMaster)
+      }
+    })
+
+    expect(result.flag1Spent).toEqual([true, false])
+    expect(result.flag2Spent).toEqual([true, true])
+    expect(result.roll1Faces).toBe(20)
+    expect(result.roll2Faces).toBe(14)
+    expect(result.lastHasLine).toBe(true)
+    expect(result.lastMentionsD14).toBe(true)
+  })
+
   // Phase 3 (continued): the ability-check roll path spends an action die and
   // surfaces the "Action N of M" line. Drives the real `rollAbilityCheck`
   // dispatcher: a 2-die actor in combat rolls a Strength check twice — the

--- a/module/__tests__/actor-skill-table-action-dice.test.js
+++ b/module/__tests__/actor-skill-table-action-dice.test.js
@@ -1,0 +1,175 @@
+/* global game, dccRollCreateRollMock */
+/**
+ * Multiple-action-dice slot handling in the skill-table adapter branch
+ * (issue #873).
+ *
+ * Cleric spell-like skills (Lay on Hands, Turn Unholy, divine aid) ARE
+ * spell checks per RAW, so when they are a later action in the round they
+ * must roll that slot's (lower) action die. `_skillTableViaAdapter`
+ * previously planned + spent the slot but never overrode the die, so a
+ * cleric's second action rolled the primary d20 again.
+ *
+ * The action-dice tracker is mocked at the planning/spending seam so each
+ * test can hand the branch a deterministic plan; `slotRollFormula` and
+ * `formatActionDiceChatLine` stay real (pure helpers).
+ */
+
+import { expect, test, vi } from 'vitest'
+import '../__mocks__/foundry.js'
+import DCCActor from '../actor'
+import { planActionDie, reconcilePlannedActionDie, spendPlannedActionDie, actionDicePresetsFromPlan } from '../action-dice-tracker.mjs'
+
+// Mock the actor-level-change module
+vi.mock('../actor-level-change.js')
+
+vi.mock('../action-dice-tracker.mjs', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    planActionDie: vi.fn(() => null),
+    reconcilePlannedActionDie: vi.fn((plan) => plan),
+    spendPlannedActionDie: vi.fn(async () => null),
+    actionDicePresetsFromPlan: vi.fn(() => null)
+  }
+})
+
+const slot2Plan = () => ({
+  combatant: {},
+  round: 1,
+  choice: { index: 1, slot: { die: 'd14', use: 'any' } }
+})
+
+function makeClericActor ({ overrideDie = null } = {}) {
+  // noinspection JSCheckFunctionSignatures
+  const actor = new DCCActor()
+  actor.system.details.sheetClass = 'Cleric'
+  actor.system.class.disapproval = 1
+  if (overrideDie) {
+    actor.system.class.spellCheckOverrideDie = overrideDie
+  }
+  actor.system.skills.layOnHands = {
+    label: 'DCC.LayOnHands',
+    die: '1d20',
+    value: 0,
+    useDisapprovalRange: true
+  }
+  return actor
+}
+
+function installSpellResultMock () {
+  const addChatMessage = vi.fn()
+  const original = game.dcc.SpellResult
+  game.dcc.SpellResult = { addChatMessage }
+  return { addChatMessage, restore: () => { game.dcc.SpellResult = original } }
+}
+
+test('a later action-die slot overrides the skill-table die and lands in the chat card (#873)', async () => {
+  dccRollCreateRollMock.mockClear()
+  game.dcc.getSkillTable.mockResolvedValue({ getResultsForRoll: () => [{ text: 'Healing' }] })
+  const spellResult = installSpellResultMock()
+
+  planActionDie.mockReturnValueOnce(slot2Plan())
+  spendPlannedActionDie.mockResolvedValueOnce({ actionNumber: 2, count: 2, die: '1d14' })
+
+  const actor = makeClericActor()
+  await actor.rollSkillCheck('layOnHands')
+
+  // The Die term rolls the slot's die, not the primary d20.
+  const [terms] = dccRollCreateRollMock.mock.calls[0]
+  const dieTerm = terms.find(t => t.type === 'Die')
+  expect(dieTerm.formula).toBe('1d14')
+
+  // The "Action N of M" line rides on the spell-result card.
+  expect(spellResult.addChatMessage).toHaveBeenCalledTimes(1)
+  const opts = spellResult.addChatMessage.mock.calls[0][3]
+  expect(opts.actionDiceChatLine).toContain('ActionDiceChatLine')
+
+  spellResult.restore()
+  game.dcc.getSkillTable.mockResolvedValue(null)
+})
+
+test('the first slot (index 0) leaves the skill die unchanged', async () => {
+  dccRollCreateRollMock.mockClear()
+  game.dcc.getSkillTable.mockResolvedValue({ getResultsForRoll: () => [{ text: 'Healing' }] })
+  const spellResult = installSpellResultMock()
+
+  planActionDie.mockReturnValueOnce({
+    combatant: {},
+    round: 1,
+    choice: { index: 0, slot: { die: 'd20', use: 'any' } }
+  })
+
+  const actor = makeClericActor()
+  await actor.rollSkillCheck('layOnHands')
+
+  const [terms] = dccRollCreateRollMock.mock.calls[0]
+  expect(terms.find(t => t.type === 'Die').formula).toBe('1d20')
+
+  spellResult.restore()
+  game.dcc.getSkillTable.mockResolvedValue(null)
+})
+
+test('spellCheckOverrideDie pins the die against a later slot', async () => {
+  dccRollCreateRollMock.mockClear()
+  game.dcc.getSkillTable.mockResolvedValue({ getResultsForRoll: () => [{ text: 'Healing' }] })
+  const spellResult = installSpellResultMock()
+
+  planActionDie.mockReturnValueOnce(slot2Plan())
+
+  const actor = makeClericActor({ overrideDie: '1d16' })
+  await actor.rollSkillCheck('layOnHands')
+
+  const [terms] = dccRollCreateRollMock.mock.calls[0]
+  expect(terms.find(t => t.type === 'Die').formula).toBe('1d16')
+
+  spellResult.restore()
+  game.dcc.getSkillTable.mockResolvedValue(null)
+  delete actor.system.class.spellCheckOverrideDie
+})
+
+test('the plan is reconciled against the rolled die before spending', async () => {
+  dccRollCreateRollMock.mockClear()
+  reconcilePlannedActionDie.mockClear()
+  spendPlannedActionDie.mockClear()
+  game.dcc.getSkillTable.mockResolvedValue({ getResultsForRoll: () => [{ text: 'Healing' }] })
+  const spellResult = installSpellResultMock()
+
+  const plan = slot2Plan()
+  planActionDie.mockReturnValueOnce(plan)
+
+  const actor = makeClericActor()
+  await actor.rollSkillCheck('layOnHands')
+
+  // Reconcile runs with the planned die's faces as the no-intervention
+  // default, then the (possibly re-pointed) plan is spent.
+  expect(reconcilePlannedActionDie).toHaveBeenCalledWith(plan, undefined, {
+    action: 'check',
+    defaultFaces: 14
+  })
+  expect(spendPlannedActionDie).toHaveBeenCalledWith(plan)
+
+  spellResult.restore()
+  game.dcc.getSkillTable.mockResolvedValue(null)
+})
+
+test('slot presets replace the config-derived presets on the dialog die term', async () => {
+  dccRollCreateRollMock.mockClear()
+  game.dcc.getSkillTable.mockResolvedValue({ getResultsForRoll: () => [{ text: 'Healing' }] })
+  const spellResult = installSpellResultMock()
+
+  planActionDie.mockReturnValueOnce(slot2Plan())
+  const presets = [
+    { formula: '1d20', label: '1d20 — action die 1 (ready)' },
+    { formula: '1d14', label: '1d14 — action die 2 (ready)' }
+  ]
+  actionDicePresetsFromPlan.mockReturnValueOnce(presets)
+
+  const actor = makeClericActor()
+  await actor.rollSkillCheck('layOnHands')
+
+  const [terms] = dccRollCreateRollMock.mock.calls[0]
+  expect(terms.find(t => t.type === 'Die').presets).toBe(presets)
+
+  spellResult.restore()
+  game.dcc.getSkillTable.mockResolvedValue(null)
+})

--- a/module/actor/rolls-skill-mixin.mjs
+++ b/module/actor/rolls-skill-mixin.mjs
@@ -3,13 +3,13 @@
 import { ensurePlus } from '../utilities.js'
 import { rollCheck as libRollCheck } from '../vendor/dcc-core-lib/index.js'
 import { actorToCharacter } from '../adapter/character-accessors.mjs'
-import { renderSkillCheck } from '../adapter/chat-renderer.mjs'
+import { renderSkillCheck, actionDiceLineHtml } from '../adapter/chat-renderer.mjs'
 import { promptRollModifierDialog } from '../adapter/roll-dialog.mjs'
 import { normalizeLibDie } from '../adapter/attack-input.mjs'
 import { logDispatch, withRollErrorBoundary } from '../adapter/debug.mjs'
 import { applyForceCritToFoundryRoll } from './force-crit.mjs'
 import { emitAfterSpellCheckResult } from './spell-result-hook.mjs'
-import { planActionDie, spendPlannedActionDie, formatActionDiceChatLine } from '../action-dice-tracker.mjs'
+import { planActionDie, spendPlannedActionDie, formatActionDiceChatLine, reconcilePlannedActionDie, actionDicePresetsFromPlan, slotRollFormula } from '../action-dice-tracker.mjs'
 import { rollOrNullOnCancel } from '../roll-cancellation.mjs'
 
 /**
@@ -388,15 +388,32 @@ export const RollsSkillMixin = (Base) => class extends Base {
     const { skill, skillItem, abilityLabel } = resolved
 
     // Multiple action dice (Phase 3): a result-table skill (Turn Unholy, cleric
-    // Lay on Hands, spell-like skills) is an action, so plan + spend a die to
-    // advance the per-round budget. The die is NOT overridden — these roll a
-    // class-specific die (the cleric spell-check / disapproval die), not the
-    // generic action die, so the slot's size doesn't apply. No "Action N of M"
-    // chat line either: this path renders via `SpellResult.addChatMessage`,
-    // which builds its own card content. Off-path (`null`) ⇒ no spend.
-    const actionDicePlan = planActionDie(this, 'check')
+    // Lay on Hands, spell-like skills) is an action — plan a slot and spend it
+    // after the roll resolves. These ARE spell checks per RAW ("By making a
+    // spell check, a cleric may lay on hands..."), so a later slot rolls its
+    // own (lower) die (#873): the Die term is overridden with the slot's
+    // formula and the slot presets replace the config-derived ones, so the
+    // modifier dialog shows the die that will actually roll and can pick a
+    // different slot (mirrors the spell path, #857). A class that pins its
+    // check die via `spellCheckOverrideDie` keeps it regardless of slot.
+    // Off-path (`planActionDie` → null) ⇒ no override, no spend.
+    let actionDicePlan = planActionDie(this, 'check')
 
     const terms = this._buildSkillCheckRollTerms(skillId, resolved)
+    const dieTerm = terms.find(t => t.type === 'Die')
+    const diePinnedByClass = !!(skill.useDisapprovalRange && this.system.class.spellCheckOverrideDie)
+    if (dieTerm && !diePinnedByClass) {
+      if (actionDicePlan?.choice && actionDicePlan.choice.index > 0) {
+        dieTerm.formula = slotRollFormula(actionDicePlan.choice.slot)
+      }
+      const slotPresets = actionDicePresetsFromPlan(actionDicePlan, { action: 'check' })
+      if (slotPresets?.length) {
+        dieTerm.presets = slotPresets
+      }
+    }
+    // Faces of the die the roll uses with no player intervention, so the
+    // post-roll reconcile can tell a real slot choice from the default.
+    const defaultActionDieFaces = parseInt(String(dieTerm?.formula || '').match(/d(\d+)/)?.[1] || '') || null
 
     const roll = await rollOrNullOnCancel(game.dcc.DCCRoll.createRoll(terms, this.getRollData(), options))
     if (!roll) return // Dialog cancelled — post no skill-check card
@@ -411,9 +428,16 @@ export const RollsSkillMixin = (Base) => class extends Base {
       await roll.evaluate()
     }
 
-    // Spend the planned action die now the roll has resolved (the tracker pip
-    // flips on the flag update). No chat line — see the planning note above.
-    await spendPlannedActionDie(actionDicePlan)
+    // The player may have picked a different slot's die in the modifier
+    // dialog — re-point the plan at the die actually rolled before spending,
+    // so the spend lands on the chosen slot (mirrors the spell path). Then
+    // spend (the tracker pip flips on the flag update) and keep the
+    // "Action N of M" descriptor for the chat card.
+    actionDicePlan = reconcilePlannedActionDie(actionDicePlan, roll.dice?.[0]?.faces, {
+      action: 'check',
+      defaultFaces: defaultActionDieFaces
+    })
+    const actionDiceChatLine = formatActionDiceChatLine(await spendPlannedActionDie(actionDicePlan))
 
     const skillTable = await game.dcc.getSkillTable(skillId)
 
@@ -455,7 +479,7 @@ export const RollsSkillMixin = (Base) => class extends Base {
       // the chat card when present (#426).
       const skillManifestation = this.system.skills?.[skillId]?.manifestation
       await game.dcc.SpellResult.addChatMessage(roll, skillTable, tableResult, {
-        crit, fumble, item: skillItem, manifestation: skillManifestation
+        crit, fumble, item: skillItem, manifestation: skillManifestation, actionDiceChatLine
       })
     } else {
       // `useDisapprovalRange` without a table: emit the same
@@ -493,7 +517,7 @@ export const RollsSkillMixin = (Base) => class extends Base {
         flavor,
         flags,
         system: { spellId: skillItem?.id, skillId },
-        content: `${rollHTML}${spellResultHtml}`
+        content: `${rollHTML}${spellResultHtml}${actionDiceLineHtml(actionDiceChatLine)}`
       })
     }
 


### PR DESCRIPTION
Fixes #873

## Summary
- Lay on Hands, Turn Unholy, and divine aid are **spell checks** per RAW ("By making a spell check, a cleric may lay on hands…"), so as the second action of a round they must roll the second (lower) action die. The skill-table adapter branch (`_skillTableViaAdapter`) planned **and spent** the action-die slot but deliberately never overrode the die — so a cleric who cast a spell (spending slot 1) and then used Lay on Hands rolled the primary d20 again while the budget advanced.
- The branch now mirrors the spell path (#834/#857):
  - a later slot overrides the Die term with the slot's formula (a d20+d14 cleric's second Lay on Hands rolls 1d14)
  - the modifier dialog's die presets become the live slot presets, so the dialog shows and can pick real slots
  - the plan is reconciled against the die actually rolled before spending, so a dialog-chosen slot spends itself rather than the auto-pick
  - the "Action N of M" line now rides on the spell-result card (and the no-table fallback), matching spells
- `spellCheckOverrideDie` still pins the check die regardless of slot.

## Test plan
- [x] 5 new unit tests (slot-2 override + card line, slot-1 unchanged, spellCheckOverrideDie pin, reconcile-before-spend with correct defaultFaces, slot presets on the dialog term)
- [x] New E2E test against live Foundry: cleric with `1d20,1d14` in combat — first Lay on Hands rolls d20, second rolls d14 with the action line on the card, budget flags advance `[true,false] → [true,true]`
- [x] Full unit suite green (2411 tests)
- [x] Full Playwright E2E suite: 285 passed, 1 unrelated flake (enhanced-attack-card, passes standalone — known chat-message race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)