### PR TITLE
fix: clearing a currency field zeroes it instead of showing NaN

### DIFF
--- a/browser-tests/e2e/data-models.spec.js
+++ b/browser-tests/e2e/data-models.spec.js
@@ -131,6 +131,49 @@ test.describe('DCC TypeDataModels E2E Tests', () => {
       await page.click('button[data-action="yes"]')
     })
 
+    test('clearing a currency field zeroes it instead of storing null/NaN (#871)', async ({ page }) => {
+      // The currency NumberFields are non-nullable: DocumentSheetV2's submit
+      // pipeline cleans an emptied text input to null on a nullable field,
+      // which numberFormat then rendered as "NaN" in the wallet.
+      const result = await page.evaluate(async () => {
+        let actor
+        try {
+          actor = await Actor.create({ name: 'P871 Wallet Probe', type: 'Player', system: { currency: { gp: 25 } } })
+          const observed = {}
+
+          // Raw update paths a form submit can produce.
+          await actor.update({ 'system.currency.gp': '' })
+          observed.emptyString = actor.system.currency.gp
+          await actor.update({ 'system.currency.gp': 25 })
+          await actor.update({ 'system.currency.gp': null })
+          observed.nullValue = actor.system.currency.gp
+
+          // Full sheet round-trip: clear the input, submit, re-read the render.
+          await actor.update({ 'system.currency.gp': 25 })
+          const sheet = actor.sheet
+          await sheet.render(true)
+          await new Promise((resolve) => setTimeout(resolve, 600))
+          sheet.changeTab?.('equipment', 'sheet')
+          await new Promise((resolve) => setTimeout(resolve, 400))
+          const input = sheet.element.querySelector('input[name="system.currency.gp"]')
+          input.value = ''
+          input.dispatchEvent(new Event('change', { bubbles: true }))
+          await new Promise((resolve) => setTimeout(resolve, 800))
+          observed.stored = actor.system.currency.gp
+          observed.displayed = sheet.element.querySelector('input[name="system.currency.gp"]')?.value
+          await sheet.close()
+          return observed
+        } finally {
+          if (actor) await actor.delete().catch(() => {})
+        }
+      })
+
+      expect(result.emptyString).toBe(0)
+      expect(result.nullValue).toBe(0)
+      expect(result.stored).toBe(0)
+      expect(result.displayed).toBe('0')
+    })
+
     test('actor derived-stat computation survives actor/derived-stats-mixin.mjs extraction', async ({ page }) => {
       // Phase 7 (Appendix-A actor.js shrinkage): the four derived-stat computation
       // helpers (computeMeleeAndMissileAttackAndDamage / computeSavingThrows /

--- a/module/actor-sheet/items.mjs
+++ b/module/actor-sheet/items.mjs
@@ -208,22 +208,25 @@ export async function prepareItems (actor, {
     }
   }
 
-  // Combine any extra coins into a single item
+  // Combine any extra coins into a single item. `|| 0` guards every
+  // denomination: a legacy null in the wallet or an emptied item-value
+  // StringField parses to NaN, which would otherwise poison the whole
+  // wallet on merge (#871).
   if (coins.length) {
     const funds = {
-      pp: parseInt(actor.system.currency.pp),
-      ep: parseInt(actor.system.currency.ep),
-      gp: parseInt(actor.system.currency.gp),
-      sp: parseInt(actor.system.currency.sp),
-      cp: parseInt(actor.system.currency.cp)
+      pp: parseInt(actor.system.currency.pp) || 0,
+      ep: parseInt(actor.system.currency.ep) || 0,
+      gp: parseInt(actor.system.currency.gp) || 0,
+      sp: parseInt(actor.system.currency.sp) || 0,
+      cp: parseInt(actor.system.currency.cp) || 0
     }
     let needsUpdate = false
     for (const c of coins) {
-      funds.pp += parseInt(c.system.value.pp)
-      funds.ep += parseInt(c.system.value.ep)
-      funds.gp += parseInt(c.system.value.gp)
-      funds.sp += parseInt(c.system.value.sp)
-      funds.cp += parseInt(c.system.value.cp)
+      funds.pp += parseInt(c.system.value.pp) || 0
+      funds.ep += parseInt(c.system.value.ep) || 0
+      funds.gp += parseInt(c.system.value.gp) || 0
+      funds.sp += parseInt(c.system.value.sp) || 0
+      funds.cp += parseInt(c.system.value.cp) || 0
       await actor.deleteEmbeddedDocuments('Item', [c._id])
       needsUpdate = true
     }

--- a/module/data/fields/currency-field.mjs
+++ b/module/data/fields/currency-field.mjs
@@ -10,12 +10,17 @@ export class CurrencyField extends SchemaField {
    * @param {object} additionalFields - Additional fields to include
    */
   constructor (additionalFields = {}) {
+    // Non-nullable: DocumentSheetV2's submit pipeline cleans an emptied
+    // text input to `null` on a nullable NumberField, which then renders
+    // as "NaN" via {{numberFormat}} (#871). Non-nullable cleans '' / null
+    // to 0 instead, so clearing a currency field zeroes it.
+    const coin = () => new NumberField({ initial: 0, integer: true, min: 0, nullable: false, required: true })
     super({
-      pp: new NumberField({ initial: 0, integer: true, min: 0 }),
-      ep: new NumberField({ initial: 0, integer: true, min: 0 }),
-      gp: new NumberField({ initial: 0, integer: true, min: 0 }),
-      sp: new NumberField({ initial: 0, integer: true, min: 0 }),
-      cp: new NumberField({ initial: 0, integer: true, min: 0 }),
+      pp: coin(),
+      ep: coin(),
+      gp: coin(),
+      sp: coin(),
+      cp: coin(),
       ...additionalFields
     })
   }


### PR DESCRIPTION
Fixes #871

## Summary
- Traced live against Foundry: `DocumentSheetV2._prepareSubmitData` cleans an emptied text input to `null` on a nullable `NumberField`, and the `numberFormat` helper renders `null` as **NaN** in the wallet input.
- The five `CurrencyField` coins are now `nullable: false, required: true` (initial 0), so both `''` and `null` clean to **0** — clearing a currency field zeroes it. Verified the non-nullable clean behavior against live `foundry.data.fields` before adopting it. Garbage text (e.g. `abc`) now gets a proper "must be a number" validation warning instead of silently storing null.
- No migration needed: a legacy `null` already stored in a world self-heals to 0 when the data model initializes.
- Also hardens the coin-merge in `actor-sheet/items.mjs` with `|| 0` guards, so a legacy null wallet value or an emptied item-value `StringField` (`TreasureValueField` is string-typed for formulas) can't poison the whole wallet with NaN during a merge.

## Test plan
- [x] New E2E test: `''` and `null` updates both store 0, and the full sheet round-trip (clear the gp input → change event → re-render) stores 0 and displays `0`
- [x] Full `data-models.spec.js` green (13 tests)
- [x] Full unit suite green (2411 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)