### PR TITLE
fix: review follow-ups for the cleric skill-table and spell-check batch

### DIFF
--- a/module/__tests__/actor-skill-table-action-dice.test.js
+++ b/module/__tests__/actor-skill-table-action-dice.test.js
@@ -1,4 +1,4 @@
-/* global game, dccRollCreateRollMock */
+/* global game, dccRollCreateRollMock, rollToMessageMock */
 /**
  * Multiple-action-dice slot handling in the skill-table adapter branch
  * (issue #873).
@@ -39,7 +39,7 @@ const slot2Plan = () => ({
   choice: { index: 1, slot: { die: 'd14', use: 'any' } }
 })
 
-function makeClericActor ({ overrideDie = null } = {}) {
+function makeClericActor ({ overrideDie = null, skillDie = null } = {}) {
   // noinspection JSCheckFunctionSignatures
   const actor = new DCCActor()
   actor.system.details.sheetClass = 'Cleric'
@@ -47,11 +47,14 @@ function makeClericActor ({ overrideDie = null } = {}) {
   if (overrideDie) {
     actor.system.class.spellCheckOverrideDie = overrideDie
   }
+  // Like the real built-in cleric slots, no authored die by default — the
+  // resolver falls back to the actor's action die (dieSource 'actionDice'),
+  // which is the only provenance a later slot may replace.
   actor.system.skills.layOnHands = {
     label: 'DCC.LayOnHands',
-    die: '1d20',
     value: 0,
-    useDisapprovalRange: true
+    useDisapprovalRange: true,
+    ...(skillDie ? { die: skillDie } : {})
   }
   return actor
 }
@@ -147,6 +150,110 @@ test('the plan is reconciled against the rolled die before spending', async () =
     defaultFaces: 14
   })
   expect(spendPlannedActionDie).toHaveBeenCalledWith(plan)
+
+  spellResult.restore()
+  game.dcc.getSkillTable.mockResolvedValue(null)
+})
+
+test('an authored per-skill die is never replaced by a slot (dieSource guard)', async () => {
+  dccRollCreateRollMock.mockClear()
+  game.dcc.getSkillTable.mockResolvedValue({ getResultsForRoll: () => [{ text: 'Healing' }] })
+  const spellResult = installSpellResultMock()
+
+  planActionDie.mockReturnValueOnce(slot2Plan())
+
+  const actor = makeClericActor({ skillDie: '1d24' })
+  await actor.rollSkillCheck('layOnHands')
+
+  const [terms] = dccRollCreateRollMock.mock.calls[0]
+  expect(terms.find(t => t.type === 'Die').formula).toBe('1d24')
+
+  spellResult.restore()
+  game.dcc.getSkillTable.mockResolvedValue(null)
+})
+
+test('a cleric natural inside the disapproval range draws the failure row with the banner (#874 parity)', async () => {
+  dccRollCreateRollMock.mockClear()
+  const getResultsForRoll = vi.fn(() => [{ text: 'row' }])
+  game.dcc.getSkillTable.mockResolvedValue({ getResultsForRoll })
+  const spellResult = installSpellResultMock()
+  const callAllSpy = vi.spyOn(globalThis.Hooks, 'callAll')
+
+  // The mock d20 rolls a fixed natural 10 — range 10 swallows it.
+  const actor = makeClericActor()
+  actor.system.class.disapproval = 10
+  await actor.rollSkillCheck('layOnHands')
+
+  expect(getResultsForRoll).toHaveBeenLastCalledWith(1)
+  const opts = spellResult.addChatMessage.mock.calls[0][3]
+  expect(opts.disapprovalFailure).toBe(true)
+  expect(opts.fumble).toBe(false)
+
+  // Hook payload parity with processSpellCheck (#874)
+  const hookCall = callAllSpy.mock.calls.find(c => c[0] === 'dcc.afterSpellCheckResult')
+  expect(hookCall[2].disapprovalFailure).toBe(true)
+  expect(hookCall[2].success).toBe(false)
+
+  callAllSpy.mockRestore()
+  spellResult.restore()
+  game.dcc.getSkillTable.mockResolvedValue(null)
+})
+
+test('the no-table branch emits the disapproval auto-failure banner', async () => {
+  dccRollCreateRollMock.mockClear()
+  rollToMessageMock.mockClear()
+  game.dcc.getSkillTable.mockResolvedValue(null)
+
+  const actor = makeClericActor()
+  actor.system.class.disapproval = 10
+  await actor.rollSkillCheck('layOnHands')
+
+  const [messageData] = rollToMessageMock.mock.calls[0]
+  expect(messageData.content).toContain('SpellCheckDisapprovalFailure')
+})
+
+test('crit detection follows the rolled die faces, not a hardcoded 20', async () => {
+  const getResultsForRoll = vi.fn(() => [{ text: 'row' }])
+  game.dcc.getSkillTable.mockResolvedValue({ getResultsForRoll })
+  const spellResult = installSpellResultMock()
+
+  // A d10 slot whose natural 10 is its max face — must crit (lookup total+level)
+  const customRoll = {
+    _evaluated: true,
+    _total: 10,
+    _formula: '1d10',
+    get total () { return this._total },
+    dice: [{ total: 10, faces: 10, options: {} }],
+    terms: [{ results: [{ result: 10 }], _total: 10 }],
+    evaluate: vi.fn(),
+    render: vi.fn(async () => ''),
+    toMessage: vi.fn(async () => ({}))
+  }
+  dccRollCreateRollMock.mockImplementationOnce(() => customRoll)
+
+  // The crit branch appends +level terms via foundry.dice.terms — stub them
+  const savedFoundry = globalThis.foundry
+  globalThis.foundry = {
+    ...savedFoundry,
+    dice: {
+      ...(savedFoundry?.dice || {}),
+      terms: {
+        OperatorTerm: class { constructor (o) { Object.assign(this, o) } },
+        NumericTerm: class { constructor (o) { Object.assign(this, o) } }
+      }
+    }
+  }
+
+  const actor = makeClericActor()
+  actor.type = 'Player' // crit detection is Player-only
+  actor.system.details.xp = { value: 0 } // getRollData reads this for Players
+  await actor.rollSkillCheck('layOnHands')
+  globalThis.foundry = savedFoundry
+
+  // Crit lookup is roll.total + level (level 0 in the mock actor ⇒ 10),
+  // and the crit flag reaches the card.
+  const opts = spellResult.addChatMessage.mock.calls[0][3]
+  expect(opts.crit).toBe(true)
 
   spellResult.restore()
   game.dcc.getSkillTable.mockResolvedValue(null)

--- a/module/__tests__/spell-result-hook.test.js
+++ b/module/__tests__/spell-result-hook.test.js
@@ -66,6 +66,7 @@ describe('emitAfterSpellCheckResult', () => {
       result: null,
       crit: false,
       fumble: false,
+      disapprovalFailure: false,
       success: true,
       castingMode: 'wizard',
       patronTaint: null,

--- a/module/action-dice-tracker.mjs
+++ b/module/action-dice-tracker.mjs
@@ -406,7 +406,7 @@ function penalizedSlotFormula (slot, penalty) {
 
 /** The die faces of a formula's primary die (`'1d16+2'` ⇒ 16), or `null`. */
 function formulaFaces (formula) {
-  const faces = parseInt(String(formula ?? '').match(/d(\d+)/)?.[1] || '')
+  const faces = parseInt(String(formula ?? '').match(/d(\d+)/i)?.[1] || '')
   return Number.isInteger(faces) ? faces : null
 }
 

--- a/module/actor/force-crit.mjs
+++ b/module/actor/force-crit.mjs
@@ -26,11 +26,16 @@
  */
 export function applyForceCritToFoundryRoll (foundryRoll, natural, options) {
   if (options?.forceCrit && natural !== 1) {
+    // Land on the rolled die's own max face, not a literal 20 — a smaller
+    // action die (multiple-action-dice slot, spells-only die) can't roll a
+    // 20, and the faces-aware crit detection keys off the die max. Matches
+    // the forceCrit rule in processSpellCheck and the design doc.
+    const critFace = foundryRoll.dice?.[0]?.faces || 20
     const original = natural
-    foundryRoll.terms[0].results[0].result = 20
-    foundryRoll.terms[0]._total = 20
-    foundryRoll._total += 20 - original
-    return 20
+    foundryRoll.terms[0].results[0].result = critFace
+    foundryRoll.terms[0]._total = critFace
+    foundryRoll._total += critFace - original
+    return critFace
   }
   if (options?.forceFumble && natural !== 1) {
     const original = natural

--- a/module/actor/rolls-skill-mixin.mjs
+++ b/module/actor/rolls-skill-mixin.mjs
@@ -163,10 +163,18 @@ export const RollsSkillMixin = (Base) => class extends Base {
 
     let die = (skill?.die && skill.die.trim()) ? skill.die : null
     let hasDie = !!die
+    // Provenance of the resolved die — 'skill' (authored on the skill),
+    // 'classOverride' (spellCheckOverrideDie), or 'actionDice' (inherited
+    // from the actor's action die). Only the 'actionDice' case may be
+    // stepped down to a later action-die slot: authored dice are deliberate
+    // choices the multiple-action-dice rules leave alone (#857 rule,
+    // docs/dev/MULTIPLE_ACTION_DICE_DESIGN.md).
+    let dieSource = hasDie ? 'skill' : null
 
     if (skill?.useDisapprovalRange && this.system.class.spellCheckOverrideDie) {
       die = this.system.class.spellCheckOverrideDie
       hasDie = true
+      dieSource = 'classOverride'
     }
 
     // Fall back to the actor's action die when no per-skill die is
@@ -194,6 +202,7 @@ export const RollsSkillMixin = (Base) => class extends Base {
       die = this.system.attributes.actionDice.value ||
         this.getActionDice()[0].formula || '1d20'
       hasDie = true
+      dieSource = 'actionDice'
     }
 
     const abilityId = skill?.ability && skill.ability.trim() ? skill.ability : null
@@ -211,7 +220,8 @@ export const RollsSkillMixin = (Base) => class extends Base {
       abilityLabel,
       abilityMod,
       die,
-      hasDie
+      hasDie,
+      dieSource
     }
   }
 
@@ -401,8 +411,10 @@ export const RollsSkillMixin = (Base) => class extends Base {
 
     const terms = this._buildSkillCheckRollTerms(skillId, resolved)
     const dieTerm = terms.find(t => t.type === 'Die')
-    const diePinnedByClass = !!(skill.useDisapprovalRange && this.system.class.spellCheckOverrideDie)
-    if (dieTerm && !diePinnedByClass) {
+    // Only an action-die-derived die steps down to a later slot. A die
+    // authored on the skill itself or pinned via `spellCheckOverrideDie`
+    // is a deliberate choice the slot must not replace (#857 rule).
+    if (dieTerm && resolved.dieSource === 'actionDice') {
       if (actionDicePlan?.choice && actionDicePlan.choice.index > 0) {
         dieTerm.formula = slotRollFormula(actionDicePlan.choice.slot)
       }
@@ -413,7 +425,9 @@ export const RollsSkillMixin = (Base) => class extends Base {
     }
     // Faces of the die the roll uses with no player intervention, so the
     // post-roll reconcile can tell a real slot choice from the default.
-    const defaultActionDieFaces = parseInt(String(dieTerm?.formula || '').match(/d(\d+)/)?.[1] || '') || null
+    // Case-insensitive: a hand-authored '1D14' must not silently disable
+    // the reconcile guard.
+    const defaultActionDieFaces = parseInt(String(dieTerm?.formula || '').match(/d(\d+)/i)?.[1] || '') || null
 
     const roll = await rollOrNullOnCancel(game.dcc.DCCRoll.createRoll(terms, this.getRollData(), options))
     if (!roll) return // Dialog cancelled — post no skill-check card
@@ -451,8 +465,32 @@ export const RollsSkillMixin = (Base) => class extends Base {
     )
 
     const fumble = naturalRoll === 1
-    const crit = naturalRoll === 20 && this.type === 'Player'
+    // Faces-aware crit: a later action-die slot can hand this branch a
+    // smaller die (#873), on which a natural 20 is unrollable — mirror the
+    // faces-aware detection in processSpellCheck / the lib's castSpell.
+    const dieFaces = roll.dice[0]?.faces || 20
+    let crit = naturalRoll === dieFaces && this.type === 'Player'
     const actorLevel = parseInt(this.system.details?.level?.value || 0, 10) || 0
+
+    // Casting mode + disapproval auto-failure, resolved BEFORE the table
+    // lookup so the card agrees with the mechanics. Spell-like skills carry
+    // an explicit castingMode (#375); built-in cleric abilities (Lay on
+    // Hands, Turn Unholy, Divine Aid) have none and fall back to cleric on
+    // a cleric actor — same default the failure-automation block below uses.
+    let castingMode = skill.castingMode
+    if (!castingMode && !skillItem && this.classId === 'cleric') {
+      castingMode = 'cleric'
+    }
+
+    // DCC RAW: any natural roll within a cleric's disapproval range
+    // automatically fails, even when the total would succeed (#874). These
+    // skill-table checks ARE spell checks per RAW, so the same rule applies:
+    // failure row, banner, no crit. Natural 1 stays a fumble.
+    const disapprovalRange = parseInt(this.system.class?.disapproval, 10) || 1
+    const disapprovalFailure = castingMode === 'cleric' && !fumble && naturalRoll <= disapprovalRange
+    if (disapprovalFailure) {
+      crit = false
+    }
 
     const flavor = `${game.i18n.localize(skill.label)}${abilityLabel}`
 
@@ -461,7 +499,7 @@ export const RollsSkillMixin = (Base) => class extends Base {
     let tableResult = null
 
     if (skillTable) {
-      if (fumble) {
+      if (fumble || disapprovalFailure) {
         tableResult = skillTable.getResultsForRoll(1)
       } else if (crit) {
         const critRoll = roll.total + actorLevel
@@ -479,7 +517,7 @@ export const RollsSkillMixin = (Base) => class extends Base {
       // the chat card when present (#426).
       const skillManifestation = this.system.skills?.[skillId]?.manifestation
       await game.dcc.SpellResult.addChatMessage(roll, skillTable, tableResult, {
-        crit, fumble, item: skillItem, manifestation: skillManifestation, actionDiceChatLine
+        crit, fumble, disapprovalFailure, item: skillItem, manifestation: skillManifestation, actionDiceChatLine
       })
     } else {
       // `useDisapprovalRange` without a table: emit the same
@@ -491,6 +529,8 @@ export const RollsSkillMixin = (Base) => class extends Base {
       let spellResultHtml
       if (fumble) {
         spellResultHtml = `<p class="emote-alert fumble">${game.i18n.localize('DCC.SpellCheckFumbleNoTable')}</p>`
+      } else if (disapprovalFailure) {
+        spellResultHtml = `<p class="emote-alert fumble">${game.i18n.localize('DCC.SpellCheckDisapprovalFailure')}</p>`
       } else if (crit) {
         spellResultHtml = `<p class="emote-alert critical">${game.i18n.localize('DCC.SpellCheckCritNoTable')}</p>`
       } else if (noTableSuccess) {
@@ -527,26 +567,20 @@ export const RollsSkillMixin = (Base) => class extends Base {
     // the success threshold uses level 1 (10 + 1 * 2), matching
     // processSpellCheck.
     //
-    // Built-in cleric abilities (Lay on Hands, Turn Unholy, Divine Aid) have
-    // no backing item and no castingMode of their own, so they fall back to
-    // the cleric casting mode when the actor is a cleric — restoring the
-    // legacy sheet-class default from `processSpellCheck` (see
-    // spell-check-processor.mjs:237-241) that this adapter path dropped:
-    // without it a failed built-in ability drew the result table but never
-    // incremented `system.class.disapproval`. Legacy's *wizard* default for
-    // item-less skills on non-clerics is deliberately not restored — it
-    // could only ever call `loseSpell(undefined)`.
-    let castingMode = skill.castingMode
-    if (!castingMode && !skillItem && this.classId === 'cleric') {
-      castingMode = 'cleric'
-    }
+    // `castingMode` was resolved before the table lookup (the disapproval
+    // auto-failure needs it there); the automation below reuses it.
+    // Legacy's *wizard* default for item-less skills on non-clerics is
+    // deliberately not restored — it could only ever call
+    // `loseSpell(undefined)`.
 
     // Skill items carry no level field, so the threshold is level 1 (10 + 2).
-    // Hoisted out of the casting-mode branches because the
-    // `dcc.afterSpellCheckResult` payload below reports `success` for every
-    // skill-table check, not just spell-like ones.
+    // A disapproval-range natural is an automatic failure regardless of the
+    // total (RAW — see disapprovalFailure above). Hoisted out of the
+    // casting-mode branches because the `dcc.afterSpellCheckResult` payload
+    // below reports `success` for every skill-table check, not just
+    // spell-like ones.
     const spellLikeLevel = skillItem?.system?.level ?? 1
-    let success = roll.total >= (10 + spellLikeLevel * 2)
+    let success = roll.total >= (10 + spellLikeLevel * 2) && !disapprovalFailure
 
     if (castingMode === 'wizard') {
       if (game.settings.get('dcc', 'automateWizardSpellLoss') && !success) {
@@ -554,9 +588,9 @@ export const RollsSkillMixin = (Base) => class extends Base {
       }
     } else if (castingMode === 'cleric') {
       if (game.settings.get('dcc', 'automateClericDisapproval')) {
-        // A natural roll inside the disapproval range triggers disapproval and
-        // is an automatic failure
-        if (naturalRoll <= this.system.class.disapproval) {
+        // A natural roll inside the disapproval range triggers disapproval
+        // (nat 1 fumbles land here too — 1 is always inside the range)
+        if (naturalRoll <= disapprovalRange) {
           await this.rollDisapproval(naturalRoll)
           success = false
         }
@@ -581,6 +615,7 @@ export const RollsSkillMixin = (Base) => class extends Base {
         total: roll.total,
         critical: crit,
         fumble,
+        disapprovalAutoFail: disapprovalFailure,
         tier: success ? 'success' : 'failure'
       },
       tableResult,

--- a/module/actor/rolls-spell-mixin.mjs
+++ b/module/actor/rolls-spell-mixin.mjs
@@ -1003,7 +1003,12 @@ export const RollsSpellMixin = (Base) => class extends Base {
       events
     )
 
-    warnIfDivergent('rollSpellCheck', foundryRoll.total, result.total, { actor: this.name, spell: spellItem?.name })
+    // The lib deliberately forces `total = 1` for fumbles and disapproval
+    // auto-failures (the failure-row lookup rule), so the Foundry roll's
+    // arithmetic total legitimately diverges there — not a formula drift.
+    if (!result.fumble && !result.disapprovalAutoFail) {
+      warnIfDivergent('rollSpellCheck', foundryRoll.total, result.total, { actor: this.name, spell: spellItem?.name })
+    }
 
     const flavor = this._buildSpellCheckFlavor(spellItem, options, profile)
     const actionDiceChatLine = await this._spendActionDiceLine(options, foundryRoll)

--- a/module/actor/spell-result-hook.mjs
+++ b/module/actor/spell-result-hook.mjs
@@ -66,6 +66,10 @@ export function emitAfterSpellCheckResult (actor, {
     result: tableResult ?? null,
     crit: !!result?.critical,
     fumble: !!result?.fumble,
+    // Parity with processSpellCheck's payload (#874): the lib result carries
+    // `disapprovalAutoFail`; the skill-table terminal's hand-built descriptor
+    // sets it from its own disapproval-failure verdict.
+    disapprovalFailure: !!result?.disapprovalAutoFail,
     success: !!(result?.tier && SUCCESS_TIERS.includes(result.tier)),
     castingMode,
     patronTaint: null,

--- a/module/adapter/chat-renderer.mjs
+++ b/module/adapter/chat-renderer.mjs
@@ -601,8 +601,15 @@ export async function renderSpellCheck ({
   // a result table. Item-bound casts (with a result table) skip this
   // and let the lib's `result.resultText` surface through the
   // downstream SpellResult.addChatMessage path that the item-aware
-  // dispatchers use.
-  const nakedHtml = !spellItem ? buildNakedSpellResultHtml(result) : null
+  // dispatchers use — EXCEPT the disapproval auto-failure banner (#874),
+  // which explains a forced failure row and must show on item-bound
+  // casts too (a macro-invoked cleric spell reads the same as the sheet).
+  let nakedHtml = null
+  if (!spellItem) {
+    nakedHtml = buildNakedSpellResultHtml(result)
+  } else if (result.disapprovalAutoFail) {
+    nakedHtml = `<p class="emote-alert fumble">${game.i18n.localize('DCC.SpellCheckDisapprovalFailure')}</p>`
+  }
 
   const toMessagePayload = {
     speaker: ChatMessage.getSpeaker({ actor }),

--- a/module/macros.mjs
+++ b/module/macros.mjs
@@ -266,7 +266,7 @@ export function _createDCCApplyDisapprovalMacro (data) {
 
   // Create the macro command
   return {
-    name: game.i18n.format('DCC.ApplyDisapprovalMacroName'),
+    name: game.i18n.localize('DCC.ApplyDisapprovalMacroName'),
     command: `const _actor = game.dcc.getMacroActor('${data.actorId}'); if (_actor) { _actor.applyDisapproval() }`,
     img: EntityImages.imageForMacro('applyDisapproval')
   }
@@ -282,7 +282,7 @@ export function _createDCCRollDisapprovalMacro (data) {
 
   // Create the macro command
   return {
-    name: game.i18n.format('DCC.RollDisapprovalMacroName'),
+    name: game.i18n.localize('DCC.RollDisapprovalMacroName'),
     command: `const _actor = game.dcc.getMacroActor('${data.actorId}'); if (_actor) { _actor.rollDisapproval() }`,
     img: EntityImages.imageForMacro('rollDisapproval')
   }

--- a/module/spell-check-processor.mjs
+++ b/module/spell-check-processor.mjs
@@ -135,7 +135,10 @@ export async function processSpellCheck (actor, spellData) {
   // the failure automation both key off it. An explicit override from the
   // caller wins, then the item's configuration, defaulting to wizard; cleric
   // sheets fall back to cleric for item-less checks (issue #375).
-  let castingMode = spellData.castingMode || (item ? item.system.config.castingMode : 'wizard')
+  // Optional-chained: this is a stable extension API and runs before the
+  // try/catch — a sibling module's item-like object without `system.config`
+  // must not throw out of the call.
+  let castingMode = spellData.castingMode || (item ? item.system?.config?.castingMode : 'wizard')
   if (!spellData.castingMode && !item && actor.classId === 'cleric') {
     castingMode = 'cleric'
   }
@@ -278,7 +281,7 @@ export async function processSpellCheck (actor, spellData) {
       const automate = game.settings.get('dcc', 'automateClericDisapproval')
 
       // Check if our natural roll was inside the disapproval range
-      if (automate && naturalRoll <= actor.system.class.disapproval) {
+      if (automate && naturalRoll <= disapprovalRange) {
         // Trigger disapproval
         await actor.rollDisapproval(naturalRoll)
 

--- a/module/spell-result.js
+++ b/module/spell-result.js
@@ -179,6 +179,9 @@ class SpellResult {
       const entry = rollTable.results.get(resultId)
       const newResultRoll = (direction > 0) ? (entry.range[1]) + 1 : (entry.range[0] - 1)
       const newResult = rollTable.getResultsForRoll(newResultRoll)[0]
+      // Carry the "Action N of M" line through the re-render — it lives in
+      // the card HTML, not the flags, so recover it from the current content.
+      const actionDiceChatLine = (this.content || '').match(/<div class="dcc-action-dice-line">([^<]*)<\/div>/)?.[1] ?? ''
       const newContent = await foundry.applications.handlebars.renderTemplate('systems/dcc/templates/chat-card-spell-result.html', {
         description: await TextEditor.enrichHTML(rollTable.description),
         results: [newResult].map(r => {
@@ -188,7 +191,8 @@ class SpellResult {
         table: rollTable,
         crit,
         fumble,
-        disapprovalFailure
+        disapprovalFailure,
+        actionDiceChatLine
       })
 
       this.update({ content: newContent })


### PR DESCRIPTION
Consolidated fixes from a three-agent post-merge review of today's batch (#879 #880 #883 #884 #885 #886). All confirmed findings addressed:

## High
- **Skill-table #874 parity**: `_skillTableViaAdapter` (Lay on Hands / Turn Unholy / divine aid) was the last path where a cleric natural inside the disapproval range drew the success row next to the red total. It now mirrors `processSpellCheck`: failure-row lookup, localized banner, crit suppression, unconditional `success = false`, and `disapprovalFailure` on the hook payload.
- **Faces-aware crit in the skill-table branch**: #886 made smaller slot dice reachable there, but crit detection was hardcoded to natural 20 — unrollable on a d16/d14 second action. Now keyed to the rolled die's max face, matching `processSpellCheck` and the lib. `applyForceCritToFoundryRoll` likewise lands on the die's max face instead of stamping a literal 20 onto a smaller die.

## Medium
- **Authored-die guard**: the slot override now only replaces an action-die-derived die (new `dieSource` provenance from `_resolveSkillCheck`) — a die authored on a spell-like skill item or pinned via `spellCheckOverrideDie` is never stepped down (the #857 rule from the design doc).
- **Hook parity**: `emitAfterSpellCheckResult` gains `disapprovalFailure`, so a single listener works across both cast paths.
- **Macro-path banner**: item-bound adapter casts (dragged-spell macros) now show the disapproval auto-failure banner like the sheet path.

## Low
- GM result-shift arrows preserve the "Action N of M" line through re-renders.
- `warnIfDivergent` no longer console-warns on fumbles / disapproval auto-failures (the lib deliberately forces total 1 there).
- Die-faces regexes are case-insensitive; `processSpellCheck` reads `castingMode` with optional chaining (stable API hardening) and reuses the parsed disapproval range; macro-name i18n uses `localize`.

## Test plan
- [x] 4 new unit tests (skill-table disapproval failure + hook payload, no-table banner, faces-aware crit, authored-die pin) and updated harnesses
- [x] Full unit suite green (2415 tests)
- [x] Full Playwright E2E suite: 286 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)