### PR TITLE
feat: vision from all owned tokens while one is controlled (#872)

### DIFF
--- a/browser-tests/e2e/token-vision.spec.js
+++ b/browser-tests/e2e/token-vision.spec.js
@@ -1,0 +1,151 @@
+/* eslint-disable no-undef -- Browser globals used in page.evaluate */
+const { expect, createSessionTest } = require('./fixtures')
+
+/**
+ * Owned-token vision (issue #872): while the `dcc.ownedTokenVision` world
+ * setting is on (the default), a non-GM player's owned sighted tokens keep
+ * providing vision even while another token is controlled — the case core
+ * suppresses (an uncontrolled token is only a vision source when no sighted
+ * token is controlled), which made a funnel character that walked out of
+ * the controlled token's sight invisible and unclickable.
+ *
+ * The suite runs as Gamemaster and the rule is non-GM only, so the
+ * behavioral tests spoof `game.user.isGM` to false as an instance property
+ * for the duration of a single evaluate (restored in a finally), with an
+ * explicit OWNER ownership entry so permission checks don't depend on GM
+ * status.
+ */
+
+const test = createSessionTest()
+
+/** Create a probe scene with token vision plus two owned, sighted tokens. */
+async function setupTokens (page) {
+  return page.evaluate(async () => {
+    const prevSceneId = game.canvas.scene?.id ?? null
+    const scene = await Scene.create({ name: 'DCC TokenVision Probe', width: 4000, height: 3000, tokenVision: true, grid: { type: 1, size: 100, distance: 5, units: 'ft' } })
+    // view() is refused while a previous scene switch is still loading, and
+    // control() no-ops while the canvas is loading — retry until the probe
+    // scene is actually viewed and ready
+    const viewDeadline = Date.now() + 15000
+    while (Date.now() < viewDeadline && !(game.canvas.ready && game.canvas.scene?.id === scene.id)) {
+      if (game.canvas.scene?.id !== scene.id) {
+        try { await scene.view() } catch { /* still loading — retry */ }
+      }
+      await new Promise(resolve => setTimeout(resolve, 200))
+    }
+
+    const makeActor = name => Actor.create({
+      name,
+      type: 'Player',
+      ownership: { [game.user.id]: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER },
+      prototypeToken: { actorLink: true, sight: { enabled: true } }
+    })
+    const controller = await makeActor('DCC TokenVision Controller')
+    const companion = await makeActor('DCC TokenVision Companion')
+
+    const [controllerToken, companionToken] = await scene.createEmbeddedDocuments('Token', [
+      { name: 'Controller', actorId: controller.id, actorLink: true, x: 500, y: 500, sight: { enabled: true } },
+      { name: 'Companion', actorId: companion.id, actorLink: true, x: 2500, y: 2500, sight: { enabled: true } }
+    ])
+    const deadline = Date.now() + 3000
+    while (Date.now() < deadline && !(game.canvas.tokens.get(controllerToken.id) && game.canvas.tokens.get(companionToken.id))) {
+      await new Promise(resolve => setTimeout(resolve, 50))
+    }
+
+    return {
+      prevSceneId,
+      sceneId: scene.id,
+      actorIds: [controller.id, companion.id],
+      controllerTokenId: controllerToken.id,
+      companionTokenId: companionToken.id
+    }
+  })
+}
+
+/** Restore the setting, view the previous scene, and delete the probe docs. */
+async function cleanupTokens (page, setup) {
+  await page.evaluate(async ({ prevSceneId, sceneId, actorIds }) => {
+    await game.settings.set('dcc', 'ownedTokenVision', true)
+    game.canvas.tokens.releaseAll()
+    // Scene switches are refused while the canvas is still loading
+    const deadline = Date.now() + 10000
+    while (Date.now() < deadline && !game.canvas.ready) {
+      await new Promise(resolve => setTimeout(resolve, 100))
+    }
+    if (prevSceneId) await game.scenes.get(prevSceneId)?.view()
+    await game.scenes.get(sceneId)?.delete()
+    for (const id of actorIds) await game.actors.get(id)?.delete()
+  }, setup)
+}
+
+/**
+ * Control the controller token, then evaluate the companion's vision-source
+ * status as a spoofed non-GM under both the DCC override and core's rule.
+ */
+async function probeVisionSources (page, setup) {
+  return page.evaluate(async ({ controllerTokenId, companionTokenId }) => {
+    const controller = game.canvas.tokens.get(controllerTokenId)
+    const companion = game.canvas.tokens.get(companionTokenId)
+    // control() can silently no-op right after a scene switch — retry until it takes
+    const deadline = Date.now() + 5000
+    while (Date.now() < deadline && !controller.controlled) {
+      controller.control({ releaseOthers: true })
+      await new Promise(resolve => setTimeout(resolve, 100))
+    }
+    Object.defineProperty(game.user, 'isGM', { value: false, configurable: true })
+    try {
+      return {
+        controllerControlled: controller.controlled,
+        companionControlled: companion.controlled,
+        dccVisionSource: companion._isVisionSource(),
+        coreVisionSource: foundry.canvas.placeables.Token.prototype._isVisionSource.call(companion)
+      }
+    } finally {
+      delete game.user.isGM
+    }
+  }, setup)
+}
+
+test.describe('Owned-token vision (issue #872)', () => {
+  test('registers the world setting (default on) and the DCCToken placeable class', async ({ page }) => {
+    const info = await page.evaluate(() => {
+      const config = game.settings.settings.get('dcc.ownedTokenVision')
+      return {
+        scope: config?.scope,
+        default: config?.default,
+        tokenClassName: CONFIG.Token.objectClass.name,
+        extendsCoreToken: CONFIG.Token.objectClass.prototype instanceof foundry.canvas.placeables.Token
+      }
+    })
+    expect(info.scope).toBe('world')
+    expect(info.default).toBe(true)
+    expect(info.tokenClassName).toBe('DCCToken')
+    expect(info.extendsCoreToken).toBe(true)
+  })
+
+  test('an owned token keeps providing vision while another token is controlled', async ({ page }) => {
+    const setup = await setupTokens(page)
+    try {
+      const result = await probeVisionSources(page, setup)
+      expect(result.controllerControlled).toBe(true)
+      expect(result.companionControlled).toBe(false)
+      // Core's rule suppresses the uncontrolled token — the #872 failure mode
+      expect(result.coreVisionSource).toBe(false)
+      // The DCC override keeps it a vision source, so it stays rendered and clickable
+      expect(result.dccVisionSource).toBe(true)
+    } finally {
+      await cleanupTokens(page, setup)
+    }
+  })
+
+  test('standard Foundry vision applies while the setting is off', async ({ page }) => {
+    const setup = await setupTokens(page)
+    try {
+      await page.evaluate(() => game.settings.set('dcc', 'ownedTokenVision', false))
+      const result = await probeVisionSources(page, setup)
+      expect(result.dccVisionSource).toBe(false)
+    } finally {
+      await cleanupTokens(page, setup)
+    }
+  })
+})

--- a/browser-tests/e2e/token-vision.spec.js
+++ b/browser-tests/e2e/token-vision.spec.js
@@ -23,41 +23,54 @@ async function setupTokens (page) {
   return page.evaluate(async () => {
     const prevSceneId = game.canvas.scene?.id ?? null
     const scene = await Scene.create({ name: 'DCC TokenVision Probe', width: 4000, height: 3000, tokenVision: true, grid: { type: 1, size: 100, distance: 5, units: 'ft' } })
-    // view() is refused while a previous scene switch is still loading, and
-    // control() no-ops while the canvas is loading — retry until the probe
-    // scene is actually viewed and ready
-    const viewDeadline = Date.now() + 15000
-    while (Date.now() < viewDeadline && !(game.canvas.ready && game.canvas.scene?.id === scene.id)) {
-      if (game.canvas.scene?.id !== scene.id) {
-        try { await scene.view() } catch { /* still loading — retry */ }
+    const actorIds = []
+    try {
+      // view() is refused while a previous scene switch is still loading, and
+      // control() no-ops while the canvas is loading — retry until the probe
+      // scene is actually viewed and ready
+      const viewDeadline = Date.now() + 15000
+      while (Date.now() < viewDeadline && !(game.canvas.ready && game.canvas.scene?.id === scene.id)) {
+        if (game.canvas.scene?.id !== scene.id) {
+          try { await scene.view() } catch { /* still loading — retry */ }
+        }
+        await new Promise(resolve => setTimeout(resolve, 200))
       }
-      await new Promise(resolve => setTimeout(resolve, 200))
-    }
 
-    const makeActor = name => Actor.create({
-      name,
-      type: 'Player',
-      ownership: { [game.user.id]: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER },
-      prototypeToken: { actorLink: true, sight: { enabled: true } }
-    })
-    const controller = await makeActor('DCC TokenVision Controller')
-    const companion = await makeActor('DCC TokenVision Companion')
+      const makeActor = async name => {
+        const actor = await Actor.create({
+          name,
+          type: 'Player',
+          ownership: { [game.user.id]: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER },
+          prototypeToken: { actorLink: true, sight: { enabled: true } }
+        })
+        actorIds.push(actor.id)
+        return actor
+      }
+      const controller = await makeActor('DCC TokenVision Controller')
+      const companion = await makeActor('DCC TokenVision Companion')
 
-    const [controllerToken, companionToken] = await scene.createEmbeddedDocuments('Token', [
-      { name: 'Controller', actorId: controller.id, actorLink: true, x: 500, y: 500, sight: { enabled: true } },
-      { name: 'Companion', actorId: companion.id, actorLink: true, x: 2500, y: 2500, sight: { enabled: true } }
-    ])
-    const deadline = Date.now() + 3000
-    while (Date.now() < deadline && !(game.canvas.tokens.get(controllerToken.id) && game.canvas.tokens.get(companionToken.id))) {
-      await new Promise(resolve => setTimeout(resolve, 50))
-    }
+      const [controllerToken, companionToken] = await scene.createEmbeddedDocuments('Token', [
+        { name: 'Controller', actorId: controller.id, actorLink: true, x: 500, y: 500, sight: { enabled: true } },
+        { name: 'Companion', actorId: companion.id, actorLink: true, x: 2500, y: 2500, sight: { enabled: true } }
+      ])
+      const deadline = Date.now() + 3000
+      while (Date.now() < deadline && !(game.canvas.tokens.get(controllerToken.id) && game.canvas.tokens.get(companionToken.id))) {
+        await new Promise(resolve => setTimeout(resolve, 50))
+      }
 
-    return {
-      prevSceneId,
-      sceneId: scene.id,
-      actorIds: [controller.id, companion.id],
-      controllerTokenId: controllerToken.id,
-      companionTokenId: companionToken.id
+      return {
+        prevSceneId,
+        sceneId: scene.id,
+        actorIds,
+        controllerTokenId: controllerToken.id,
+        companionTokenId: companionToken.id
+      }
+    } catch (err) {
+      // Don't leak probe documents into the shared E2E world if setup dies
+      // mid-way — the tests' finally-cleanup never runs without a setup object
+      for (const id of actorIds) await game.actors.get(id)?.delete().catch(() => {})
+      await scene.delete().catch(() => {})
+      throw err
     }
   })
 }

--- a/docs/user-guide/Party-Sheet.md
+++ b/docs/user-guide/Party-Sheet.md
@@ -27,6 +27,8 @@ You can then double-click this to see the party sheet. You can use the gear on t
 ## Using individual tokens on the map
 You can still drag individual actors onto the map, and they will create their own tokens. You can then move them around the map individually.
 
+When a player runs several characters this way, the **Vision From All Owned Tokens** setting (on by default) keeps all of their characters visible and selectable even while one token is selected — see [System Settings](System-Settings.md).
+
 You can use the topmost box when you right-click a token to edit their hp - you can type expressions like '-2' or '+2' to make incremental changes to their HP.
 
 ![Individual Token ](images/token_edit_hp.png)

--- a/docs/user-guide/System-Settings.md
+++ b/docs/user-guide/System-Settings.md
@@ -82,6 +82,8 @@ Click the **Multiple Action Dice** button to configure the experimental multiple
 
 **Automate Fleeting Luck** will automatically add Fleeting Luck on criticals. If this is unchecked, it will not automatically apply Fleeting Luck.
 
+**Vision From All Owned Tokens** (on by default) lets players see from every token they own, even while controlling a single token. Foundry normally limits vision to the controlled token only, so when a player runs several characters — such as during a funnel — a character who walks out of the selected token's line of sight disappears from the map and can't be clicked. With this setting on, all of a player's characters keep providing vision, so they stay visible and selectable wherever they are. Turn it off to use standard Foundry vision. Judges are unaffected either way.
+
 **Active Variant** selects the active ruleset variant. Variant modules (XCC, MCC, etc.) register themselves with the system; their styles and class lists apply when their variant is selected. Leave this on **Dungeon Crawl Classics** unless a variant module tells you otherwise.
 
 **Enable Mighty Deed Tables** offers a Mighty Deed table prompt on attack cards when a warrior's deed die succeeds (3 or higher). See [Mighty Deeds](Mighty-Deeds.md).

--- a/docs/user-guide/System-Settings.md
+++ b/docs/user-guide/System-Settings.md
@@ -82,7 +82,7 @@ Click the **Multiple Action Dice** button to configure the experimental multiple
 
 **Automate Fleeting Luck** will automatically add Fleeting Luck on criticals. If this is unchecked, it will not automatically apply Fleeting Luck.
 
-**Vision From All Owned Tokens** (on by default) lets players see from every token they own, even while controlling a single token. Foundry normally limits vision to the controlled token only, so when a player runs several characters — such as during a funnel — a character who walks out of the selected token's line of sight disappears from the map and can't be clicked. With this setting on, all of a player's characters keep providing vision, so they stay visible and selectable wherever they are. Turn it off to use standard Foundry vision. Judges are unaffected either way.
+**Vision From All Owned Tokens** (on by default) lets players see from every token they own — or can observe, matching Foundry's own vision fallback rule — even while controlling a single token. Foundry normally limits vision to the controlled token only, so when a player runs several characters — such as during a funnel — a character who walks out of the selected token's line of sight disappears from the map and can't be clicked. With this setting on, all of a player's characters keep providing vision, so they stay visible and selectable wherever they are. Turn it off to use standard Foundry vision. Judges are unaffected either way.
 
 **Active Variant** selects the active ruleset variant. Variant modules (XCC, MCC, etc.) register themselves with the system; their styles and class lists apply when their variant is selected. Leave this on **Dungeon Crawl Classics** unless a variant module tells you otherwise.
 

--- a/lang/cn.json
+++ b/lang/cn.json
@@ -722,7 +722,7 @@
   "DCC.SettingAutoResetActionDice": "每回合自动重置动作骰",
   "DCC.SettingAutoResetActionDiceHint": "在每回合参战者轮到行动时补满其动作骰标记，无需手动追踪。仅在启用「多动作骰」时生效。",
   "DCC.SettingOwnedTokenVision": "所有拥有指示物的视野",
-  "DCC.SettingOwnedTokenVisionHint": "玩家即使只控制一个指示物，也能通过自己拥有的所有指示物获得视野，因此分开行动的角色仍然可见且可选中。当每位玩家操控多个角色（例如漏斗团）时非常有用。关闭后使用 Foundry 标准视野（仅受控指示物）。",
+  "DCC.SettingOwnedTokenVisionHint": "玩家即使只控制一个指示物，也能通过自己拥有或可观察的所有指示物获得视野，因此分开行动的角色仍然可见且可选中。当每位玩家操控多个角色（例如漏斗团）时非常有用。关闭后使用 Foundry 标准视野（仅受控指示物）。",
   "DCC.SettingHideSingleActionDiePips": "隐藏单动作骰角色的标记",
   "DCC.SettingHideSingleActionDiePipsHint": "仅为拥有两颗或更多动作骰的参战者显示标记，让战斗追踪器更简洁。仅在启用「多动作骰」时生效。",
   "DCC.SettingMightyDeedsTablesCompendium": "壮举表合集",

--- a/lang/cn.json
+++ b/lang/cn.json
@@ -721,6 +721,8 @@
   "DCC.SettingTrackActionDiceInCombatHint": "在战斗追踪器中每名参战者旁显示每回合动作骰标记（● 就绪，○ 已用，⊛ 仅限法术）。仅在启用「多动作骰」时生效。",
   "DCC.SettingAutoResetActionDice": "每回合自动重置动作骰",
   "DCC.SettingAutoResetActionDiceHint": "在每回合参战者轮到行动时补满其动作骰标记，无需手动追踪。仅在启用「多动作骰」时生效。",
+  "DCC.SettingOwnedTokenVision": "所有拥有指示物的视野",
+  "DCC.SettingOwnedTokenVisionHint": "玩家即使只控制一个指示物，也能通过自己拥有的所有指示物获得视野，因此分开行动的角色仍然可见且可选中。当每位玩家操控多个角色（例如漏斗团）时非常有用。关闭后使用 Foundry 标准视野（仅受控指示物）。",
   "DCC.SettingHideSingleActionDiePips": "隐藏单动作骰角色的标记",
   "DCC.SettingHideSingleActionDiePipsHint": "仅为拥有两颗或更多动作骰的参战者显示标记，让战斗追踪器更简洁。仅在启用「多动作骰」时生效。",
   "DCC.SettingMightyDeedsTablesCompendium": "壮举表合集",

--- a/lang/de.json
+++ b/lang/de.json
@@ -721,6 +721,8 @@
   "DCC.SettingTrackActionDiceInCombatHint": "Zeigt pro Runde Aktionswürfel-Marken neben jedem Kämpfer in der Kampfleiste (● bereit, ○ verbraucht, ⊛ nur Zauber). Wirkt nur, wenn Mehrere Aktionswürfel aktiviert ist.",
   "DCC.SettingAutoResetActionDice": "Aktionswürfel jede Runde zurücksetzen",
   "DCC.SettingAutoResetActionDiceHint": "Füllt die Aktionswürfel-Marken eines Kämpfers zu Beginn seines Zuges jede Runde wieder auf, damit niemand von Hand mitzählen muss. Wirkt nur, wenn Mehrere Aktionswürfel aktiviert ist.",
+  "DCC.SettingOwnedTokenVision": "Sicht durch alle eigenen Token",
+  "DCC.SettingOwnedTokenVisionHint": "Spieler sehen durch alle Token, die ihnen gehören, auch während sie einen einzelnen Token kontrollieren — getrennte Charaktere bleiben so sichtbar und auswählbar. Hilfreich, wenn jeder Spieler mehrere Charaktere führt, etwa in einem Trichter (Funnel). Deaktivieren für die Standard-Foundry-Sicht (nur der kontrollierte Token).",
   "DCC.SettingHideSingleActionDiePips": "Marken für Akteure mit nur einem Aktionswürfel ausblenden",
   "DCC.SettingHideSingleActionDiePipsHint": "Entrümpelt die Kampfleiste, indem Marken nur für Kämpfer mit zwei oder mehr Aktionswürfeln angezeigt werden. Wirkt nur, wenn Mehrere Aktionswürfel aktiviert ist.",
   "DCC.SettingMightyDeedsTablesCompendium": "Kompendium für Großtat-Tabellen",

--- a/lang/de.json
+++ b/lang/de.json
@@ -722,7 +722,7 @@
   "DCC.SettingAutoResetActionDice": "Aktionswürfel jede Runde zurücksetzen",
   "DCC.SettingAutoResetActionDiceHint": "Füllt die Aktionswürfel-Marken eines Kämpfers zu Beginn seines Zuges jede Runde wieder auf, damit niemand von Hand mitzählen muss. Wirkt nur, wenn Mehrere Aktionswürfel aktiviert ist.",
   "DCC.SettingOwnedTokenVision": "Sicht durch alle eigenen Token",
-  "DCC.SettingOwnedTokenVisionHint": "Spieler sehen durch alle Token, die ihnen gehören, auch während sie einen einzelnen Token kontrollieren — getrennte Charaktere bleiben so sichtbar und auswählbar. Hilfreich, wenn jeder Spieler mehrere Charaktere führt, etwa in einem Trichter (Funnel). Deaktivieren für die Standard-Foundry-Sicht (nur der kontrollierte Token).",
+  "DCC.SettingOwnedTokenVisionHint": "Spieler sehen durch alle Token, die ihnen gehören oder die sie beobachten können, auch während sie einen einzelnen Token kontrollieren — getrennte Charaktere bleiben so sichtbar und auswählbar. Hilfreich, wenn jeder Spieler mehrere Charaktere führt, etwa in einem Trichter (Funnel). Deaktivieren für die Standard-Foundry-Sicht (nur der kontrollierte Token).",
   "DCC.SettingHideSingleActionDiePips": "Marken für Akteure mit nur einem Aktionswürfel ausblenden",
   "DCC.SettingHideSingleActionDiePipsHint": "Entrümpelt die Kampfleiste, indem Marken nur für Kämpfer mit zwei oder mehr Aktionswürfeln angezeigt werden. Wirkt nur, wenn Mehrere Aktionswürfel aktiviert ist.",
   "DCC.SettingMightyDeedsTablesCompendium": "Kompendium für Großtat-Tabellen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -721,6 +721,8 @@
   "DCC.SettingTrackActionDiceInCombatHint": "Show per-round action-die pips next to each combatant in the combat tracker (● ready, ○ spent, ⊛ spells-only). Only takes effect when Multiple Action Dice is on.",
   "DCC.SettingAutoResetActionDice": "Auto-reset action dice each round",
   "DCC.SettingAutoResetActionDiceHint": "Refill a combatant's action-die pips at the start of its turn each round, so no one has to track it by hand. Only takes effect when Multiple Action Dice is on.",
+  "DCC.SettingOwnedTokenVision": "Vision From All Owned Tokens",
+  "DCC.SettingOwnedTokenVisionHint": "Players see from every token they own, even while controlling a single token, so characters that split up stay visible and selectable. Helpful when each player runs several characters, such as during a funnel. Disable for standard Foundry vision (controlled token only).",
   "DCC.SettingHideSingleActionDiePips": "Hide pips for single-action-die actors",
   "DCC.SettingHideSingleActionDiePipsHint": "Declutter the combat tracker by only showing pips for combatants with two or more action dice. Only takes effect when Multiple Action Dice is on.",
   "DCC.SettingMightyDeedsTablesCompendium": "Mighty Deeds Tables Compendium",

--- a/lang/en.json
+++ b/lang/en.json
@@ -722,7 +722,7 @@
   "DCC.SettingAutoResetActionDice": "Auto-reset action dice each round",
   "DCC.SettingAutoResetActionDiceHint": "Refill a combatant's action-die pips at the start of its turn each round, so no one has to track it by hand. Only takes effect when Multiple Action Dice is on.",
   "DCC.SettingOwnedTokenVision": "Vision From All Owned Tokens",
-  "DCC.SettingOwnedTokenVisionHint": "Players see from every token they own, even while controlling a single token, so characters that split up stay visible and selectable. Helpful when each player runs several characters, such as during a funnel. Disable for standard Foundry vision (controlled token only).",
+  "DCC.SettingOwnedTokenVisionHint": "Players see from every token they own or can observe, even while controlling a single token, so characters that split up stay visible and selectable. Helpful when each player runs several characters, such as during a funnel. Disable for standard Foundry vision (controlled token only).",
   "DCC.SettingHideSingleActionDiePips": "Hide pips for single-action-die actors",
   "DCC.SettingHideSingleActionDiePipsHint": "Declutter the combat tracker by only showing pips for combatants with two or more action dice. Only takes effect when Multiple Action Dice is on.",
   "DCC.SettingMightyDeedsTablesCompendium": "Mighty Deeds Tables Compendium",

--- a/lang/es.json
+++ b/lang/es.json
@@ -722,7 +722,7 @@
   "DCC.SettingAutoResetActionDice": "Reiniciar los dados de acción cada asalto",
   "DCC.SettingAutoResetActionDiceHint": "Rellena las marcas de dados de acción de un combatiente al inicio de su turno cada asalto, para que nadie tenga que llevar la cuenta a mano. Solo tiene efecto cuando Múltiples dados de acción está activado.",
   "DCC.SettingOwnedTokenVision": "Visión de todos los tokens propios",
-  "DCC.SettingOwnedTokenVisionHint": "Los jugadores ven a través de todos los tokens que poseen, incluso mientras controlan un solo token, de modo que los personajes que se separan siguen visibles y seleccionables. Útil cuando cada jugador lleva varios personajes, como en un embudo (funnel). Desactívalo para usar la visión estándar de Foundry (solo el token controlado).",
+  "DCC.SettingOwnedTokenVisionHint": "Los jugadores ven a través de todos los tokens que poseen o pueden observar, incluso mientras controlan un solo token, de modo que los personajes que se separan siguen visibles y seleccionables. Útil cuando cada jugador lleva varios personajes, como en un embudo (funnel). Desactívalo para usar la visión estándar de Foundry (solo el token controlado).",
   "DCC.SettingHideSingleActionDiePips": "Ocultar marcas para actores con un solo dado de acción",
   "DCC.SettingHideSingleActionDiePipsHint": "Despeja el rastreador de combate mostrando marcas solo para combatientes con dos o más dados de acción. Solo tiene efecto cuando Múltiples dados de acción está activado.",
   "DCC.SettingMightyDeedsTablesCompendium": "Compendio de Tablas de Hazañas",

--- a/lang/es.json
+++ b/lang/es.json
@@ -721,6 +721,8 @@
   "DCC.SettingTrackActionDiceInCombatHint": "Muestra marcas de dados de acción por asalto junto a cada combatiente en el rastreador de combate (● disponible, ○ gastado, ⊛ solo conjuros). Solo tiene efecto cuando Múltiples dados de acción está activado.",
   "DCC.SettingAutoResetActionDice": "Reiniciar los dados de acción cada asalto",
   "DCC.SettingAutoResetActionDiceHint": "Rellena las marcas de dados de acción de un combatiente al inicio de su turno cada asalto, para que nadie tenga que llevar la cuenta a mano. Solo tiene efecto cuando Múltiples dados de acción está activado.",
+  "DCC.SettingOwnedTokenVision": "Visión de todos los tokens propios",
+  "DCC.SettingOwnedTokenVisionHint": "Los jugadores ven a través de todos los tokens que poseen, incluso mientras controlan un solo token, de modo que los personajes que se separan siguen visibles y seleccionables. Útil cuando cada jugador lleva varios personajes, como en un embudo (funnel). Desactívalo para usar la visión estándar de Foundry (solo el token controlado).",
   "DCC.SettingHideSingleActionDiePips": "Ocultar marcas para actores con un solo dado de acción",
   "DCC.SettingHideSingleActionDiePipsHint": "Despeja el rastreador de combate mostrando marcas solo para combatientes con dos o más dados de acción. Solo tiene efecto cuando Múltiples dados de acción está activado.",
   "DCC.SettingMightyDeedsTablesCompendium": "Compendio de Tablas de Hazañas",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -709,7 +709,7 @@
   "DCC.SettingAutoResetActionDice": "Réinitialiser les dés d'action à chaque round",
   "DCC.SettingAutoResetActionDiceHint": "Recharge les pastilles de dés d'action d'un combattant au début de son tour à chaque round, pour que personne n'ait à le suivre à la main. N'a d'effet que lorsque Dés d'action multiples est activé.",
   "DCC.SettingOwnedTokenVision": "Vision de tous les tokens possédés",
-  "DCC.SettingOwnedTokenVisionHint": "Les joueurs voient à travers tous les tokens qu'ils possèdent, même lorsqu'ils contrôlent un seul token : les personnages qui se séparent restent visibles et sélectionnables. Utile quand chaque joueur incarne plusieurs personnages, comme dans un entonnoir (funnel). Désactivez pour la vision standard de Foundry (token contrôlé uniquement).",
+  "DCC.SettingOwnedTokenVisionHint": "Les joueurs voient à travers tous les tokens qu'ils possèdent ou peuvent observer, même lorsqu'ils contrôlent un seul token : les personnages qui se séparent restent visibles et sélectionnables. Utile quand chaque joueur incarne plusieurs personnages, comme dans un entonnoir (funnel). Désactivez pour la vision standard de Foundry (token contrôlé uniquement).",
   "DCC.SettingHideSingleActionDiePips": "Masquer les pastilles pour les acteurs à un seul dé d'action",
   "DCC.SettingHideSingleActionDiePipsHint": "Allège le suivi de combat en n'affichant les pastilles que pour les combattants ayant deux dés d'action ou plus. N'a d'effet que lorsque Dés d'action multiples est activé.",
   "DCC.SettingMightyDeedsTablesCompendium": "Compendium des tables de hauts faits",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -708,6 +708,8 @@
   "DCC.SettingTrackActionDiceInCombatHint": "Affiche des pastilles de dés d'action par round à côté de chaque combattant dans le suivi de combat (● prêt, ○ dépensé, ⊛ sorts uniquement). N'a d'effet que lorsque Dés d'action multiples est activé.",
   "DCC.SettingAutoResetActionDice": "Réinitialiser les dés d'action à chaque round",
   "DCC.SettingAutoResetActionDiceHint": "Recharge les pastilles de dés d'action d'un combattant au début de son tour à chaque round, pour que personne n'ait à le suivre à la main. N'a d'effet que lorsque Dés d'action multiples est activé.",
+  "DCC.SettingOwnedTokenVision": "Vision de tous les tokens possédés",
+  "DCC.SettingOwnedTokenVisionHint": "Les joueurs voient à travers tous les tokens qu'ils possèdent, même lorsqu'ils contrôlent un seul token : les personnages qui se séparent restent visibles et sélectionnables. Utile quand chaque joueur incarne plusieurs personnages, comme dans un entonnoir (funnel). Désactivez pour la vision standard de Foundry (token contrôlé uniquement).",
   "DCC.SettingHideSingleActionDiePips": "Masquer les pastilles pour les acteurs à un seul dé d'action",
   "DCC.SettingHideSingleActionDiePipsHint": "Allège le suivi de combat en n'affichant les pastilles que pour les combattants ayant deux dés d'action ou plus. N'a d'effet que lorsque Dés d'action multiples est activé.",
   "DCC.SettingMightyDeedsTablesCompendium": "Compendium des tables de hauts faits",

--- a/lang/it.json
+++ b/lang/it.json
@@ -722,7 +722,7 @@
   "DCC.SettingAutoResetActionDice": "Reimposta i dadi azione a ogni round",
   "DCC.SettingAutoResetActionDiceHint": "Ripristina i segnalini dei dadi azione di un combattente all'inizio del suo turno a ogni round, così nessuno deve tenerne il conto a mano. Ha effetto solo quando Dadi azione multipli è attivo.",
   "DCC.SettingOwnedTokenVision": "Visione da tutti i token posseduti",
-  "DCC.SettingOwnedTokenVisionHint": "I giocatori vedono attraverso tutti i token che possiedono, anche mentre controllano un singolo token: i personaggi che si separano restano visibili e selezionabili. Utile quando ogni giocatore gestisce più personaggi, come in un funnel. Disattivare per la visione standard di Foundry (solo il token controllato).",
+  "DCC.SettingOwnedTokenVisionHint": "I giocatori vedono attraverso tutti i token che possiedono o possono osservare, anche mentre controllano un singolo token: i personaggi che si separano restano visibili e selezionabili. Utile quando ogni giocatore gestisce più personaggi, come in un funnel. Disattivare per la visione standard di Foundry (solo il token controllato).",
   "DCC.SettingHideSingleActionDiePips": "Nascondi i segnalini per gli attori con un solo dado azione",
   "DCC.SettingHideSingleActionDiePipsHint": "Sfoltisce il tracker di combattimento mostrando i segnalini solo per i combattenti con due o più dadi azione. Ha effetto solo quando Dadi azione multipli è attivo.",
   "DCC.SettingMightyDeedsTablesCompendium": "Compendio delle Tabelle dei Cimenti",

--- a/lang/it.json
+++ b/lang/it.json
@@ -721,6 +721,8 @@
   "DCC.SettingTrackActionDiceInCombatHint": "Mostra segnalini dei dadi azione per round accanto a ogni combattente nel tracker di combattimento (● pronto, ○ speso, ⊛ solo incantesimi). Ha effetto solo quando Dadi azione multipli è attivo.",
   "DCC.SettingAutoResetActionDice": "Reimposta i dadi azione a ogni round",
   "DCC.SettingAutoResetActionDiceHint": "Ripristina i segnalini dei dadi azione di un combattente all'inizio del suo turno a ogni round, così nessuno deve tenerne il conto a mano. Ha effetto solo quando Dadi azione multipli è attivo.",
+  "DCC.SettingOwnedTokenVision": "Visione da tutti i token posseduti",
+  "DCC.SettingOwnedTokenVisionHint": "I giocatori vedono attraverso tutti i token che possiedono, anche mentre controllano un singolo token: i personaggi che si separano restano visibili e selezionabili. Utile quando ogni giocatore gestisce più personaggi, come in un funnel. Disattivare per la visione standard di Foundry (solo il token controllato).",
   "DCC.SettingHideSingleActionDiePips": "Nascondi i segnalini per gli attori con un solo dado azione",
   "DCC.SettingHideSingleActionDiePipsHint": "Sfoltisce il tracker di combattimento mostrando i segnalini solo per i combattenti con due o più dadi azione. Ha effetto solo quando Dadi azione multipli è attivo.",
   "DCC.SettingMightyDeedsTablesCompendium": "Compendio delle Tabelle dei Cimenti",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -721,6 +721,8 @@
   "DCC.SettingTrackActionDiceInCombatHint": "Pokazuje znaczniki kości akcji na rundę obok każdego uczestnika walki w trackerze (● gotowa, ○ wydana, ⊛ tylko zaklęcia). Działa tylko, gdy włączone jest Wiele kości akcji.",
   "DCC.SettingAutoResetActionDice": "Automatycznie odświeżaj kości akcji co rundę",
   "DCC.SettingAutoResetActionDiceHint": "Odnawia znaczniki kości akcji uczestnika na początku jego tury w każdej rundzie, by nikt nie musiał liczyć ręcznie. Działa tylko, gdy włączone jest Wiele kości akcji.",
+  "DCC.SettingOwnedTokenVision": "Widzenie ze wszystkich posiadanych tokenów",
+  "DCC.SettingOwnedTokenVisionHint": "Gracze widzą ze wszystkich tokenów, które posiadają, nawet gdy kontrolują pojedynczy token — rozdzielone postacie pozostają widoczne i możliwe do zaznaczenia. Przydatne, gdy każdy gracz prowadzi kilka postaci, np. w funnelu. Wyłącz, aby używać standardowego widzenia Foundry (tylko kontrolowany token).",
   "DCC.SettingHideSingleActionDiePips": "Ukryj znaczniki dla postaci z jedną kością akcji",
   "DCC.SettingHideSingleActionDiePipsHint": "Odchudza tracker walki, pokazując znaczniki tylko dla uczestników z dwiema lub więcej kośćmi akcji. Działa tylko, gdy włączone jest Wiele kości akcji.",
   "DCC.SettingMightyDeedsTablesCompendium": "Kompendium Tabel Czynów",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -722,7 +722,7 @@
   "DCC.SettingAutoResetActionDice": "Automatycznie odświeżaj kości akcji co rundę",
   "DCC.SettingAutoResetActionDiceHint": "Odnawia znaczniki kości akcji uczestnika na początku jego tury w każdej rundzie, by nikt nie musiał liczyć ręcznie. Działa tylko, gdy włączone jest Wiele kości akcji.",
   "DCC.SettingOwnedTokenVision": "Widzenie ze wszystkich posiadanych tokenów",
-  "DCC.SettingOwnedTokenVisionHint": "Gracze widzą ze wszystkich tokenów, które posiadają, nawet gdy kontrolują pojedynczy token — rozdzielone postacie pozostają widoczne i możliwe do zaznaczenia. Przydatne, gdy każdy gracz prowadzi kilka postaci, np. w funnelu. Wyłącz, aby używać standardowego widzenia Foundry (tylko kontrolowany token).",
+  "DCC.SettingOwnedTokenVisionHint": "Gracze widzą ze wszystkich tokenów, które posiadają lub mogą obserwować, nawet gdy kontrolują pojedynczy token — rozdzielone postacie pozostają widoczne i możliwe do zaznaczenia. Przydatne, gdy każdy gracz prowadzi kilka postaci, np. w funnelu. Wyłącz, aby używać standardowego widzenia Foundry (tylko kontrolowany token).",
   "DCC.SettingHideSingleActionDiePips": "Ukryj znaczniki dla postaci z jedną kością akcji",
   "DCC.SettingHideSingleActionDiePipsHint": "Odchudza tracker walki, pokazując znaczniki tylko dla uczestników z dwiema lub więcej kośćmi akcji. Działa tylko, gdy włączone jest Wiele kości akcji.",
   "DCC.SettingMightyDeedsTablesCompendium": "Kompendium Tabel Czynów",

--- a/module/__mocks__/foundry.js
+++ b/module/__mocks__/foundry.js
@@ -1523,6 +1523,8 @@ global.gameSettingsGetMock = vi.fn((module, key) => {
         return 'dcc-core-book.dcc-lay-on-hands'
       case 'levelData':
         return 'dcc-core-book.dcc-level-data'
+      case 'ownedTokenVision':
+        return true
       default:
         return undefined
     }
@@ -1537,6 +1539,22 @@ class ClientSettings {
 }
 
 global.game.settings = new ClientSettings()
+
+/**
+ * Canvas — shared minimal stub of the pieces production code touches
+ * (`canvas.tokens.controlled`, the vision-source checks in
+ * module/token-vision.mjs, the perception refresh). Tests that need
+ * different shapes override the fields (or the whole global) locally.
+ */
+global.canvasPerceptionUpdateMock = vi.fn().mockName('canvas.perception.update')
+global.canvas = {
+  ready: true,
+  level: { id: 0 },
+  tokens: { controlled: [], placeables: [] },
+  visibility: { tokenVision: true },
+  perception: { update: global.canvasPerceptionUpdateMock }
+}
+global.game.canvas ??= global.canvas
 
 /**
  * ChatMessage

--- a/module/__tests__/init-hook.test.js
+++ b/module/__tests__/init-hook.test.js
@@ -65,6 +65,7 @@ vi.mock('../death-clock-tracker.mjs', () => ({
   DeathClockTracker: { name: 'DeathClockTracker' },
   registerDeathClockTracker: vi.fn()
 }))
+vi.mock('../token-vision.mjs', () => ({ registerTokenVision: vi.fn() }))
 vi.mock('../macros.mjs', () => ({ getMacroActor: vi.fn(), getMacroOptions: vi.fn(), rollDCCWeaponMacro: vi.fn() }))
 vi.mock('../spell-check-processor.mjs', () => ({ processSpellCheck: vi.fn() }))
 vi.mock('../table-loading.mjs', () => ({ getSkillTable: vi.fn() }))
@@ -317,6 +318,9 @@ describe('onInit', () => {
     // The Death Clock tracker registered (issue #843 phase 2)
     const { registerDeathClockTracker } = await import('../death-clock-tracker.mjs')
     expect(registerDeathClockTracker).toHaveBeenCalledTimes(1)
+    // The owned-token-vision Token class registered (issue #872)
+    const { registerTokenVision } = await import('../token-vision.mjs')
+    expect(registerTokenVision).toHaveBeenCalledTimes(1)
     // The journal roll-link enrichers registered (issue #794)
     const { registerJournalEnrichers } = await import('../journal-enrichers.mjs')
     expect(registerJournalEnrichers).toHaveBeenCalledTimes(1)

--- a/module/__tests__/token-vision.test.js
+++ b/module/__tests__/token-vision.test.js
@@ -3,9 +3,10 @@
  *
  * `isOwnedTokenVisionSource` is exercised against the shared foundry mock's
  * `game` / `canvas` globals with plain token stubs; `registerTokenVision` is
- * checked against a stand-in core Token class. The live-Foundry behavior
- * (vision-source evaluation during canvas draw, perception refresh on the
- * setting's onChange) is covered by `browser-tests/e2e/token-vision.spec.js`.
+ * checked against a stand-in core Token class, and the setting's onChange
+ * perception refresh against the mock's captured registration. The
+ * live-Foundry behavior (vision-source evaluation during canvas draw) is
+ * covered by `browser-tests/e2e/token-vision.spec.js`.
  */
 
 import { beforeEach, describe, expect, test, vi } from 'vitest'
@@ -13,6 +14,12 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 import '../__mocks__/foundry.js'
 
 import { isOwnedTokenVisionSource, registerTokenVision } from '../token-vision.mjs'
+
+vi.mock('../settings-menus.mjs', () => ({
+  DCCEnhancedCombatSettings: class {},
+  DCCTableSettings: class {},
+  DCCActionDiceSettings: class {}
+}))
 
 /** A token stub satisfying every owned-token-vision requirement. */
 function makeToken (overrides = {}) {
@@ -105,5 +112,29 @@ describe('registerTokenVision', () => {
     // ... but not when the setting is off
     global.gameSettingsGetMock.mockReturnValueOnce(false)
     expect(token._isVisionSource()).toBe(false)
+  })
+})
+
+describe('ownedTokenVision setting onChange', () => {
+  test('re-initializes vision sources on change, only while the canvas is ready', async () => {
+    const registrations = {}
+    global.game.settings.register = vi.fn((namespace, key, config) => { registrations[key] = config })
+    const { registerEarlySystemSettings } = await import('../settings.js')
+    registerEarlySystemSettings()
+
+    const config = registrations.ownedTokenVision
+    expect(config.scope).toBe('world')
+    expect(config.default).toBe(true)
+
+    global.canvasPerceptionUpdateMock.mockClear()
+    global.canvas.ready = true
+    config.onChange()
+    expect(global.canvasPerceptionUpdateMock).toHaveBeenCalledWith({ initializeVision: true })
+
+    global.canvasPerceptionUpdateMock.mockClear()
+    global.canvas.ready = false
+    config.onChange()
+    expect(global.canvasPerceptionUpdateMock).not.toHaveBeenCalled()
+    global.canvas.ready = true
   })
 })

--- a/module/__tests__/token-vision.test.js
+++ b/module/__tests__/token-vision.test.js
@@ -1,0 +1,109 @@
+/**
+ * Unit coverage for the owned-token-vision feature (issue #872).
+ *
+ * `isOwnedTokenVisionSource` is exercised against the shared foundry mock's
+ * `game` / `canvas` globals with plain token stubs; `registerTokenVision` is
+ * checked against a stand-in core Token class. The live-Foundry behavior
+ * (vision-source evaluation during canvas draw, perception refresh on the
+ * setting's onChange) is covered by `browser-tests/e2e/token-vision.spec.js`.
+ */
+
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import '../__mocks__/foundry.js'
+
+import { isOwnedTokenVisionSource, registerTokenVision } from '../token-vision.mjs'
+
+/** A token stub satisfying every owned-token-vision requirement. */
+function makeToken (overrides = {}) {
+  return {
+    hasSight: true,
+    document: { level: 0, hidden: false },
+    actor: { testUserPermission: vi.fn().mockReturnValue(true) },
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  global.game.user = { _id: 1, isGM: false }
+  global.canvas.visibility.tokenVision = true
+  global.canvas.level = { id: 0 }
+  global.gameSettingsGetMock.mockClear()
+})
+
+describe('isOwnedTokenVisionSource', () => {
+  test('an owned, sighted, visible token on the viewed level provides vision', () => {
+    const token = makeToken()
+    expect(isOwnedTokenVisionSource(token)).toBe(true)
+    expect(token.actor.testUserPermission).toHaveBeenCalledWith(global.game.user, 'OBSERVER')
+  })
+
+  test('never applies to GM users', () => {
+    global.game.user.isGM = true
+    expect(isOwnedTokenVisionSource(makeToken())).toBe(false)
+  })
+
+  test('does nothing while the ownedTokenVision setting is off', () => {
+    global.gameSettingsGetMock.mockReturnValueOnce(false)
+    expect(isOwnedTokenVisionSource(makeToken())).toBe(false)
+    expect(global.gameSettingsGetMock).toHaveBeenCalledWith('dcc', 'ownedTokenVision')
+  })
+
+  test('requires scene token vision', () => {
+    global.canvas.visibility.tokenVision = false
+    expect(isOwnedTokenVisionSource(makeToken())).toBe(false)
+  })
+
+  test('requires the token to have sight enabled', () => {
+    expect(isOwnedTokenVisionSource(makeToken({ hasSight: false }))).toBe(false)
+  })
+
+  test('ignores tokens on a different scene level', () => {
+    expect(isOwnedTokenVisionSource(makeToken({ document: { level: 1, hidden: false } }))).toBe(false)
+  })
+
+  test('ignores hidden tokens', () => {
+    expect(isOwnedTokenVisionSource(makeToken({ document: { level: 0, hidden: true } }))).toBe(false)
+  })
+
+  test('requires OBSERVER permission on the actor', () => {
+    const token = makeToken()
+    token.actor.testUserPermission.mockReturnValue(false)
+    expect(isOwnedTokenVisionSource(token)).toBe(false)
+  })
+
+  test('tolerates tokens with no actor', () => {
+    expect(isOwnedTokenVisionSource(makeToken({ actor: null }))).toBe(false)
+  })
+})
+
+describe('registerTokenVision', () => {
+  test('registers a Token subclass that ORs the owned-token rule into _isVisionSource', () => {
+    class CoreToken {
+      _isVisionSource () {
+        return this.coreResult
+      }
+    }
+    global.foundry.canvas = { placeables: { Token: CoreToken } }
+    global.CONFIG.Token = {}
+
+    registerTokenVision()
+
+    const DCCToken = global.CONFIG.Token.objectClass
+    expect(Object.getPrototypeOf(DCCToken)).toBe(CoreToken)
+
+    const token = Object.assign(new DCCToken(), makeToken())
+
+    // Core's own rule (e.g. a controlled token) still wins outright
+    token.coreResult = true
+    expect(token._isVisionSource()).toBe(true)
+
+    // Core says no (another token is controlled) → owned-token rule applies
+    token.coreResult = false
+    expect(token._isVisionSource()).toBe(true)
+
+    // ... but not when the setting is off
+    global.gameSettingsGetMock.mockReturnValueOnce(false)
+    expect(token._isVisionSource()).toBe(false)
+  })
+})

--- a/module/init-hook.mjs
+++ b/module/init-hook.mjs
@@ -47,6 +47,7 @@ import { registerEarlySystemSettings } from './settings.js'
 import { registerJournalEnrichers } from './journal-enrichers.mjs'
 import { registerDCCSidebarTab } from './sidebar-tab.mjs'
 import { DeathClockTracker, registerDeathClockTracker } from './death-clock-tracker.mjs'
+import { registerTokenVision } from './token-vision.mjs'
 import { getMacroActor, getMacroOptions, rollDCCWeaponMacro } from './macros.mjs'
 import { processSpellCheck } from './spell-check-processor.mjs'
 import { getSkillTable } from './table-loading.mjs'
@@ -332,6 +333,7 @@ export async function onInit () {
   registerSheets()
   registerDCCSidebarTab()
   registerDeathClockTracker()
+  registerTokenVision()
   registerJournalEnrichers()
   await loadSystemTemplates()
   registerEarlySettings()

--- a/module/init-hook.mjs
+++ b/module/init-hook.mjs
@@ -335,8 +335,10 @@ export async function onInit () {
   registerDeathClockTracker()
   registerTokenVision()
   registerJournalEnrichers()
-  await loadSystemTemplates()
+  // Before the template await: a template-loading failure must not leave the
+  // early settings unregistered while DCCToken (which reads one) is live.
   registerEarlySettings()
+  await loadSystemTemplates()
 }
 
 /**

--- a/module/settings.js
+++ b/module/settings.js
@@ -1,4 +1,4 @@
-/* global CONFIG, game, Hooks */
+/* global CONFIG, canvas, game, Hooks */
 
 import { DCCEnhancedCombatSettings, DCCTableSettings, DCCActionDiceSettings } from './settings-menus.mjs'
 
@@ -23,6 +23,10 @@ export const pubConstants = {
  *   at `ready` meant the action-dice list was never derived on world load
  *   and sheet chips/pips only appeared after an actor update re-prepared
  *   the actor.
+ * - `ownedTokenVision` is read by `DCCToken#_isVisionSource` during the
+ *   first canvas draw, which `Game#setupGame` kicks off *before* firing
+ *   `ready` — a `ready`-registered setting could still be unregistered
+ *   when the initial vision sources are computed.
  *
  * Registration order is display order in the settings window, but all of
  * these either render inside a submenu (`config: false`) or pair with a
@@ -113,6 +117,26 @@ export const registerEarlySystemSettings = function () {
     type: Boolean,
     default: true,
     config: false
+  })
+
+  /**
+   * Vision from all owned tokens (issue #872): while on, every token a
+   * player owns keeps providing vision even while a single token is
+   * controlled, so a party of funnel characters that splits up stays
+   * visible and selectable. Read by `DCCToken#_isVisionSource`
+   * (module/token-vision.mjs). No reload needed — the onChange refresh
+   * re-initializes vision sources on every client.
+   */
+  game.settings.register('dcc', 'ownedTokenVision', {
+    name: 'DCC.SettingOwnedTokenVision',
+    hint: 'DCC.SettingOwnedTokenVisionHint',
+    scope: 'world',
+    type: Boolean,
+    default: true,
+    config: true,
+    onChange: () => {
+      if (canvas?.ready) canvas.perception.update({ initializeVision: true })
+    }
   })
 }
 

--- a/module/token-vision.mjs
+++ b/module/token-vision.mjs
@@ -1,0 +1,58 @@
+/* global CONFIG, canvas, foundry, game */
+
+/**
+ * Vision from all owned tokens (issue #872).
+ *
+ * Core's `Token#_isVisionSource` only lets an uncontrolled token provide
+ * vision while the player controls no other sighted token, so a player
+ * running several characters (a funnel) loses the rest of the party's
+ * vision the moment they select one token — and a character outside the
+ * controlled token's line of sight stops rendering entirely and cannot be
+ * clicked or drag-selected to recover. That suppression is deliberate core
+ * design (foundryvtt#11016) with no core setting to relax it.
+ *
+ * While the `ownedTokenVision` world setting is on (the default), the
+ * DCCToken placeable registered here also treats every owned/observed,
+ * sighted, non-hidden token as a vision source for non-GM players. A token
+ * that is a vision source is always rendered (`Token#isVisible`
+ * short-circuits on `this.vision?.active`), so the separated character
+ * stays visible and selectable with no extra visibility handling. GM
+ * vision is unchanged.
+ */
+
+/**
+ * Would this token provide vision under the owned-token-vision rule?
+ *
+ * Mirrors core `_isVisionSource`'s own requirements — scene token vision
+ * on, sight enabled, viewed level, not hidden, OBSERVER-or-better on the
+ * actor (core's fallback rule uses OBSERVER, not OWNER) — minus the
+ * "player controls another sighted token" suppression.
+ *
+ * @param {foundry.canvas.placeables.Token} token
+ * @returns {boolean}
+ */
+export function isOwnedTokenVisionSource (token) {
+  if (game.user.isGM) return false
+  if (!game.settings.get('dcc', 'ownedTokenVision')) return false
+  if (!canvas.visibility.tokenVision || !token.hasSight) return false
+  if (token.document.level !== canvas.level.id) return false
+  if (token.document.hidden) return false
+  return token.actor?.testUserPermission(game.user, 'OBSERVER') ?? false
+}
+
+/**
+ * Register the DCCToken placeable class onto `CONFIG.Token.objectClass`.
+ * Runs at `init` (module/init-hook.mjs). Core re-runs `_isVisionSource`
+ * for every token on control/release/update, so the override needs no
+ * hook plumbing of its own; toggling the setting mid-session is handled
+ * by its `onChange` perception refresh (module/settings.js).
+ */
+export function registerTokenVision () {
+  class DCCToken extends foundry.canvas.placeables.Token {
+    /** @override */
+    _isVisionSource () {
+      return super._isVisionSource() || isOwnedTokenVisionSource(this)
+    }
+  }
+  CONFIG.Token.objectClass = DCCToken
+}

--- a/module/token-vision.mjs
+++ b/module/token-vision.mjs
@@ -26,7 +26,10 @@
  * Mirrors core `_isVisionSource`'s own requirements — scene token vision
  * on, sight enabled, viewed level, not hidden, OBSERVER-or-better on the
  * actor (core's fallback rule uses OBSERVER, not OWNER) — minus the
- * "player controls another sighted token" suppression.
+ * "player controls another sighted token" suppression. Re-diff against
+ * core's `Token#_isVisionSource` when bumping the supported Foundry
+ * version: a new core gate must be mirrored here, or the OR-composition
+ * in DCCToken widens vision past it silently.
  *
  * @param {foundry.canvas.placeables.Token} token
  * @returns {boolean}


### PR DESCRIPTION
## Summary

- Fixes the funnel-play vision problem from #872: Foundry limits vision to the controlled token, so when a player runs several characters, a character who walks out of the selected token's line of sight disappears from the map and can't be clicked, drag-selected, or grabbed with Select All. Core treats this suppression as intended (foundryvtt/foundryvtt#11016) and offers no setting.
- Adds the **Vision From All Owned Tokens** world setting (`dcc.ownedTokenVision`, default **on**): while enabled, every owned/observed, sighted, non-hidden token keeps providing vision for non-GM players even while a single token is controlled. A vision-source token is always rendered, so separated characters stay visible and selectable with no extra visibility handling. GM vision is unchanged.
- Implementation is the system's first Token placeable subclass (`DCCToken`, `module/token-vision.mjs`) registered on `CONFIG.Token.objectClass` at `init`; `_isVisionSource` ORs the owned-token rule into core's. The setting registers in `registerEarlySystemSettings()` because vision sources are computed during the first canvas draw, which starts before `ready`; toggling it mid-session refreshes perception via `onChange` (no reload).
- Adds a shared minimal `canvas` stub to the unit-test foundry mock (`tokens.controlled`, `visibility`, `level`, `perception.update`) so tests stop hand-rolling divergent stubs.
- Docs: new entry in System Settings guide plus a cross-reference from the Party Sheet guide; i18n keys translated to all 7 languages.
- No dependent-module impact: dcc-qol, xcc, mcc-classes, and dcc-crawl-classes don't touch `CONFIG.Token`.

## Test plan

- [x] Unit: `module/__tests__/token-vision.test.js` covers every branch of the owned-token rule (GM, setting off, scene vision off, no sight, hidden, wrong level, no permission, no actor) and the `DCCToken` registration/OR behavior — 2430 vitest tests green
- [x] E2E: `browser-tests/e2e/token-vision.spec.js` verifies against live Foundry that the setting registers (world scope, default on), `DCCToken` extends the core Token, an owned token stays a vision source while another is controlled where core's rule suppresses it (spoofed non-GM), and standard vision applies with the setting off
- [x] Full Playwright suite run: 290/292 passed; the two failures (auto-apply-damage, weapon-range firing-into-melee) are pre-existing order-dependent scene-loading flakes — both pass standalone, and the same pair also passed 3/3 reruns with this change applied
- [x] `npm run check` green (format, scss, tests, compare-lang)

Closes #872 (vision aspect — Party-sheet "select all tokens" and a control-all keybinding are possible follow-ons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)