### PR TITLE
feat: checked-in e2e world template + Observer GM user

### DIFF
--- a/browser-tests/e2e/test-environment.json
+++ b/browser-tests/e2e/test-environment.json
@@ -1,5 +1,5 @@
 {
-  "world": "v14",
+  "world": "dcc-e2e",
   "modules": ["dcc-core-book"],
   "settings": {
     "core.moduleConfiguration": {

--- a/browser-tests/e2e/world-template/users/gamemaster.json
+++ b/browser-tests/e2e/world-template/users/gamemaster.json
@@ -1,0 +1,14 @@
+{
+  "_id": "dccE2eGamemaster",
+  "name": "Gamemaster",
+  "role": 4,
+  "password": "",
+  "avatar": null,
+  "character": null,
+  "color": "#cc2893",
+  "pronouns": "",
+  "hotbar": {},
+  "permissions": {},
+  "flags": {},
+  "_key": "!users!dccE2eGamemaster"
+}

--- a/browser-tests/e2e/world-template/users/observer.json
+++ b/browser-tests/e2e/world-template/users/observer.json
@@ -1,0 +1,14 @@
+{
+  "_id": "dccE2eObserver00",
+  "name": "Observer",
+  "role": 4,
+  "password": "",
+  "avatar": null,
+  "character": null,
+  "color": "#28a0cc",
+  "pronouns": "",
+  "hotbar": {},
+  "permissions": {},
+  "flags": {},
+  "_key": "!users!dccE2eObserver00"
+}

--- a/browser-tests/e2e/world-template/world.json
+++ b/browser-tests/e2e/world-template/world.json
@@ -1,0 +1,13 @@
+{
+  "id": "dcc-e2e",
+  "title": "DCC E2E",
+  "system": "dcc",
+  "coreVersion": "14.365",
+  "compatibility": {
+    "minimum": "14",
+    "verified": "14.365"
+  },
+  "systemVersion": "0.70.43",
+  "description": "<p>Disposable world for the isolated e2e environment (#893). Rebuilt from browser-tests/e2e/world-template on every env bootstrap and reset — never edit the built copy, edit the template. coreVersion/systemVersion are stamped at build time by scripts/e2e-env.mjs.</p>",
+  "flags": {}
+}

--- a/docs/dev/TESTING.md
+++ b/docs/dev/TESTING.md
@@ -320,17 +320,30 @@ npx playwright install chromium chromium-headless-shell
 For parallel work across worktrees (#893), `scripts/e2e-env.mjs` bootstraps a
 self-contained Foundry server inside the checkout you run it from — its own
 gitignored `.foundry-server/` with a private `Config/` (unique port), the
-system **symlinked** so code is served live, and the test world + modules
-**copied** (LevelDB pack locks forbid sharing them between servers). The
-environment (world, module set, forced world settings such as dcc-qol
-inactive) is declared in `browser-tests/e2e/test-environment.json`.
+system **symlinked** so code is served live, modules **copied** from the
+live install (LevelDB pack locks forbid sharing them between servers), and
+the test world **built from the checked-in template** at
+`browser-tests/e2e/world-template/` — no dependence on (or leakage from) the
+live install's worlds. The environment (world id, module set, forced world
+settings such as dcc-qol inactive) is declared in
+`browser-tests/e2e/test-environment.json`.
+
+The template world (`dcc-e2e`) ships two role-4 users, both without
+passwords: **Gamemaster** (claimed by Playwright) and **Observer** — log in
+as Observer to watch or poke at an env while a suite is running, without
+stealing the GM slot the tests need. To change the world's contents, edit
+the template (each subdirectory compiles to a world LevelDB collection via
+foundryvtt-cli, `_key` fields and all, exactly like `packs/*/src`) and
+`reset`. `world.json`'s coreVersion/systemVersion are stamped at build time
+from the actual install and system.json; the dcc migration stamp is set
+automatically so fresh worlds skip the empty-world migration.
 
 ```bash
 pnpm run e2e:env up        # bootstrap (idempotent) + launch + wait ready; prints URL
 pnpm run e2e:env status    # port / pid / health for this worktree's server
 pnpm run e2e:env test -- adapter-dispatch.spec.js   # up + run spec(s) against it
 pnpm run e2e:env test      # full suite (takes the machine-wide ~/.dcc-e2e.lock)
-pnpm run e2e:env reset     # fresh world copy + re-applied settings
+pnpm run e2e:env reset     # rebuild the world from the template + re-apply settings
 pnpm run e2e:env down      # stop the server, keep .foundry-server/
 pnpm run e2e:env destroy   # stop + remove .foundry-server/
 ```
@@ -349,8 +362,9 @@ Refresh semantics: manifest **settings** are re-applied on every cold `up`
 (and on `reset`); the **system packs** copy refreshes on every `up` (rerun
 `todb` in the checkout, then restart the env); **module** copies are made
 once and only refreshed by `destroy` + `up` — a dcc-core-book update in the
-live install does not reach existing envs on its own. The world copy is only
-replaced by `reset`.
+live install does not reach existing envs on its own. The **world** is only
+rebuilt from the template by `reset` (state accumulated during test runs
+persists across `up`/`down` until then).
 
 ### Running a suite (manual, against the live install)
 

--- a/scripts/e2e-env.mjs
+++ b/scripts/e2e-env.mjs
@@ -4,10 +4,13 @@
  *
  * Builds a self-contained, gitignored .foundry-server/ dir inside this
  * checkout/worktree: its own Config/ (unique port), a Data/ where the system
- * is symlinked entry-by-entry to this checkout (code served live) but modules
- * and the test world are copies (LevelDB pack locks forbid sharing them),
- * then launches Foundry's main.js directly against it. N worktrees = N
- * servers on N ports, each with its own world, GM slot, packs and settings.
+ * is symlinked entry-by-entry to this checkout (code served live), modules
+ * are copies from the live install (LevelDB pack locks forbid sharing them),
+ * and the world is BUILT from the checked-in template at
+ * browser-tests/e2e/world-template/ (Gamemaster for Playwright + an Observer
+ * GM so a human can watch the same env). It then launches Foundry's main.js
+ * directly against it. N worktrees = N servers on N ports, each with its own
+ * world, GM slot, packs and settings.
  *
  * Usage:
  *   pnpm run e2e:env up        Bootstrap (idempotent) + launch + wait ready
@@ -111,7 +114,9 @@ function findFoundryInstall () {
     if (!fs.existsSync(pkgPath)) continue
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
     const main = path.join(installPath, pkg.main || 'main.js')
-    if (fs.existsSync(main)) return { installPath, main, build: pkg.release?.build }
+    if (fs.existsSync(main)) {
+      return { installPath, main, build: pkg.release?.build, generation: pkg.release?.generation }
+    }
   }
   fail('Could not find a Foundry VTT installation. Set FOUNDRY_PATH.')
 }
@@ -332,18 +337,66 @@ function copyModules (manifest, userdataRoot) {
   }
 }
 
-function copyWorld (manifest, userdataRoot, { force = false } = {}) {
+/**
+ * Build the disposable test world from the checked-in template at
+ * browser-tests/e2e/world-template/ — no dependence on (or leakage from) the
+ * live install's worlds, and fully reproducible on any machine. Each
+ * subdirectory of the template compiles to a world LevelDB collection via
+ * foundryvtt-cli (same pipeline as the system packs); world.json gets
+ * coreVersion/systemVersion stamped from the actual Foundry install and
+ * system.json so version drift never triggers migration prompts.
+ */
+async function buildWorld (manifest, install, { force = false } = {}) {
   const world = manifest.world
   const dest = path.join(SERVER_DIR, 'Data', 'worlds', world)
   if (fs.existsSync(dest)) {
     if (!force) return false
     fs.rmSync(dest, { recursive: true, force: true })
   }
-  const src = path.join(userdataRoot, 'Data', 'worlds', world)
-  if (!fs.existsSync(src)) fail(`World "${world}" not found at ${src}`)
-  console.log(`  Copying world ${world}...`)
-  cloneCopy(src, dest)
+  // SCRIPT_HOME fallback mirrors loadManifest: a DCC_E2E_ROOT worktree on an
+  // older branch may not carry the template yet.
+  let template = path.join(PROJECT_ROOT, 'browser-tests', 'e2e', 'world-template')
+  if (!fs.existsSync(template)) {
+    template = path.join(path.resolve(import.meta.dirname, '..'), 'browser-tests', 'e2e', 'world-template')
+  }
+  if (!fs.existsSync(path.join(template, 'world.json'))) {
+    fail(`World template not found at ${template}`)
+  }
+  console.log(`  Building world ${world} from template...`)
+  const worldJson = JSON.parse(fs.readFileSync(path.join(template, 'world.json'), 'utf-8'))
+  worldJson.id = world
+  if (install.generation && install.build) {
+    worldJson.coreVersion = `${install.generation}.${install.build}`
+    worldJson.compatibility = { minimum: String(install.generation), verified: worldJson.coreVersion }
+  }
+  const systemJson = path.join(PROJECT_ROOT, 'system.json')
+  if (fs.existsSync(systemJson)) {
+    worldJson.systemVersion = JSON.parse(fs.readFileSync(systemJson, 'utf-8')).version
+  }
+  fs.mkdirSync(path.join(dest, 'data'), { recursive: true })
+  fs.writeFileSync(path.join(dest, 'world.json'), JSON.stringify(worldJson, null, 2) + '\n')
+  const require = createRequire(path.join(PROJECT_ROOT, 'package.json'))
+  const { compilePack } = require('@foundryvtt/foundryvtt-cli')
+  for (const entry of fs.readdirSync(template, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    await compilePack(path.join(template, entry.name), path.join(dest, 'data', entry.name), { log: false })
+  }
   return true
+}
+
+/**
+ * The stored dcc.systemMigrationVersion that makes checkMigrations skip. A
+ * fresh world would otherwise run a (harmless but noisy) empty-world
+ * migration on first GM login. Parsed from migrations.js so it can't go
+ * stale; if parsing fails the migration simply runs once.
+ */
+function migrationStamp () {
+  try {
+    const src = fs.readFileSync(path.join(PROJECT_ROOT, 'module', 'migrations.js'), 'utf-8')
+    const match = src.match(/NEEDS_MIGRATION_VERSION = ([\d.]+)/)
+    if (match) return Number(match[1])
+  } catch { /* fall through */ }
+  return null
 }
 
 /**
@@ -354,7 +407,11 @@ function copyWorld (manifest, userdataRoot, { force = false } = {}) {
  * anything else replaces it.
  */
 async function applyWorldSettings (manifest) {
-  const settings = manifest.settings || {}
+  const settings = { ...(manifest.settings || {}) }
+  const stamp = migrationStamp()
+  if (stamp !== null && settings['dcc.systemMigrationVersion'] === undefined) {
+    settings['dcc.systemMigrationVersion'] = stamp
+  }
   if (Object.keys(settings).length === 0) return
   const require = createRequire(path.join(PROJECT_ROOT, 'package.json'))
   const { ClassicLevel } = require('classic-level')
@@ -612,15 +669,16 @@ async function cmdUp () {
   const port = existing?.port ?? await choosePort()
 
   console.log(`Bootstrapping .foundry-server/ (Foundry build ${install.build}, port ${port})`)
-  const needsCopies = !fs.existsSync(path.join(SERVER_DIR, 'Data', 'worlds', manifest.world)) ||
-    (manifest.modules || []).some(m => !fs.existsSync(path.join(SERVER_DIR, 'Data', 'modules', m)))
+  // The world is built from the checked-in template, so only module copies
+  // still read the live install's LevelDBs.
+  const needsCopies = (manifest.modules || []).some(m => !fs.existsSync(path.join(SERVER_DIR, 'Data', 'modules', m)))
   if (needsCopies) await warnIfLiveServerRunning()
   ensureBuildArtifacts()
   writeOptions(port, manifest.world)
   copyLicense(userdataRoot)
   linkSystem()
   copyModules(manifest, userdataRoot)
-  copyWorld(manifest, userdataRoot)
+  await buildWorld(manifest, install)
   // Re-applied on every cold start so manifest settings edits take effect
   // without a full reset (the world db is closed here — server is down).
   await applyWorldSettings(manifest)
@@ -672,10 +730,10 @@ async function cmdReset () {
   const state = readState()
   const wasRunning = await stopServer(state, { quiet: true })
   const manifest = loadManifest()
-  const userdataRoot = findUserdataRoot()
-  copyWorld(manifest, userdataRoot, { force: true })
+  const install = findFoundryInstall()
+  await buildWorld(manifest, install, { force: true })
   await applyWorldSettings(manifest)
-  console.log(`World ${manifest.world} reset to a fresh copy.`)
+  console.log(`World ${manifest.world} rebuilt from the template.`)
   if (wasRunning) await cmdUp()
 }
 


### PR DESCRIPTION
## Summary

Final checklist item of #893 (world-template phase 2).

- **The isolated env's world is now built, not copied.** `scripts/e2e-env.mjs` compiles a disposable `dcc-e2e` world from the checked-in template at `browser-tests/e2e/world-template/` — `world.json` plus per-collection JSON docs compiled via `foundryvtt-cli`'s `compilePack`, the same pipeline as `packs/*/src`. This removes the last world-shaped dependence on the live install: no personal world data leaking into test envs, no torn-LevelDB-copy risk for the world (only module copies still read the live install), and `reset` rebuilds from the template in milliseconds. Envs are now reproducible on any machine with a Foundry install + license.
- **Observer GM user.** The template ships two passwordless role-4 users: **Gamemaster** (claimed by Playwright's worker-scoped session) and **Observer** — log into any worktree's env as Observer to watch or poke at a run without stealing the GM slot the tests need.
- **Version stamping so nothing goes stale:** `world.json`'s `coreVersion`/`compatibility` come from the actual Foundry install's `package.json` and `systemVersion` from `system.json` at build time; `dcc.systemMigrationVersion` is stamped from `migrations.js`'s `NEEDS_MIGRATION_VERSION` (parsed, not hardcoded) so fresh worlds skip the empty-world migration — and if parsing ever fails, the migration just runs once, harmlessly.
- Template fallback mirrors the manifest fallback for `DCC_E2E_ROOT` worktrees on pre-template branches; TESTING.md documents the template-editing workflow and updated refresh semantics.

## Test plan

- [x] `destroy` → `up`: world builds from template, both users appear on `/join` (verified via headless browser: "Gamemaster, Observer"), migration stamp + moduleConfiguration applied, license sign+relaunch path still green
- [x] **Full Playwright suite against the minimal template world: 291/292 passed (~5 min)** — the strongest possible evidence the suite needs nothing from the old copied world (specs create their own actors/items/probe scene; fixtures already dismiss the fresh-world welcome dialogs)
- [x] The one failure (`ability-score-log` spellburn click timeout) passes standalone 7/7 — load-order flake, not a world-content gap
- [x] `reset` rebuilds from template; `pnpm test` green (2374); standard clean

Completes the #893 checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)