### PR TITLE
chore: doctor cleanup — slim CLAUDE.md, fix remote session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -7,8 +7,7 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-# Use `npm ci` for a deterministic install from package-lock.json: it never
-# rewrites the lockfile (unlike `npm install`, which can reconcile it and leave
-# stray churn in the working tree). Requires the lockfile to be in sync, which
-# is the desired failure mode in an ephemeral session.
-npm ci --no-audit --no-fund
+# Deterministic install from pnpm-lock.yaml: --frozen-lockfile never rewrites
+# the lockfile and fails if it's out of sync with package.json, which is the
+# desired failure mode in an ephemeral session.
+pnpm install --frozen-lockfile

--- a/.claude/skills/sync-core-lib/SKILL.md
+++ b/.claude/skills/sync-core-lib/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: sync-core-lib
+description: Sync the vendored dcc-core-lib copy after a lib fix merges upstream, then clean up temporary adapter workarounds. Use after a moonloch/dcc-core-lib PR lands, or when asked to update module/vendor/dcc-core-lib.
+---
+
+# Vendor sync for dcc-core-lib
+
+The lib's compiled output lives at `module/vendor/dcc-core-lib/` and is
+committed to the system repo (Foundry has no bundler). The upstream
+checkout is at `/Users/timlwhite/WebstormProjects/dcc-core-lib`
+(GitHub repo `moonloch/dcc-core-lib`).
+
+## Sync procedure
+
+1. After the lib PR merges, pull `main` in the lib checkout.
+2. From the system repo, run `pnpm run sync-core-lib`. The script
+   (`scripts/sync-core-lib.mjs`) builds the lib via `pnpm run build`,
+   copies `dist/` into the vendor directory, and writes
+   `module/vendor/dcc-core-lib/VERSION.json` with the source commit
+   SHA + timestamp.
+   - Override the source path with
+     `DCC_CORE_LIB_SRC=/path/to/dcc-core-lib pnpm run sync-core-lib`.
+3. Commit the resulting vendor diff with a message like
+   `vendor: sync dcc-core-lib to <version> (<sha7>)`.
+
+## Adapter cleanup follows the sync
+
+Once the new vendor copy is in place, remove any temporary adapter
+workaround added while the lib fix was in flight, and update tests
+that were asserting the workaround's compensated values back to the
+natural contract.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,16 +18,6 @@ Quick reference for Claude Code working with the DCC system for FoundryVTT.
 | `pnpm run tojson` | Extract LevelDB → JSON packs |
 | `pnpm run compare-lang` | Check translation coverage |
 
-## Key Files
-
-| File | Purpose |
-|------|---------|
-| `module/dcc.js` | Entry point, system init |
-| `module/actor.js` | DCCActor class |
-| `module/item.js` | DCCItem class |
-| `template.json` | Data model definition |
-| `styles/dcc.scss` | Main styles (edit this, not .css) |
-
 ## Critical Rules
 
 - **SCSS only**: Edit `styles/dcc.scss`, never `styles/dcc.css`
@@ -69,21 +59,8 @@ to be in the lib (not just an adapter translation issue):
   adapter-side compensation as a permanent solution. (Short-lived
   workarounds in the adapter are OK while the lib PR is in flight,
   but the workaround must be removed once the fix lands.)
-- **Vendor sync.** The lib's compiled output lives at
-  `module/vendor/dcc-core-lib/` and is committed to the system repo
-  (Foundry has no bundler). After the lib PR merges and you've pulled
-  `main` in the lib checkout, run `pnpm run sync-core-lib` from the
-  system repo. The script (`scripts/sync-core-lib.mjs`) builds the
-  lib via `pnpm run build`, copies `dist/` into the vendor directory,
-  and writes `module/vendor/dcc-core-lib/VERSION.json` with the
-  source commit SHA + timestamp. Override the source path with
-  `DCC_CORE_LIB_SRC=/path/to/dcc-core-lib pnpm run sync-core-lib`.
-  Commit the resulting vendor diff with a message like
-  `vendor: sync dcc-core-lib to <version> (<sha7>)`.
-- **Adapter cleanup follows the sync.** Once the new vendor copy is
-  in place, remove any temporary adapter workaround you added while
-  the lib fix was in flight, and update tests that were asserting
-  the workaround's compensated values back to the natural contract.
+- After the lib fix merges, follow the `sync-core-lib` skill for the
+  vendor sync procedure and post-sync adapter cleanup.
 
 ## Standing authorizations
 


### PR DESCRIPTION
## Summary
- Trim the derivable **Key Files** table from `CLAUDE.md` (reconstructable from `ls`/`system.json`; its one gotcha — edit `.scss` not `.css` — already lives in Critical Rules)
- Move the dcc-core-lib **vendor sync procedure** (sync script details, commit-message format, post-sync adapter cleanup) into a lazy-loaded skill at `.claude/skills/sync-core-lib/SKILL.md`; the always-loaded policy (fix lib bugs upstream in `moonloch/dcc-core-lib`, no permanent adapter workarounds, scoped npm-name warning) stays in `CLAUDE.md` with a pointer to the skill
- Fix `.claude/hooks/session-start.sh`: it ran `npm ci` in remote sessions, which always fails now that the repo is a pnpm workspace with no `package-lock.json` (#898); switched to `pnpm install --frozen-lockfile`, which keeps the same never-rewrite-the-lockfile contract

Net effect: ~340 fewer resident context tokens per Claude session, and a working remote-session install hook. No runtime/system code touched.

## Test plan
- [x] `pnpm run check` green (format, scss, 2431 unit tests, compare-lang)
- [x] `bash -n .claude/hooks/session-start.sh` and local no-op path verified (hook only installs when `CLAUDE_CODE_REMOTE=true`)
- [x] `sync-core-lib` skill registers (confirmed live in the authoring session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)