### PR TITLE
Add autocomplete for Active Effect attribute keys

### DIFF
--- a/browser-tests/e2e/active-effects.spec.js
+++ b/browser-tests/e2e/active-effects.spec.js
@@ -1026,4 +1026,136 @@ test.describe('DCC Active Effects', () => {
       expect(result.hp).toEqual(['HP Boon'])
     })
   })
+
+  test.describe('Effect Key Autocomplete (#904)', () => {
+    test('effect config injects a datalist wired to the key input', async ({ page }) => {
+      const result = await page.evaluate(async () => {
+        const actor = await Actor.create({ name: 'V14 Effect Autocomplete', type: 'Player' })
+        const [effect] = await actor.createEmbeddedDocuments('ActiveEffect', [{
+          name: 'Autocomplete Probe',
+          changes: [{ key: '', value: '1', type: 'add' }]
+        }])
+        const sheet = effect.sheet
+        try {
+          await sheet.render(true)
+          await new Promise(resolve => setTimeout(resolve, 500))
+          const el = sheet.element
+          const datalist = el.querySelector('datalist.dcc-effect-key-list')
+          const input = el.querySelector('input[name="system.changes.0.key"]')
+          const values = datalist ? Array.from(datalist.options).map(o => o.value) : []
+          return {
+            hasDatalist: !!datalist,
+            datalistId: datalist?.id ?? null,
+            inputList: input?.getAttribute('list') ?? null,
+            hasStrOtherMod: values.includes('system.abilities.str.otherMod'),
+            hasSaveBonus: values.includes('system.saves.ref.otherBonus'),
+            hasActionDice: values.includes('system.attributes.actionDice.value'),
+            hasHpValue: values.includes('system.attributes.hp.value'),
+            hasAbilityBase: values.includes('system.abilities.str.value'),
+            strLabel: datalist?.querySelector('option[value="system.abilities.str.otherMod"]')?.label ?? null
+          }
+        } finally {
+          await sheet.close().catch(() => {})
+        }
+      })
+
+      expect(result.hasDatalist).toBe(true)
+      expect(result.inputList).toBe(result.datalistId)
+      expect(result.hasStrOtherMod).toBe(true)
+      expect(result.hasSaveBonus).toBe(true)
+      expect(result.hasActionDice).toBe(true)
+      // Editable base values must never be offered
+      expect(result.hasHpValue).toBe(false)
+      expect(result.hasAbilityBase).toBe(false)
+      // Options carry human-readable labels ("Strength")
+      expect(result.strLabel).toBeTruthy()
+    })
+
+    test('rows added via the add-change control pick up the datalist', async ({ page }) => {
+      const result = await page.evaluate(async () => {
+        const actor = await Actor.create({ name: 'V14 Effect Autocomplete Add', type: 'Player' })
+        const [effect] = await actor.createEmbeddedDocuments('ActiveEffect', [{
+          name: 'Autocomplete Add Probe',
+          changes: [{ key: 'system.abilities.str.otherMod', value: '1', type: 'add' }]
+        }])
+        const sheet = effect.sheet
+        try {
+          await sheet.render(true)
+          await new Promise(resolve => setTimeout(resolve, 500))
+          sheet.element.querySelector('[data-action="addChange"]').click()
+          // Poll for the re-rendered second row carrying the list attribute
+          let newInput = null
+          for (let i = 0; i < 20 && !newInput?.getAttribute('list'); i++) {
+            await new Promise(resolve => setTimeout(resolve, 250))
+            newInput = sheet.element.querySelector('input[name="system.changes.1.key"]')
+          }
+          const datalist = sheet.element.querySelector('datalist.dcc-effect-key-list')
+          return {
+            hasNewInput: !!newInput,
+            newInputList: newInput?.getAttribute('list') ?? null,
+            datalistId: datalist?.id ?? null,
+            datalistCount: sheet.element.querySelectorAll('datalist.dcc-effect-key-list').length
+          }
+        } finally {
+          await sheet.close().catch(() => {})
+        }
+      })
+
+      expect(result.hasNewInput).toBe(true)
+      expect(result.newInputList).toBe(result.datalistId)
+      expect(result.datalistCount).toBe(1)
+    })
+
+    test('NPC effects offer NPC keys only; unowned item effects fall back to the curated list', async ({ page }) => {
+      const result = await page.evaluate(async () => {
+        const observed = {}
+        const npc = await Actor.create({ name: 'V14 Effect Autocomplete NPC', type: 'NPC' })
+        const [npcEffect] = await npc.createEmbeddedDocuments('ActiveEffect', [{
+          name: 'NPC Probe',
+          changes: [{ key: '', value: '1', type: 'add' }]
+        }])
+        const npcSheet = npcEffect.sheet
+        try {
+          await npcSheet.render(true)
+          await new Promise(resolve => setTimeout(resolve, 500))
+          const npcValues = Array.from(npcSheet.element.querySelector('datalist.dcc-effect-key-list')?.options ?? []).map(o => o.value)
+          observed.npcHasSave = npcValues.includes('system.saves.wil.otherBonus')
+          observed.npcHasAbility = npcValues.includes('system.abilities.str.otherMod')
+          observed.npcHasLuckDie = npcValues.includes('system.class.luckDie')
+          observed.npcHasThiefSkill = npcValues.includes('system.skills.sneakSilently.otherMod')
+        } finally {
+          await npcSheet.close().catch(() => {})
+        }
+
+        const item = await Item.create({ name: 'V14 Autocomplete Charm', type: 'equipment' })
+        const [itemEffect] = await item.createEmbeddedDocuments('ActiveEffect', [{
+          name: 'Item Probe',
+          transfer: true,
+          changes: [{ key: '', value: '1', type: 'add' }]
+        }])
+        const itemSheet = itemEffect.sheet
+        try {
+          await itemSheet.render(true)
+          await new Promise(resolve => setTimeout(resolve, 500))
+          const itemValues = Array.from(itemSheet.element.querySelector('datalist.dcc-effect-key-list')?.options ?? []).map(o => o.value)
+          observed.itemHasLuckDie = itemValues.includes('system.class.luckDie')
+          observed.itemHasAbility = itemValues.includes('system.abilities.str.otherMod')
+          observed.itemHasShieldBash = itemValues.includes('system.skills.shieldBash.otherMod')
+        } finally {
+          await itemSheet.close().catch(() => {})
+        }
+        return observed
+      })
+
+      expect(result.npcHasSave).toBe(true)
+      expect(result.npcHasAbility).toBe(true)
+      // Player-class fields don't exist on the NPC schema
+      expect(result.npcHasLuckDie).toBe(false)
+      expect(result.npcHasThiefSkill).toBe(false)
+      // Unowned world item: curated fallback list offers everything
+      expect(result.itemHasLuckDie).toBe(true)
+      expect(result.itemHasAbility).toBe(true)
+      expect(result.itemHasShieldBash).toBe(true)
+    })
+  })
 })

--- a/docs/user-guide/Active-Effects.md
+++ b/docs/user-guide/Active-Effects.md
@@ -39,7 +39,13 @@ When you create a new effect, you can configure:
 
 Each change consists of:
 
-- **Attribute Key**: The path to the value you want to modify
+- **Attribute Key**: The path to the value you want to modify. This field
+  autocompletes: click into it (or start typing, e.g. `sneak` or `saves`) and
+  your browser offers the valid modifier keys for the actor the effect
+  applies to, each labeled with the stat it modifies. Only the sanctioned
+  modifier-style keys are suggested — the editable base values you should
+  never target (see the warning below) are deliberately left out. You can
+  still type any path by hand.
 - **Change Mode**: How to apply the modification (Add, Multiply, Override, etc.)
 - **Effect Value**: The value to use for the modification. This can be a plain number (e.g., `2`) or an `@`-variable reference to another actor attribute (e.g., `@system.abilities.lck.mod`). See [Using @-Variable References](#using--variable-references) below.
 

--- a/module/__tests__/active-effect-key-autocomplete.test.js
+++ b/module/__tests__/active-effect-key-autocomplete.test.js
@@ -1,0 +1,241 @@
+/**
+ * Tests for the Active Effect attribute-key autocomplete (#904)
+ */
+
+import { expect, test, describe, vi, beforeEach, afterEach } from 'vitest'
+import '../__mocks__/foundry.js'
+import {
+  isSanctionedEffectKey,
+  getEffectKeyOptions,
+  onRenderActiveEffectConfig
+} from '../active-effect-key-autocomplete.mjs'
+
+/**
+ * Build a fake actor exposing just what the autocomplete reads:
+ * documentName, system.toObject() and system.skills labels
+ * @param {object} data - Raw system data
+ * @returns {object}
+ */
+function fakeActor (data) {
+  return {
+    documentName: 'Actor',
+    system: {
+      ...data,
+      toObject () { return data }
+    }
+  }
+}
+
+const playerSystemData = {
+  abilities: {
+    str: { value: 10, max: 10, mod: 0, otherMod: 0 },
+    lck: { value: 10, max: 10, mod: 0, otherMod: 0 }
+  },
+  attributes: {
+    ac: { value: 10, checkPenalty: 0, otherMod: 0 },
+    actionDice: { value: '1d20', options: [{ value: '1d20', label: '1d20' }] },
+    critical: { die: '1d4', table: 'I' },
+    fumble: { die: '1d4' },
+    hp: { value: 5, max: 5 },
+    init: { die: '1d20', otherMod: 0, value: '+0' },
+    speed: { value: '30', base: '30', otherMod: 0 }
+  },
+  details: {
+    attackHitBonus: {
+      melee: { value: '+0', adjustment: '+0' },
+      missile: { value: '+0', adjustment: '+0' }
+    },
+    attackDamageBonus: {
+      melee: { value: '+0', adjustment: '+0' },
+      missile: { value: '+0', adjustment: '+0' }
+    }
+  },
+  saves: {
+    frt: { value: '+0', otherBonus: '' },
+    ref: { value: '+0', otherBonus: '' },
+    wil: { value: '+0', otherBonus: '' }
+  },
+  class: {
+    className: 'Thief',
+    luckDie: '1d3',
+    backstab: '0',
+    spellCheckOtherMod: null
+  },
+  skills: {
+    sneakSilently: { label: 'DCC.SneakSilently', ability: 'agl', value: '0', otherMod: 0 },
+    detectSecretDoors: { label: 'DCC.HeightenedSenses', ability: 'int', value: '+4', otherMod: 0 }
+  }
+}
+
+describe('isSanctionedEffectKey', () => {
+  test('accepts modifier-style fields', () => {
+    expect(isSanctionedEffectKey('system.abilities.str.otherMod')).toBe(true)
+    expect(isSanctionedEffectKey('system.saves.ref.otherBonus')).toBe(true)
+    expect(isSanctionedEffectKey('system.skills.sneakSilently.otherMod')).toBe(true)
+    expect(isSanctionedEffectKey('system.class.spellCheckOtherMod')).toBe(true)
+    expect(isSanctionedEffectKey('system.details.attackHitBonus.melee.adjustment')).toBe(true)
+    expect(isSanctionedEffectKey('system.details.attackDamageBonus.missile.adjustment')).toBe(true)
+  })
+
+  test('accepts dice-chain and class extras', () => {
+    expect(isSanctionedEffectKey('system.attributes.actionDice.value')).toBe(true)
+    expect(isSanctionedEffectKey('system.attributes.critical.die')).toBe(true)
+    expect(isSanctionedEffectKey('system.attributes.fumble.die')).toBe(true)
+    expect(isSanctionedEffectKey('system.class.luckDie')).toBe(true)
+    expect(isSanctionedEffectKey('system.class.backstab')).toBe(true)
+  })
+
+  test('rejects editable base values and derived fields', () => {
+    expect(isSanctionedEffectKey('system.abilities.str.value')).toBe(false)
+    expect(isSanctionedEffectKey('system.abilities.str.max')).toBe(false)
+    expect(isSanctionedEffectKey('system.abilities.str.mod')).toBe(false)
+    expect(isSanctionedEffectKey('system.attributes.hp.value')).toBe(false)
+    expect(isSanctionedEffectKey('system.attributes.hp.max')).toBe(false)
+    expect(isSanctionedEffectKey('system.attributes.ac.value')).toBe(false)
+    expect(isSanctionedEffectKey('system.saves.ref.value')).toBe(false)
+    expect(isSanctionedEffectKey('system.skills.sneakSilently.value')).toBe(false)
+    expect(isSanctionedEffectKey('system.details.attackHitBonus.melee.value')).toBe(false)
+  })
+})
+
+describe('getEffectKeyOptions', () => {
+  test('derives keys from the parent actor schema, excluding base values', () => {
+    const effect = { parent: fakeActor(playerSystemData) }
+    const options = getEffectKeyOptions(effect)
+    const values = options.map(o => o.value)
+
+    expect(values).toContain('system.abilities.str.otherMod')
+    expect(values).toContain('system.attributes.ac.otherMod')
+    expect(values).toContain('system.attributes.actionDice.value')
+    expect(values).toContain('system.details.attackHitBonus.melee.adjustment')
+    expect(values).toContain('system.saves.wil.otherBonus')
+    expect(values).toContain('system.class.luckDie')
+    expect(values).toContain('system.skills.sneakSilently.otherMod')
+
+    expect(values).not.toContain('system.attributes.hp.value')
+    expect(values).not.toContain('system.abilities.str.value')
+    expect(values).not.toContain('system.abilities.str.mod')
+    expect(values).not.toContain('system.saves.frt.value')
+  })
+
+  test('labels known keys and skill keys from actor data', () => {
+    const effect = { parent: fakeActor(playerSystemData) }
+    const options = getEffectKeyOptions(effect)
+    const byValue = Object.fromEntries(options.map(o => [o.value, o.label]))
+
+    expect(byValue['system.abilities.str.otherMod']).toBe('Strength')
+    expect(byValue['system.saves.frt.otherBonus']).toBe('Fortitude')
+    // Skill label comes from the actor's own data (class/module overrides win)
+    expect(byValue['system.skills.detectSecretDoors.otherMod']).toBe('HeightenedSenses')
+  })
+
+  test('walks up to the owning actor for effects on owned items', () => {
+    const actor = fakeActor(playerSystemData)
+    const effect = { parent: { documentName: 'Item', parent: actor } }
+    const values = getEffectKeyOptions(effect).map(o => o.value)
+    expect(values).toContain('system.abilities.lck.otherMod')
+    expect(values).not.toContain('system.attributes.hp.value')
+  })
+
+  test('falls back to the curated list for unowned items', () => {
+    const effect = { parent: { documentName: 'Item', parent: null } }
+    const options = getEffectKeyOptions(effect)
+    const curated = global.CONFIG.DCC.activeEffectKeyLabels
+    expect(options.length).toBe(Object.keys(curated).length)
+    const values = options.map(o => o.value)
+    expect(values).toContain('system.class.luckDie')
+    expect(values).toContain('system.skills.shieldBash.otherMod')
+  })
+
+  test('falls back to the curated list when the actor has no matching fields', () => {
+    const effect = { parent: fakeActor({ details: { notes: '' } }) }
+    const options = getEffectKeyOptions(effect)
+    expect(options.length).toBe(Object.keys(global.CONFIG.DCC.activeEffectKeyLabels).length)
+  })
+})
+
+describe('onRenderActiveEffectConfig', () => {
+  /** Minimal stand-in for a DOM node */
+  class FakeNode {
+    constructor (tagName) {
+      this.tagName = tagName.toUpperCase()
+      this.children = []
+      this.attributes = {}
+      this.className = ''
+      this.id = ''
+    }
+
+    appendChild (child) {
+      this.children.push(child)
+      return child
+    }
+
+    replaceChildren (...nodes) {
+      this.children = nodes
+    }
+
+    setAttribute (name, value) {
+      this.attributes[name] = value
+    }
+
+    getAttribute (name) {
+      return this.attributes[name]
+    }
+  }
+
+  /** Fake app root exposing the two selectors the handler uses */
+  function fakeRoot (keyInputs) {
+    return {
+      children: [],
+      appendChild (child) {
+        this.children.push(child)
+        return child
+      },
+      querySelector (selector) {
+        if (selector.startsWith('datalist')) {
+          return this.children.find(c => c.tagName === 'DATALIST') ?? null
+        }
+        return null
+      },
+      querySelectorAll (selector) {
+        return selector.startsWith('input') ? keyInputs : []
+      }
+    }
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal('document', { createElement: tag => new FakeNode(tag) })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  test('injects a datalist and points key inputs at it', () => {
+    const keyInputs = [new FakeNode('input'), new FakeNode('input')]
+    const root = fakeRoot(keyInputs)
+    const app = { id: 'ActiveEffectConfig-test', document: { parent: fakeActor(playerSystemData) } }
+
+    onRenderActiveEffectConfig(app, root)
+
+    const datalist = root.children.find(c => c.tagName === 'DATALIST')
+    expect(datalist).toBeDefined()
+    expect(datalist.id).toBe('ActiveEffectConfig-test-effect-key-list')
+    expect(datalist.children.length).toBeGreaterThan(0)
+    expect(datalist.children.map(o => o.value)).toContain('system.abilities.str.otherMod')
+    for (const input of keyInputs) {
+      expect(input.getAttribute('list')).toBe('ActiveEffectConfig-test-effect-key-list')
+    }
+  })
+
+  test('re-render reuses the existing datalist instead of duplicating it', () => {
+    const root = fakeRoot([])
+    const app = { id: 'ActiveEffectConfig-test', document: { parent: fakeActor(playerSystemData) } }
+
+    onRenderActiveEffectConfig(app, root)
+    onRenderActiveEffectConfig(app, root)
+
+    const datalists = root.children.filter(c => c.tagName === 'DATALIST')
+    expect(datalists.length).toBe(1)
+  })
+})

--- a/module/__tests__/chat-and-hook-wiring.test.js
+++ b/module/__tests__/chat-and-hook-wiring.test.js
@@ -97,6 +97,7 @@ const {
 } = await import('../chat-and-hook-wiring.mjs')
 
 const { abilityLogPreUpdateActor } = await import('../ability-score-log.js')
+const { onRenderActiveEffectConfig } = await import('../active-effect-key-autocomplete.mjs')
 const { onModifyAttackRollTerms } = await import('../weapon-range.mjs')
 const {
   onCombatTurnForActionDice,
@@ -732,7 +733,7 @@ describe('CHAT_AND_HOOK_WIRING_HOOKS dispatch table', () => {
     expect(CHAT_AND_HOOK_WIRING_HOOKS.getProseMirrorMenuDropDowns.handler).toBe(onGetProseMirrorMenuDropDowns)
   })
 
-  test('covers exactly the twenty-two documented hook names', () => {
+  test('covers exactly the twenty-three documented hook names', () => {
     expect(Object.keys(CHAT_AND_HOOK_WIRING_HOOKS).sort()).toEqual([
       'applyActiveEffect',
       'combatRound',
@@ -750,6 +751,7 @@ describe('CHAT_AND_HOOK_WIRING_HOOKS dispatch table', () => {
       'preCreateActor',
       'preCreateItem',
       'preUpdateActor',
+      'renderActiveEffectConfig',
       'renderActorDirectory',
       'renderChatMessageHTML',
       'renderCombatTracker',
@@ -787,6 +789,7 @@ describe('registerChatAndHookWiring', () => {
     expect(onCalls.getCompendiumContextOptions).toEqual([onGetCompendiumContextOptions])
     expect(onCalls.getUserContextOptions).toEqual([onGetUserContextOptions])
     expect(onCalls.renderActorDirectory).toEqual([onRenderActorDirectory])
+    expect(onCalls.renderActiveEffectConfig).toEqual([onRenderActiveEffectConfig])
     expect(onCalls.preCreateActor).toEqual([onPreCreateActor])
     expect(onCalls.preCreateItem).toEqual([onPreCreateItem])
     expect(onCalls.applyActiveEffect).toEqual([onApplyActiveEffect])
@@ -810,12 +813,12 @@ describe('registerChatAndHookWiring', () => {
     expect(globalThis.Hooks.once).toHaveBeenCalledWith('item-piles-ready', onItemPilesReady)
   })
 
-  test('registers exactly twenty-two Hooks.on listeners and one Hooks.once listener', () => {
+  test('registers exactly twenty-three Hooks.on listeners and one Hooks.once listener', () => {
     registerChatAndHookWiring()
 
-    // Twenty-one dispatch-table listeners (incl. the seven action-dice combat
+    // Twenty-two dispatch-table listeners (incl. the seven action-dice combat
     // hooks) + the ability-score-log fallback logger
-    expect(globalThis.Hooks.on).toHaveBeenCalledTimes(22)
+    expect(globalThis.Hooks.on).toHaveBeenCalledTimes(23)
     expect(globalThis.Hooks.once).toHaveBeenCalledTimes(1)
   })
 })

--- a/module/active-effect-key-autocomplete.mjs
+++ b/module/active-effect-key-autocomplete.mjs
@@ -1,0 +1,126 @@
+/* global game, foundry, CONFIG, document */
+
+/**
+ * Autocomplete for Active Effect attribute keys (#904).
+ *
+ * Injects a <datalist> of sanctioned DCC attribute keys into the core
+ * ActiveEffectConfig sheet and attaches it to each change-row key input,
+ * so typing a key offers valid completions instead of requiring users to
+ * memorize paths from the docs.
+ *
+ * Keys are derived from the owning actor's schema where possible (which
+ * automatically picks up modifier fields contributed by class mixins and
+ * sibling modules) and fall back to the curated
+ * `CONFIG.DCC.activeEffectKeyLabels` list when no actor is available
+ * (e.g. effects on unowned world items).
+ */
+
+// Dice-chain targets and other sanctioned keys that don't follow the
+// otherMod / otherBonus / adjustment naming patterns
+const EXTRA_SANCTIONED_KEYS = [
+  'system.attributes.actionDice.value',
+  'system.attributes.critical.die',
+  'system.attributes.fumble.die',
+  'system.class.luckDie',
+  'system.class.backstab'
+]
+
+const ATTACK_ADJUSTMENT_PATTERN = /^system\.details\.attack(?:Hit|Damage)Bonus\.(?:melee|missile)\.adjustment$/
+
+/**
+ * Is this attribute key a sanctioned Active Effect target?
+ * Modifier-style fields only — never the editable base values
+ * (see docs/user-guide/Active-Effects.md).
+ * @param {string} key - Full attribute key path (e.g. 'system.saves.ref.otherBonus')
+ * @returns {boolean}
+ */
+export function isSanctionedEffectKey (key) {
+  // Covers both nested fields (`saves.ref.otherBonus`) and camelCase
+  // composites (`class.spellCheckOtherMod`)
+  return key.endsWith('.otherMod') || key.endsWith('OtherMod') ||
+    key.endsWith('.otherBonus') || key.endsWith('OtherBonus') ||
+    ATTACK_ADJUSTMENT_PATTERN.test(key) ||
+    EXTRA_SANCTIONED_KEYS.includes(key)
+}
+
+/**
+ * Find the actor an effect will apply to, if determinable
+ * @param {ActiveEffect} effect
+ * @returns {Actor|null}
+ */
+function getTargetActor (effect) {
+  const parent = effect?.parent
+  if (parent?.documentName === 'Actor') return parent
+  if (parent?.documentName === 'Item' && parent.parent?.documentName === 'Actor') return parent.parent
+  return null
+}
+
+/**
+ * Localized label for a sanctioned key. Prefers the curated label map;
+ * skill keys fall back to the label stored in the actor's skill data so
+ * class-specific overrides (e.g. elf Heightened Senses) and sibling-module
+ * skills label themselves.
+ * @param {string} key - Full attribute key path
+ * @param {Actor|null} actor - Owning actor, if any
+ * @returns {string} - Localized label, or '' if none is known
+ */
+function labelForKey (key, actor) {
+  const skillMatch = key.match(/^system\.skills\.([^.]+)\.otherMod$/)
+  const skillLabel = skillMatch ? actor?.system?.skills?.[skillMatch[1]]?.label : null
+  const labelKey = skillLabel ?? CONFIG.DCC.activeEffectKeyLabels[key]
+  return labelKey ? game.i18n.localize(labelKey) : ''
+}
+
+/**
+ * Build the autocomplete options for an effect's attribute-key inputs.
+ * @param {ActiveEffect} effect - The effect being configured
+ * @returns {Array<{value: string, label: string}>}
+ */
+export function getEffectKeyOptions (effect) {
+  const actor = getTargetActor(effect)
+  if (actor?.system) {
+    const flat = foundry.utils.flattenObject(actor.system.toObject())
+    const keys = Object.keys(flat)
+      .map(key => `system.${key}`)
+      .filter(isSanctionedEffectKey)
+    if (keys.length) {
+      return keys.map(key => ({ value: key, label: labelForKey(key, actor) }))
+    }
+  }
+
+  // No actor context (unowned item) or nothing matched (e.g. Party actors):
+  // offer the full curated list
+  return Object.entries(CONFIG.DCC.activeEffectKeyLabels)
+    .map(([value, labelKey]) => ({ value, label: game.i18n.localize(labelKey) }))
+}
+
+/**
+ * renderActiveEffectConfig hook: inject/update the key datalist and point
+ * every change-row key input at it. Runs on every render, so rows added
+ * via the sheet's own add-change control pick the datalist up too.
+ * @param {ActiveEffectConfig} app - The effect config application
+ * @param {HTMLElement} element - The application's root element
+ */
+export function onRenderActiveEffectConfig (app, element) {
+  const options = getEffectKeyOptions(app.document)
+  if (!options.length) return
+
+  const listId = `${app.id}-effect-key-list`
+  let datalist = element.querySelector('datalist.dcc-effect-key-list')
+  if (!datalist) {
+    datalist = document.createElement('datalist')
+    datalist.className = 'dcc-effect-key-list'
+    datalist.id = listId
+    element.appendChild(datalist)
+  }
+  datalist.replaceChildren(...options.map(({ value, label }) => {
+    const option = document.createElement('option')
+    option.value = value
+    if (label) option.label = label
+    return option
+  }))
+
+  for (const input of element.querySelectorAll('input[name^="system.changes."][name$=".key"]')) {
+    input.setAttribute('list', listId)
+  }
+}

--- a/module/chat-and-hook-wiring.mjs
+++ b/module/chat-and-hook-wiring.mjs
@@ -12,6 +12,7 @@
  *   - `getCompendiumContextOptions` — hide "Import All" for non-world-document packs
  *     (our `dcc-effects` ActiveEffect compendium)
  *   - `renderActorDirectory` — parser quick-import bridge
+ *   - `renderActiveEffectConfig` — attribute-key autocomplete datalist (#904)
  *   - `preCreateActor` / `preCreateItem` — default-image assignment + Player
  *     prototype-token actor-link
  *   - `applyActiveEffect` — DiceChain bump for string-valued dice expressions
@@ -47,6 +48,7 @@ import { onCombatTurnForActionDice, onCombatRoundForActionDice, onRenderCombatTr
 import { onUpdateActorForDeath } from './auto-dead-status.mjs'
 import { onRenderChatMessageHTMLForDeathClock, onRenderCombatTrackerForDeathClock, onUpdateActorForDeathClock, onUpdateCombatForDeathClock } from './death-clock.mjs'
 import { shouldRenderEnhancedAttackCard, renderEnhancedAttackCard } from './chat/enhanced-attack-card.mjs'
+import { onRenderActiveEffectConfig } from './active-effect-key-autocomplete.mjs'
 
 /**
  * Create a macro when a rollable is dropped on the hotbar.
@@ -475,6 +477,7 @@ export const CHAT_AND_HOOK_WIRING_HOOKS = Object.freeze({
   getCompendiumContextOptions: { handler: onGetCompendiumContextOptions, once: false },
   getUserContextOptions: { handler: onGetUserContextOptions, once: false },
   renderActorDirectory: { handler: onRenderActorDirectory, once: false },
+  renderActiveEffectConfig: { handler: onRenderActiveEffectConfig, once: false },
   preCreateActor: { handler: onPreCreateActor, once: false },
   preCreateItem: { handler: onPreCreateItem, once: false },
   applyActiveEffect: { handler: onApplyActiveEffect, once: false },

--- a/module/config.js
+++ b/module/config.js
@@ -354,6 +354,57 @@ DCC.languages = {
 DCC.DICE_CHAIN = DICE_CHAIN
 DCC.effectChangeTypes = effectChangeTypes
 
+/**
+ * Sanctioned Active Effect attribute keys mapped to i18n label keys.
+ * These are the modifier-style fields effects should target (never the
+ * editable base values — see docs/user-guide/Active-Effects.md). Used to
+ * label the effect-config key autocomplete, and as the full fallback list
+ * when no owning actor is available (e.g. effects on unowned world items).
+ * Order here is the order options appear in the autocomplete dropdown.
+ */
+DCC.activeEffectKeyLabels = {
+  'system.abilities.str.otherMod': 'DCC.AbilityStr',
+  'system.abilities.agl.otherMod': 'DCC.AbilityAgl',
+  'system.abilities.sta.otherMod': 'DCC.AbilitySta',
+  'system.abilities.per.otherMod': 'DCC.AbilityPer',
+  'system.abilities.int.otherMod': 'DCC.AbilityInt',
+  'system.abilities.lck.otherMod': 'DCC.AbilityLck',
+  'system.attributes.ac.otherMod': 'DCC.ACOtherMod',
+  'system.attributes.init.otherMod': 'DCC.InitiativeOtherMod',
+  'system.attributes.speed.otherMod': 'DCC.SpeedOtherMod',
+  'system.attributes.actionDice.value': 'DCC.ActionDie',
+  'system.attributes.critical.die': 'DCC.CritDie',
+  'system.attributes.fumble.die': 'DCC.FumbleDie',
+  'system.details.attackHitBonus.melee.adjustment': 'DCC.MeleeAttackAdjustment',
+  'system.details.attackHitBonus.missile.adjustment': 'DCC.MissileAttackAdjustment',
+  'system.details.attackDamageBonus.melee.adjustment': 'DCC.MeleeDamageAdjustment',
+  'system.details.attackDamageBonus.missile.adjustment': 'DCC.MissileDamageAdjustment',
+  'system.saves.frt.otherBonus': 'DCC.SavesFortitude',
+  'system.saves.ref.otherBonus': 'DCC.SavesReflex',
+  'system.saves.wil.otherBonus': 'DCC.SavesWill',
+  'system.class.spellCheckOtherMod': 'DCC.SpellCheck',
+  'system.class.luckDie': 'DCC.LuckDie',
+  'system.class.backstab': 'DCC.Backstab',
+  'system.skills.detectSecretDoors.otherMod': 'DCC.HeightenedSenses',
+  'system.skills.sneakSilently.otherMod': 'DCC.SneakSilently',
+  'system.skills.hideInShadows.otherMod': 'DCC.HideInShadows',
+  'system.skills.pickPockets.otherMod': 'DCC.PickPocket',
+  'system.skills.climbSheerSurfaces.otherMod': 'DCC.ClimbSheerSurfaces',
+  'system.skills.pickLock.otherMod': 'DCC.PickLock',
+  'system.skills.findTrap.otherMod': 'DCC.FindTrap',
+  'system.skills.disableTrap.otherMod': 'DCC.DisableTrap',
+  'system.skills.forgeDocument.otherMod': 'DCC.ForgeDocument',
+  'system.skills.disguiseSelf.otherMod': 'DCC.DisguiseSelf',
+  'system.skills.readLanguages.otherMod': 'DCC.ReadLanguages',
+  'system.skills.handlePoison.otherMod': 'DCC.HandlePoison',
+  'system.skills.castSpellFromScroll.otherMod': 'DCC.CastSpellFromScroll',
+  'system.skills.sneakAndHide.otherMod': 'DCC.SneakAndHide',
+  'system.skills.divineAid.otherMod': 'DCC.DivineAid',
+  'system.skills.turnUnholy.otherMod': 'DCC.TurnUnholy',
+  'system.skills.layOnHands.otherMod': 'DCC.LayOnHands',
+  'system.skills.shieldBash.otherMod': 'DCC.ShieldBash'
+}
+
 // Critical Hit and Disapproval Compendiums, Fumble table, and Mercurial Magic table
 // Updated at runtime from settings
 DCC.criticalHitPacks = null

--- a/module/config.js
+++ b/module/config.js
@@ -360,7 +360,8 @@ DCC.effectChangeTypes = effectChangeTypes
  * editable base values — see docs/user-guide/Active-Effects.md). Used to
  * label the effect-config key autocomplete, and as the full fallback list
  * when no owning actor is available (e.g. effects on unowned world items).
- * Order here is the order options appear in the autocomplete dropdown.
+ * Order here is the order options appear when this fallback list is used;
+ * actor-derived keys follow the actor's schema order instead.
  */
 DCC.activeEffectKeyLabels = {
   'system.abilities.str.otherMod': 'DCC.AbilityStr',


### PR DESCRIPTION
Fixes #904

## Summary
- The Attribute Key field in the Active Effect config sheet now autocompletes: a `<datalist>` of sanctioned DCC attribute keys is injected via a `renderActiveEffectConfig` hook, with each option labeled with the stat it modifies (existing i18n labels — no new translation keys).
- Keys are derived from the owning actor's schema (`*.otherMod`, `*.otherBonus`, attack hit/damage `adjustment` fields, plus the dice-chain targets like `system.attributes.actionDice.value` and `system.class.luckDie`), so fields contributed by class mixins and sibling modules appear automatically, and NPC effects only offer NPC-valid keys.
- Editable base values (`hp.value`, ability `value`/`max`, skill `value`, …) are deliberately excluded, steering users toward the modifier fields per the Active Effects user-guide guidance (#714). Free-form typing still works — the datalist is suggestions only.
- Effects on unowned world items (no actor context) fall back to a curated `CONFIG.DCC.activeEffectKeyLabels` list covering all classes.
- Change rows added via the sheet's add-change control pick the datalist up on re-render.
- User guide updated to mention the autocomplete.

## Test plan
- [x] Unit tests: key sanctioning rules, schema-derived options, owned-item → actor walk-up, curated fallback, datalist injection idempotence (`module/__tests__/active-effect-key-autocomplete.test.js`)
- [x] Hook-wiring dispatch-table contract tests updated for the new hook
- [x] E2E (Playwright, live Foundry v14): datalist wired to the key input with base values excluded; add-change rows keep the autocomplete; NPC key filtering + unowned-item fallback (`browser-tests/e2e/active-effects.spec.js`)
- [x] Full unit suite green (2430 passed); full E2E suite run — only the two known order-dependent flakes failed (ability-score-log spellburn, weapon-range firing-into-melee) and both pass standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)