### PR TITLE
chore: drop worktree isolation from the /pr reviewer step

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -113,7 +113,7 @@ If `$ARGUMENTS` is provided, use it as the base branch instead of `main`.
 
 ## Step 11: Automated PR Review
 
-Launch the `foundryvtt-dev:foundryvtt-reviewer` agent using the Agent tool with `isolation: "worktree"` to prevent branch switching in the main working directory.
+Launch the `foundryvtt-dev:foundryvtt-reviewer` agent using the Agent tool, pointed at the current working directory. Do **not** use `isolation: "worktree"`: the reviewer is read-only (`Read`, `Grep`, `Glob`), so it cannot switch branches or modify anything — and when running inside a per-issue `work:start` worktree, a spawned worktree comes from the shared parent repo and lands on a stale `worktree-agent-*` branch that does not contain the PR's changes.
 
 The reviewer will check for CLAUDE.md compliance, bugs, style issues, empty catches, swallowed errors, and test coverage gaps.
 


### PR DESCRIPTION
## Summary
- The /pr skill's Step 11 told us to launch `foundryvtt-dev:foundryvtt-reviewer` with `isolation: "worktree"` "to prevent branch switching" — but the reviewer agent is read-only (`Read`, `Grep`, `Glob`) and cannot switch branches or modify anything, so the isolation protects against nothing.
- Worse, when /pr runs inside a per-issue `work:start` worktree (the normal flow since #893), the spawned agent worktree comes from the shared parent repo and lands on a stale `worktree-agent-*` branch that lacks the PR's changes — observed on #905's review pass, where the reviewer had to abandon its worktree and locate the real checkout by path.
- Step 11 now says to run the reviewer against the current working directory with no isolation, and documents why.

## Test plan
- [x] Doc-only change to `.claude/commands/pr.md`; no runtime code touched
- [x] Next /pr run exercises the updated step

🤖 Generated with [Claude Code](https://claude.com/claude-code)