### PR TITLE
fix: melee damage ignores temporarily lowered Strength; retire runtime weapon migration (#907)

### DIFF
--- a/browser-tests/e2e/adapter-dispatch.spec.js
+++ b/browser-tests/e2e/adapter-dispatch.spec.js
@@ -4030,10 +4030,13 @@ test.describe('DCC Adapter Dispatch Validation', () => {
     test('legacy weapon (bare `damage`, no `damageWeapon`) applies a temporarily lowered Strength mod to melee damage', async ({ page }) => {
       // User report: max Str 9 (mod 0) temporarily lowered to 7 (mod -1).
       // Legacy / imported weapons store only `system.damage` ('1d4') with no
-      // `damageWeapon`; item.js's prepareBaseData migration used to misread
-      // the bare die as a custom formula once the actor's melee damage bonus
-      // was nonzero, freeze it via `config.damageOverride`, and drop the -1
-      // from the damage roll entirely.
+      // `damageWeapon`. item.js's old per-prepare heuristic misread the bare
+      // die as a custom formula once the actor's melee damage bonus was
+      // nonzero, froze it via `config.damageOverride`, and dropped the -1
+      // from the damage roll entirely. Post-#907, `DCCItem._preCreate`
+      // persists the weapon-die split when the item is embedded (this
+      // createEmbeddedDocuments call), so the composed formula tracks the
+      // actor's current Strength modifier.
       await page.evaluate(async () => {
         const actor = await Actor.create({
           name: 'P1 PC WeakenedStr',

--- a/browser-tests/e2e/adapter-dispatch.spec.js
+++ b/browser-tests/e2e/adapter-dispatch.spec.js
@@ -4027,6 +4027,75 @@ test.describe('DCC Adapter Dispatch Validation', () => {
       expect(cursedEntry.amount).toBe(-1)
     })
 
+    test('legacy weapon (bare `damage`, no `damageWeapon`) applies a temporarily lowered Strength mod to melee damage', async ({ page }) => {
+      // User report: max Str 9 (mod 0) temporarily lowered to 7 (mod -1).
+      // Legacy / imported weapons store only `system.damage` ('1d4') with no
+      // `damageWeapon`; item.js's prepareBaseData migration used to misread
+      // the bare die as a custom formula once the actor's melee damage bonus
+      // was nonzero, freeze it via `config.damageOverride`, and drop the -1
+      // from the damage roll entirely.
+      await page.evaluate(async () => {
+        const actor = await Actor.create({
+          name: 'P1 PC WeakenedStr',
+          type: 'Player',
+          system: { abilities: { str: { value: 7, max: 9 } } }
+        })
+        await actor.createEmbeddedDocuments('Item', [{
+          name: 'P1-LegacyClub',
+          type: 'weapon',
+          system: {
+            actionDie: '1d20',
+            critRange: 20,
+            damage: '1d4', // legacy/imported shape — no damageWeapon
+            melee: true,
+            equipped: true
+          }
+        }])
+        await game.settings.set('dcc', 'automateDamageFumblesCrits', true)
+      })
+
+      // The prepared formula must carry the current (lowered) Str mod, not a
+      // frozen override
+      const prepared = await page.evaluate(() => {
+        const weapon = game.actors.getName('P1 PC WeakenedStr').items.getName('P1-LegacyClub')
+        return { damage: weapon.system.damage, override: weapon.system.config.damageOverride }
+      })
+      expect(prepared.override || '').toBe('')
+      expect(prepared.damage).toBe('1d4-1')
+
+      const weaponId = await page.evaluate(() => {
+        return game.actors.getName('P1 PC WeakenedStr').items.getName('P1-LegacyClub').id
+      })
+      await page.evaluate(async (id) => {
+        await game.actors.getName('P1 PC WeakenedStr').rollWeaponAttack(id)
+      }, weaponId)
+      const damageLine = await waitForAdapterLog('rollDamage')
+      assertPath(damageLine, 'adapter', { weapon: 'P1-LegacyClub' })
+
+      const flag = await page.evaluate(async () => {
+        const deadline = Date.now() + 3000
+        while (Date.now() < deadline) {
+          const msg = game.messages.contents
+            .slice()
+            .reverse()
+            .find(m =>
+              m.speaker?.alias === 'P1 PC WeakenedStr' &&
+              m.getFlag('dcc', 'isToHit') &&
+              m.getFlag('dcc', 'libDamageResult')
+            )
+          if (msg) return msg.getFlag('dcc', 'libDamageResult')
+          await new Promise(resolve => setTimeout(resolve, 50))
+        }
+        return null
+      })
+
+      expect(flag, 'legacy-weapon adapter-path damage must set dcc.libDamageResult').not.toBeNull()
+      expect(flag.passthrough).toBeUndefined()
+      const strengthEntry = flag.breakdown.find(b => b.source === 'Strength')
+      expect(strengthEntry, 'lowered Strength mod must surface as its own breakdown entry').toBeDefined()
+      expect(strengthEntry.amount).toBe(-1)
+    })
+
     test('dice-bearing magic bonus (`damageWeaponBonus: "+1d4"`) routes via adapter with extraDamageDice (D2 damage sub-slice d)', async ({ page }) => {
       // Phase 3 session 19 broadened the gate to accept dice-bearing
       // `damageWeaponBonus`. `item.js` concatenates the raw bonus onto

--- a/module/__mocks__/foundry.js
+++ b/module/__mocks__/foundry.js
@@ -1054,8 +1054,27 @@ class MockItem {
 
 // Lifecycle hooks and dialogs for MockItem
 MockItem.prototype._onCreate = async function () {}
+MockItem.prototype._preCreate = async function () {}
 MockItem.prototype._preDelete = async function () {}
 MockItem.prototype.deleteDialog = async function () { return this }
+
+// Minimal Document#updateSource: apply dotted-key changes to the document
+// (and its _source when present), like real Foundry's pre-creation mutation.
+MockItem.prototype.updateSource = function (changes = {}) {
+  for (const target of [this, this._source].filter(Boolean)) {
+    for (const [key, value] of Object.entries(changes)) {
+      const parts = key.split('.')
+      let obj = target
+      while (parts.length > 1) {
+        const part = parts.shift()
+        if (typeof obj[part] !== 'object' || obj[part] === null) obj[part] = {}
+        obj = obj[part]
+      }
+      obj[parts[0]] = value
+    }
+  }
+  return changes
+}
 
 // Minimal Document#clone: copy data, apply (possibly dotted-key) changes,
 // preserve the actor reference; keepId keeps _id/id like real Foundry.

--- a/module/__tests__/item.test.js
+++ b/module/__tests__/item.test.js
@@ -808,6 +808,44 @@ describe('DCCItem Tests', () => {
 
     // Legacy damage field migration is tested implicitly in other tests
 
+    test('legacy bare-die damage picks up a positive actor damage bonus', () => {
+      weapon = new DCCItem({ type: 'weapon', name: 'legacy sword' }, {})
+      weapon.system = {
+        melee: true,
+        damage: '1d8', // Legacy/imported weapon: no damageWeapon set
+        damageWeapon: '',
+        config: {}
+      }
+      weapon.actor = actor
+
+      weapon.prepareBaseData()
+
+      // Bare die is the weapon die, not a custom override — actor bonus applies
+      expect(weapon.system.config.damageOverride).toBeUndefined()
+      expect(weapon.system.damageWeapon).toBe('1d8')
+      expect(weapon.system.damage).toBe('1d8+3')
+    })
+
+    test('legacy bare-die damage subtracts a negative Strength damage bonus (temp Str loss)', () => {
+      // Max Str 9 (mod 0, damage stored as bare '1d4') temporarily lowered
+      // to 7 (mod -1): the -1 must reach the melee damage formula
+      actor.system.details.attackDamageBonus.melee.value = '-1'
+
+      weapon = new DCCItem({ type: 'weapon', name: 'club' }, {})
+      weapon.system = {
+        melee: true,
+        damage: '1d4',
+        damageWeapon: '',
+        config: {}
+      }
+      weapon.actor = actor
+
+      weapon.prepareBaseData()
+
+      expect(weapon.system.config.damageOverride).toBeUndefined()
+      expect(weapon.system.damage).toBe('1d4-1')
+    })
+
     test('should handle weapons with non-standard damage override', () => {
       weapon = new DCCItem({ type: 'weapon', name: 'special weapon' }, {})
       weapon.system = {

--- a/module/__tests__/item.test.js
+++ b/module/__tests__/item.test.js
@@ -925,6 +925,100 @@ describe('DCCItem Tests', () => {
       expect(weapon.system.config.damageOverride).toBeUndefined()
       expect(weapon.system.damage).toBe('2d4+fire')
     })
+
+    test('_preCreate uses the missile bonus for non-melee weapons', async () => {
+      actor.type = 'Player'
+      // Suite actor's missile damage bonus is '+1'
+      weapon = new DCCItem({ type: 'weapon', name: 'shortbow' }, {})
+      weapon.system = {
+        melee: false,
+        damage: '1d6+1', // Matches die + missile bonus, NOT melee ('+3')
+        damageWeapon: '',
+        config: {}
+      }
+      weapon._source = { system: weapon.system }
+      weapon.parent = actor
+
+      await weapon._preCreate({}, {}, {})
+      expect(weapon.system.damageWeapon).toBe('1d6')
+    })
+
+    test('_preCreate never touches non-weapons, unowned items, or already-normalized weapons', async () => {
+      actor.type = 'Player'
+
+      // Non-weapon item types are ignored even with weapon-shaped data
+      const equipment = new DCCItem({ type: 'equipment', name: 'torch' }, {})
+      equipment.system = { damage: '1d4', damageWeapon: '', config: {} }
+      equipment._source = { system: equipment.system }
+      equipment.parent = actor
+      await equipment._preCreate({}, {}, {})
+      expect(equipment.system.damageWeapon).toBe('')
+
+      // World-item creation (no parent): no owner context, no split
+      const worldWeapon = new DCCItem({ type: 'weapon', name: 'display sword' }, {})
+      worldWeapon.system = { melee: true, damage: '1d8', damageWeapon: '', config: {} }
+      worldWeapon._source = { system: worldWeapon.system }
+      worldWeapon.parent = null
+      await worldWeapon._preCreate({}, {}, {})
+      expect(worldWeapon.system.damageWeapon).toBe('')
+
+      // damageWeapon already recorded: the split never overwrites it
+      const modern = new DCCItem({ type: 'weapon', name: 'modern sword' }, {})
+      modern.system = { melee: true, damage: '1d8+3', damageWeapon: '1d10', config: {} }
+      modern._source = { system: modern.system }
+      modern.parent = actor
+      await modern._preCreate({}, {}, {})
+      expect(modern.system.damageWeapon).toBe('1d10')
+
+      // Explicit damageOverride: the author's formula is authoritative
+      const custom = new DCCItem({ type: 'weapon', name: 'custom sword' }, {})
+      custom.system = { melee: true, damage: '1d8', damageWeapon: '', config: { damageOverride: '2d6' } }
+      custom._source = { system: custom.system }
+      custom.parent = actor
+      await custom._preCreate({}, {}, {})
+      expect(custom.system.damageWeapon).toBe('')
+
+      // Empty damage: nothing to infer from
+      const blank = new DCCItem({ type: 'weapon', name: 'blank sword' }, {})
+      blank.system = { melee: true, damage: '', damageWeapon: '', config: {} }
+      blank._source = { system: blank.system }
+      blank.parent = actor
+      await blank._preCreate({}, {}, {})
+      expect(blank.system.damageWeapon).toBe('')
+    })
+
+    test('a fresh weapon with no damage and no damageWeapon stays empty after prepare', () => {
+      // Pre-#907 the composition ran unconditionally, so a brand-new weapon
+      // displayed the actor bonus alone ('+3') as its damage. The gated
+      // composition leaves it empty until a weapon die is recorded.
+      weapon = new DCCItem({ type: 'weapon', name: 'new weapon' }, {})
+      weapon.system = {
+        melee: true,
+        damage: '',
+        damageWeapon: '',
+        config: {}
+      }
+      weapon.actor = actor
+
+      weapon.prepareBaseData()
+
+      expect(weapon.system.damage).toBe('')
+    })
+
+    test('damageOverride still wins for weapons with no damageWeapon', () => {
+      weapon = new DCCItem({ type: 'weapon', name: 'overridden legacy' }, {})
+      weapon.system = {
+        melee: true,
+        damage: '1d8',
+        damageWeapon: '',
+        config: { damageOverride: '3d6' }
+      }
+      weapon.actor = actor
+
+      weapon.prepareBaseData()
+
+      expect(weapon.system.damage).toBe('3d6')
+    })
   })
 
   describe('Initiative Bonus Calculations', () => {

--- a/module/__tests__/item.test.js
+++ b/module/__tests__/item.test.js
@@ -26,6 +26,18 @@ vi.mock('../utilities.js', () => ({
     const match = value?.match(/\d*d\d+/)
     return match ? match[0] : null
   }),
+  // Mirrors the real implementation: bare die or die + the given bonus
+  // (tolerating a dropped '+0') infers the die; anything else returns ''.
+  inferWeaponDie: vi.fn((damage, bonus = '') => {
+    if (typeof damage !== 'string' || damage === '') return ''
+    const match = damage.match(/\d*d\d+/)
+    const die = match ? match[0] : ''
+    if (!die) return ''
+    if (damage === die) return die
+    const total = `${die}${bonus || ''}`
+    if (damage === total || damage === total.replaceAll('+0', '')) return die
+    return ''
+  }),
   // Mirrors the real implementation: single die of the first listed faces
   // with its flat rider kept ('2d20' → '1d20', '1d20+4' → '1d20+4'), ''
   // when no die is present.
@@ -806,13 +818,16 @@ describe('DCCItem Tests', () => {
       expect(weapon.system.damage).toBe('1d6+1+2')
     })
 
-    // Legacy damage field migration is tested implicitly in other tests
+    // Legacy-shape weapons (`damage` stored, no `damageWeapon`): the
+    // heuristic runtime split retired in #907. `_preCreate` and the world
+    // migration persist `damageWeapon` for confidently-attributable shapes;
+    // prepareBaseData rolls anything left verbatim.
 
-    test('legacy bare-die damage picks up a positive actor damage bonus', () => {
+    test('weapon with no damageWeapon keeps its stored damage formula verbatim', () => {
       weapon = new DCCItem({ type: 'weapon', name: 'legacy sword' }, {})
       weapon.system = {
         melee: true,
-        damage: '1d8', // Legacy/imported weapon: no damageWeapon set
+        damage: '1d8',
         damageWeapon: '',
         config: {}
       }
@@ -820,16 +835,19 @@ describe('DCCItem Tests', () => {
 
       weapon.prepareBaseData()
 
-      // Bare die is the weapon die, not a custom override — actor bonus applies
+      // No heuristic split at prepare time, and no override baked in — the
+      // stored formula is the safety net
       expect(weapon.system.config.damageOverride).toBeUndefined()
-      expect(weapon.system.damageWeapon).toBe('1d8')
-      expect(weapon.system.damage).toBe('1d8+3')
+      expect(weapon.system.damageWeapon).toBe('')
+      expect(weapon.system.damage).toBe('1d8')
     })
 
-    test('legacy bare-die damage subtracts a negative Strength damage bonus (temp Str loss)', () => {
-      // Max Str 9 (mod 0, damage stored as bare '1d4') temporarily lowered
-      // to 7 (mod -1): the -1 must reach the melee damage formula
+    test('_preCreate splits the weapon die for a legacy weapon embedded on a Player (temp Str loss)', async () => {
+      // User report: max Str 9 (mod 0, damage stored as bare '1d4')
+      // temporarily lowered to 7 (mod -1). Normalizing at creation is what
+      // lets the composed formula subtract the current -1.
       actor.system.details.attackDamageBonus.melee.value = '-1'
+      actor.type = 'Player'
 
       weapon = new DCCItem({ type: 'weapon', name: 'club' }, {})
       weapon.system = {
@@ -838,15 +856,60 @@ describe('DCCItem Tests', () => {
         damageWeapon: '',
         config: {}
       }
+      weapon._source = { system: weapon.system }
+      weapon.parent = actor
+
+      await weapon._preCreate({}, {}, {})
+      expect(weapon.system.damageWeapon).toBe('1d4')
+
       weapon.actor = actor
-
       weapon.prepareBaseData()
-
       expect(weapon.system.config.damageOverride).toBeUndefined()
       expect(weapon.system.damage).toBe('1d4-1')
     })
 
-    test('should handle weapons with non-standard damage override', () => {
+    test('_preCreate splits when the stored formula matches die + current actor bonus', async () => {
+      actor.type = 'Player'
+      // Suite actor's melee damage bonus is '+3'
+      weapon = new DCCItem({ type: 'weapon', name: 'longsword' }, {})
+      weapon.system = {
+        melee: true,
+        damage: '1d8+3',
+        damageWeapon: '',
+        config: {}
+      }
+      weapon._source = { system: weapon.system }
+      weapon.parent = actor
+
+      await weapon._preCreate({}, {}, {})
+      expect(weapon.system.damageWeapon).toBe('1d8')
+    })
+
+    test('_preCreate leaves ambiguous formulas and non-Player owners alone', async () => {
+      actor.type = 'Player'
+      weapon = new DCCItem({ type: 'weapon', name: 'odd blade' }, {})
+      weapon.system = {
+        melee: true,
+        damage: '1d8+5', // Doesn't match bare die or die + bonus ('+3')
+        damageWeapon: '',
+        config: {}
+      }
+      weapon._source = { system: weapon.system }
+      weapon.parent = actor
+      await weapon._preCreate({}, {}, {})
+      expect(weapon.system.damageWeapon).toBe('')
+
+      // NPC-owned weapons use `damage` directly — never split
+      const npc = { type: 'NPC', system: actor.system }
+      const npcWeapon = new DCCItem({ type: 'weapon', name: 'claw' }, {})
+      npcWeapon.system = { melee: true, damage: '1d4', damageWeapon: '', config: {} }
+      npcWeapon._source = { system: npcWeapon.system }
+      npcWeapon.parent = npc
+      await npcWeapon._preCreate({}, {}, {})
+      expect(npcWeapon.system.damageWeapon).toBe('')
+    })
+
+    test('should handle weapons with non-standard damage', () => {
       weapon = new DCCItem({ type: 'weapon', name: 'special weapon' }, {})
       weapon.system = {
         melee: true,
@@ -858,7 +921,9 @@ describe('DCCItem Tests', () => {
 
       weapon.prepareBaseData()
 
-      expect(weapon.system.config.damageOverride).toBe('2d4+fire')
+      // Rolled as stored — no override is baked in anymore (#907)
+      expect(weapon.system.config.damageOverride).toBeUndefined()
+      expect(weapon.system.damage).toBe('2d4+fire')
     })
   })
 

--- a/module/__tests__/migrations-data-driven.test.js
+++ b/module/__tests__/migrations-data-driven.test.js
@@ -545,4 +545,26 @@ describe('migrateActorData — weapon context for the legacy weapon-die split (#
 
     expect(await migrateActorData(actor)).toEqual({})
   })
+
+  test('an actor without bonus data still splits the unambiguous bare die', async () => {
+    // Non-NPC actors missing attackDamageBonus (partial fixtures, odd
+    // third-party data) pass empty bonuses — the bare-die case needs none
+    const actor = cleanActor()
+    actor.type = 'Player'
+    actor.items = [{ type: 'weapon', system: { damage: '1d4', damageWeapon: '', config: {} } }]
+
+    const updateData = await migrateActorData(actor)
+
+    expect(updateData.items).toHaveLength(1)
+    expect(updateData.items[0]['system.damageWeapon']).toBe('1d4')
+  })
+
+  test('a Player-owned ambiguous weapon produces no item update at all', async () => {
+    const actor = cleanActor()
+    actor.type = 'Player'
+    actor.system.details.attackDamageBonus = { melee: { value: '-1' }, missile: { value: '+0' } }
+    actor.items = [{ type: 'weapon', system: { damage: '1d8+5', damageWeapon: '', config: {} } }]
+
+    expect(await migrateActorData(actor)).toEqual({})
+  })
 })

--- a/module/__tests__/migrations-data-driven.test.js
+++ b/module/__tests__/migrations-data-driven.test.js
@@ -468,3 +468,81 @@ describe('migrateItemData — V14 ActiveEffect numeric mode → string type', ()
     expect(migrateItemData(item).effects[0].changes[0].type).toBe('add')
   })
 })
+
+// #907: persist the weapon-die split for legacy-shape weapons (`damage`
+// stored with no `damageWeapon`). The runtime heuristic in item.js is gone,
+// so this branch is what lets old weapons track the actor's current damage
+// bonus. Only confident shapes are stamped; ambiguous formulas are left
+// untouched and roll as stored.
+describe('migrateItemData — legacy weapon-die split (#907)', () => {
+  /** A legacy-shape weapon: `damage` persisted, no `damageWeapon`. */
+  function legacyWeapon (damage, extra = {}) {
+    return { type: 'weapon', system: { damage, damageWeapon: '', config: {}, ...extra } }
+  }
+
+  test('splits a bare-die formula without owner context', () => {
+    expect(migrateItemData(legacyWeapon('1d4'))).toEqual({ 'system.damageWeapon': '1d4' })
+  })
+
+  test('splits die + matching melee bonus with owner context', () => {
+    const updateData = migrateItemData(legacyWeapon('1d8-1'), { damageBonusMelee: '-1', damageBonusMissile: '+0' })
+    expect(updateData).toEqual({ 'system.damageWeapon': '1d8' })
+  })
+
+  test('uses the missile bonus for non-melee weapons', () => {
+    const updateData = migrateItemData(legacyWeapon('1d6+2', { melee: false }), { damageBonusMelee: '-1', damageBonusMissile: '+2' })
+    expect(updateData).toEqual({ 'system.damageWeapon': '1d6' })
+  })
+
+  test('leaves ambiguous formulas untouched', () => {
+    expect(migrateItemData(legacyWeapon('1d4+1'), { damageBonusMelee: '-1' })).toEqual({})
+    expect(migrateItemData(legacyWeapon('1d8+2+@ab'), { damageBonusMelee: '+2' })).toEqual({})
+    expect(migrateItemData(legacyWeapon('2d4+fire'))).toEqual({})
+  })
+
+  test('is a no-op when damageWeapon is already set or an override exists', () => {
+    expect(migrateItemData({ type: 'weapon', system: { damage: '1d4', damageWeapon: '1d4', config: {} } })).toEqual({})
+    expect(migrateItemData({ type: 'weapon', system: { damage: '1d4', damageWeapon: '', config: { damageOverride: '1d4' } } })).toEqual({})
+    expect(migrateItemData({ type: 'weapon', system: { damage: '', damageWeapon: '', config: {} } })).toEqual({})
+  })
+
+  test('skipWeapons suppresses the split (NPC-owned weapons)', () => {
+    expect(migrateItemData(legacyWeapon('1d4'), { skipWeapons: true })).toEqual({})
+  })
+
+  test('reads raw _source over prepared system data', () => {
+    const item = {
+      type: 'weapon',
+      // Prepared data looks normalized, but the raw source is still legacy
+      system: { damage: '1d4-1', damageWeapon: '1d4', config: {} },
+      _source: { system: { damage: '1d4', damageWeapon: '', config: {} } }
+    }
+    expect(migrateItemData(item)).toEqual({ 'system.damageWeapon': '1d4' })
+  })
+
+  test('non-weapon items are never touched', () => {
+    expect(migrateItemData({ type: 'equipment', system: { damage: '1d4', damageWeapon: '' } })).toEqual({})
+  })
+})
+
+describe('migrateActorData — weapon context for the legacy weapon-die split (#907)', () => {
+  test('a Player actor passes its damage bonuses so a matching baked-in modifier splits', async () => {
+    const actor = cleanActor()
+    actor.type = 'Player'
+    actor.system.details.attackDamageBonus = { melee: { value: '-1' }, missile: { value: '+0' } }
+    actor.items = [{ type: 'weapon', system: { damage: '1d8-1', damageWeapon: '', config: {} } }]
+
+    const updateData = await migrateActorData(actor)
+
+    expect(updateData.items).toHaveLength(1)
+    expect(updateData.items[0]['system.damageWeapon']).toBe('1d8')
+  })
+
+  test('NPC-owned weapons are never split', async () => {
+    const actor = cleanActor()
+    actor.type = 'NPC'
+    actor.items = [{ type: 'weapon', system: { damage: '1d4', damageWeapon: '', config: {} } }]
+
+    expect(await migrateActorData(actor)).toEqual({})
+  })
+})

--- a/module/__tests__/migrations-data-driven.test.js
+++ b/module/__tests__/migrations-data-driven.test.js
@@ -421,16 +421,19 @@ describe('migrateActorData — action die seed from config.actionDice', () => {
 })
 
 describe('migrateActorData — owned item recursion', () => {
-  test('folds a migrated owned item into updateData.items', async () => {
+  test('folds a migrated owned item into updateData.items as an {_id, ...changes} delta', async () => {
     const actor = cleanActor()
-    actor.items = [{
-      _id: 'item1',
-      effects: [effectWithChanges([{ key: 'k', mode: 2, value: '1' }])]
-    }]
+    actor.items = [
+      { _id: 'item1', effects: [effectWithChanges([{ key: 'k', mode: 2, value: '1' }])] },
+      { _id: 'item2', effects: [] } // unchanged — must not appear in the update
+    ]
 
     const updateData = await migrateActorData(actor)
 
+    // Plain differential deltas keyed by _id — the shape Actor#update
+    // persists to _source (#907 review); never merged live documents
     expect(updateData.items).toHaveLength(1)
+    expect(updateData.items[0]._id).toBe('item1')
     expect(updateData.items[0].effects[0].changes[0].type).toBe('add')
   })
 
@@ -530,12 +533,11 @@ describe('migrateActorData — weapon context for the legacy weapon-die split (#
     const actor = cleanActor()
     actor.type = 'Player'
     actor.system.details.attackDamageBonus = { melee: { value: '-1' }, missile: { value: '+0' } }
-    actor.items = [{ type: 'weapon', system: { damage: '1d8-1', damageWeapon: '', config: {} } }]
+    actor.items = [{ _id: 'weapon1', type: 'weapon', system: { damage: '1d8-1', damageWeapon: '', config: {} } }]
 
     const updateData = await migrateActorData(actor)
 
-    expect(updateData.items).toHaveLength(1)
-    expect(updateData.items[0]['system.damageWeapon']).toBe('1d8')
+    expect(updateData.items).toEqual([{ _id: 'weapon1', 'system.damageWeapon': '1d8' }])
   })
 
   test('NPC-owned weapons are never split', async () => {
@@ -551,12 +553,11 @@ describe('migrateActorData — weapon context for the legacy weapon-die split (#
     // third-party data) pass empty bonuses — the bare-die case needs none
     const actor = cleanActor()
     actor.type = 'Player'
-    actor.items = [{ type: 'weapon', system: { damage: '1d4', damageWeapon: '', config: {} } }]
+    actor.items = [{ _id: 'weapon1', type: 'weapon', system: { damage: '1d4', damageWeapon: '', config: {} } }]
 
     const updateData = await migrateActorData(actor)
 
-    expect(updateData.items).toHaveLength(1)
-    expect(updateData.items[0]['system.damageWeapon']).toBe('1d4')
+    expect(updateData.items).toEqual([{ _id: 'weapon1', 'system.damageWeapon': '1d4' }])
   })
 
   test('a Player-owned ambiguous weapon produces no item update at all', async () => {

--- a/module/__tests__/migrations-version-gate-guard.test.js
+++ b/module/__tests__/migrations-version-gate-guard.test.js
@@ -45,7 +45,7 @@ const antiPattern = /currentVersion\s*(?:<=?|>=?|===?|!==?)\s*0\.(?:0\d|1\d|2[01
 describe('classifyMigrationDecision', () => {
   test('exported floor + ceiling constants', () => {
     expect(MINIMUM_SUPPORTED_VERSION).toBe(0.22)
-    expect(NEEDS_MIGRATION_VERSION).toBe(0.71)
+    expect(NEEDS_MIGRATION_VERSION).toBe(0.72)
   })
 
   test('fresh world (default: 0) runs migrateWorld', () => {
@@ -87,8 +87,12 @@ describe('classifyMigrationDecision', () => {
     expect(classifyMigrationDecision(0.70)).toBe('run')
   })
 
-  test('already migrated (0.71) skips', () => {
-    expect(classifyMigrationDecision(0.71)).toBe('skip')
+  test('previous ceiling (0.71) re-runs for the 0.72 weapon-die split', () => {
+    expect(classifyMigrationDecision(0.71)).toBe('run')
+  })
+
+  test('already migrated (0.72) skips', () => {
+    expect(classifyMigrationDecision(0.72)).toBe('skip')
   })
 
   test('above ceiling skips', () => {

--- a/module/__tests__/pc-parser.test.js
+++ b/module/__tests__/pc-parser.test.js
@@ -2672,3 +2672,30 @@ Dwarf skill: Shield bash - make an extra d14 attack with your shield. (1d3 damag
   ]
   expect(parsedNPC).toMatchObject(expected)
 })
+
+/* #907: the zero-level single-weapon branch splits out the weapon die at
+ * import time (like the upper-level weapons[] branch always did), so the
+ * composed damage tracks the actor's current Strength modifier. */
+test('zero-level weapon import records the weapon die', () => {
+  // Damage with a baked-in modifier: die split out, stored damage preserved
+  const parsed = parsePCs('{"occTitle": "Farmer", "weapon": "Pitchfork", "attackDamage": "1d8+1"}')
+  expect(parsed[0].items[0].system).toMatchObject({
+    damage: '1d8+1',
+    damageWeapon: '1d8',
+    melee: true
+  })
+
+  // No damage expression in the import: both fields take the 1d3 default
+  const defaulted = parsePCs('{"occTitle": "Farmer", "weapon": "Fists"}')
+  expect(defaulted[0].items[0].system).toMatchObject({
+    damage: '1d3',
+    damageWeapon: '1d3'
+  })
+
+  // Die-less damage text: no die recorded — the weapon rolls as stored
+  const dieless = parsePCs('{"occTitle": "Farmer", "weapon": "Net", "attackDamage": "special"}')
+  expect(dieless[0].items[0].system).toMatchObject({
+    damage: 'special',
+    damageWeapon: ''
+  })
+})

--- a/module/__tests__/pc-parser.test.js
+++ b/module/__tests__/pc-parser.test.js
@@ -56,6 +56,9 @@ Languages: Common`)
         system: {
           toHit: '-1',
           damage: '1d4-1',
+          // Weapon die split out at import so the composed damage tracks
+          // the actor's current Strength modifier (#907)
+          damageWeapon: '1d4',
           melee: true
         }
       },
@@ -411,6 +414,8 @@ Languages: Common `)
           system: {
             toHit: '-1',
             damage: '1d6-1',
+            // Weapon die split out at import (#907) — plain-text path
+            damageWeapon: '1d6',
             melee: true
           }
         },

--- a/module/__tests__/pc-parser.test.js
+++ b/module/__tests__/pc-parser.test.js
@@ -2677,12 +2677,22 @@ Dwarf skill: Shield bash - make an extra d14 attack with your shield. (1d3 damag
  * import time (like the upper-level weapons[] branch always did), so the
  * composed damage tracks the actor's current Strength modifier. */
 test('zero-level weapon import records the weapon die', () => {
-  // Damage with a baked-in modifier: die split out, stored damage preserved
-  const parsed = parsePCs('{"occTitle": "Farmer", "weapon": "Pitchfork", "attackDamage": "1d8+1"}')
+  // Damage matching die + the imported Str mod (13 -> +1): die split out,
+  // stored damage preserved
+  const parsed = parsePCs('{"occTitle": "Farmer", "weapon": "Pitchfork", "strengthScore": "13", "attackDamage": "1d8+1"}')
   expect(parsed[0].items[0].system).toMatchObject({
     damage: '1d8+1',
     damageWeapon: '1d8',
     melee: true
+  })
+
+  // Baked-in bonus that is NOT the Str mod (Str 9 -> +0): conservative — no
+  // die recorded, the weapon rolls the imported total verbatim (e.g. a
+  // damage-affecting birth augur must not be replaced by the Str bonus)
+  const augur = parsePCs('{"occTitle": "Farmer", "weapon": "Lucky Club", "strengthScore": "9", "attackDamage": "1d8+1"}')
+  expect(augur[0].items[0].system).toMatchObject({
+    damage: '1d8+1',
+    damageWeapon: ''
   })
 
   // No damage expression in the import: both fields take the 1d3 default

--- a/module/__tests__/utilities.test.js
+++ b/module/__tests__/utilities.test.js
@@ -237,6 +237,15 @@ describe('Utilities', () => {
       // Formula-with-bonus but no bonus context stays ambiguous
       expect(inferWeaponDie('1d4-1', null)).toBe('')
     })
+
+    it('declines dice outside getFirstDie range instead of truncating them', () => {
+      // getFirstDie's regex caps at 2-digit counts/faces; these must be a
+      // conservative miss (rolls as stored), never a shrunken die
+      expect(inferWeaponDie('1d100')).toBe('')
+      expect(inferWeaponDie('1d100', '+2')).toBe('')
+      expect(inferWeaponDie('100d6')).toBe('')
+      expect(inferWeaponDie('d6')).toBe('')
+    })
   })
 
   describe('getSingleActionDie', () => {

--- a/module/__tests__/utilities.test.js
+++ b/module/__tests__/utilities.test.js
@@ -227,6 +227,15 @@ describe('Utilities', () => {
       expect(inferWeaponDie('+2')).toBe('')
       expect(inferWeaponDie(null)).toBe('')
       expect(inferWeaponDie(undefined)).toBe('')
+      expect(inferWeaponDie(4)).toBe('') // non-string input
+    })
+
+    it('handles multi-die counts and null-ish bonus values', () => {
+      expect(inferWeaponDie('2d8+3', '+3')).toBe('2d8')
+      expect(inferWeaponDie('1d4', null)).toBe('1d4')
+      expect(inferWeaponDie('1d4', undefined)).toBe('1d4')
+      // Formula-with-bonus but no bonus context stays ambiguous
+      expect(inferWeaponDie('1d4-1', null)).toBe('')
     })
   })
 

--- a/module/__tests__/utilities.test.js
+++ b/module/__tests__/utilities.test.js
@@ -13,6 +13,7 @@ import {
   getFirstDie,
   getFirstMod,
   getSingleActionDie,
+  inferWeaponDie,
   addDamageFlavorToRolls,
   getCritTableLink,
   getCritTableResult,
@@ -192,6 +193,40 @@ describe('Utilities', () => {
       expect(getFirstDie('d6')).toBe('') // No dice count
       expect(getFirstDie('1d')).toBe('') // No face count
       expect(getFirstDie('100d100')).toBe('00d10') // Note: regex captures first 2 digits
+    })
+  })
+
+  describe('inferWeaponDie', () => {
+    it('infers the die from a bare-die formula regardless of bonus', () => {
+      expect(inferWeaponDie('1d4')).toBe('1d4')
+      expect(inferWeaponDie('1d4', '-1')).toBe('1d4')
+      expect(inferWeaponDie('2d8', '+3')).toBe('2d8')
+    })
+
+    it('infers the die when the formula is die + the given bonus', () => {
+      expect(inferWeaponDie('1d4-1', '-1')).toBe('1d4')
+      expect(inferWeaponDie('1d8+3', '+3')).toBe('1d8')
+      expect(inferWeaponDie('1d6+1d3', '+1d3')).toBe('1d6')
+    })
+
+    it('tolerates a dropped +0 in the stored formula', () => {
+      expect(inferWeaponDie('1d8', '+0')).toBe('1d8')
+      expect(inferWeaponDie('1d8+1d3', '+1d3+0')).toBe('1d8')
+    })
+
+    it('returns empty string for ambiguous or custom formulas', () => {
+      expect(inferWeaponDie('1d4+1', '-1')).toBe('') // baked-in bonus no longer matches
+      expect(inferWeaponDie('1d4+1')).toBe('') // no bonus context
+      expect(inferWeaponDie('1d8+2+@ab', '+2')).toBe('') // deed form
+      expect(inferWeaponDie('2d4+fire', '+3')).toBe('') // non-standard
+      expect(inferWeaponDie('(1d8)*2+3', '+3')).toBe('') // sub-expression
+    })
+
+    it('returns empty string for die-less or empty input', () => {
+      expect(inferWeaponDie('')).toBe('')
+      expect(inferWeaponDie('+2')).toBe('')
+      expect(inferWeaponDie(null)).toBe('')
+      expect(inferWeaponDie(undefined)).toBe('')
     })
   })
 

--- a/module/item.js
+++ b/module/item.js
@@ -215,7 +215,12 @@ class DCCItem extends SpellItemMixin(CurrencyItemMixin(ContainerItemMixin(Item))
           if (!this.system?.melee) {
             total = `${damageWeapon}${this.actor?.system?.details?.attackDamageBonus?.missile?.value || ''}`
           }
-          if (this.system.damage === total || this.system.damage === total.replaceAll('+0', '')
+          // A bare die ('1d4') is the derived shape from a +0-bonus actor, not
+          // a custom formula — treat it as the weapon die so the actor's
+          // *current* damage bonus applies. Freezing it as an override left a
+          // temporarily lowered Strength mod out of melee damage entirely.
+          if (this.system.damage === total || this.system.damage === total.replaceAll('+0', '') ||
+            this.system.damage === damageWeapon
           ) {
             this.system.damage = this.actor?.system?.details?.attackDamageBonus?.melee?.value || ''
             this.system.damageWeapon = damageWeapon

--- a/module/item.js
+++ b/module/item.js
@@ -1,7 +1,7 @@
 /* global Item, foundry, game, ui, Roll, Dialog */
 
 import DiceChain from './dice-chain.js'
-import { ensurePlus, getFirstDie, getSingleActionDie } from './utilities.js'
+import { ensurePlus, getSingleActionDie, inferWeaponDie } from './utilities.js'
 import { ContainerItemMixin } from './item/container-mixin.mjs'
 import { CurrencyItemMixin } from './item/currency-mixin.mjs'
 import { SpellItemMixin } from './item/spell-mixin.mjs'
@@ -24,6 +24,32 @@ class DCCItem extends SpellItemMixin(CurrencyItemMixin(ContainerItemMixin(Item))
    * @type {boolean}
    */
   #castInFlight = false
+
+  /**
+   * Normalize legacy-shape weapons (`damage` persisted with no
+   * `damageWeapon`) when they are embedded into a Player actor — dragged
+   * from a compendium, created by a module, or re-created by the importer's
+   * compendium remap (#907). Splitting out the weapon die here, with the
+   * owning actor's damage bonus available for attribution, is what lets the
+   * composed formula track the actor's *current* Strength modifier instead
+   * of freezing the imported total. Shapes that can't be attributed
+   * confidently are left alone — prepareBaseData rolls them as stored.
+   * @override
+   */
+  async _preCreate (data, options, user) {
+    const allowed = await super._preCreate(data, options, user)
+    if (allowed === false) return false
+    if (this.type !== 'weapon' || this.parent?.type !== 'Player') return
+    const source = this._source.system
+    if (!source.damage || source.damageWeapon || source.config?.damageOverride) return
+    const bonus = (source.melee !== false)
+      ? this.parent.system?.details?.attackDamageBonus?.melee?.value
+      : this.parent.system?.details?.attackDamageBonus?.missile?.value
+    const damageWeapon = inferWeaponDie(source.damage, bonus || '')
+    if (damageWeapon) {
+      this.updateSource({ 'system.damageWeapon': damageWeapon })
+    }
+  }
 
   prepareBaseData () {
     super.prepareBaseData()
@@ -199,65 +225,36 @@ class DCCItem extends SpellItemMixin(CurrencyItemMixin(ContainerItemMixin(Item))
         this.system.toHit = ensurePlus(this.system.config.attackBonusOverride)
       }
 
-      // Damage Calculation
-      // First handle older items that may not have damageWeapon set
-      if (this.system.damage && !this.system.damageWeapon) {
-        // Refresh actor data if this is an owned item
-        if (this.actor) {
-          this.actor.prepareBaseData()
+      // Damage Calculation - compose the formula from the weapon damage die
+      // and other settings. A weapon with no recorded weapon die (legacy
+      // shape: only `damage` persisted — see #907) keeps its stored formula
+      // verbatim: `_preCreate` and the world migration normalize the shapes
+      // they can attribute confidently, and anything left is safer rolled
+      // as-stored than recomposed around a missing die.
+      if (this.system.damageWeapon) {
+        // Start by setting the damage to any bonus from the actor
+        if (this.system.melee) {
+          this.system.damage = this.actor?.system?.details?.attackDamageBonus?.melee?.value || ''
+        } else {
+          this.system.damage = this.actor?.system?.details?.attackDamageBonus?.missile?.value || ''
         }
 
-        // Get the first die of the damage and see if that can be the weapon damage
-        // Otherwise set the current damage value as the override
-        const damageWeapon = getFirstDie(this.system.damage) || ''
-        if (damageWeapon) {
-          let total = `${damageWeapon}${this.actor?.system?.details?.attackDamageBonus?.melee?.value || ''}`
-          if (!this.system?.melee) {
-            total = `${damageWeapon}${this.actor?.system?.details?.attackDamageBonus?.missile?.value || ''}`
-          }
-          // A bare die ('1d4') is the derived shape from a +0-bonus actor, not
-          // a custom formula — treat it as the weapon die so the actor's
-          // *current* damage bonus applies. Freezing it as an override left a
-          // temporarily lowered Strength mod out of melee damage entirely.
-          if (this.system.damage === total || this.system.damage === total.replaceAll('+0', '') ||
-            this.system.damage === damageWeapon
-          ) {
-            this.system.damage = this.actor?.system?.details?.attackDamageBonus?.melee?.value || ''
-            this.system.damageWeapon = damageWeapon
+        // Then add in any weapon bonus - formatting dependent on whether there is a deed from the actor
+        if (this.system.damageWeaponBonus) {
+          if (this.system.damage.includes('d') || this.system.damageWeaponBonus.includes('d')) {
+            this.system.damage = `${this.system.damage}${this.system.damageWeaponBonus}`
           } else {
-            this.system.config.damageOverride = this.system.damage
-          }
-        } else {
-          if (this.system.damage !== '+0') {
-            this.system.config.damageOverride = this.system.damage
+            this.system.damage = ensurePlus(Roll.safeEval(`${this.system.damage}${this.system.damageWeaponBonus}`))
           }
         }
-      }
-
-      // Next calculate the correct value from the weapon damage and other settings
-
-      // Start by setting the damage to any bonus from the actor
-      if (this.system.melee) {
-        this.system.damage = this.actor?.system?.details?.attackDamageBonus?.melee?.value || ''
-      } else {
-        this.system.damage = this.actor?.system?.details?.attackDamageBonus?.missile?.value || ''
-      }
-
-      // Then add in any weapon bonus - formatting dependent on whether there is a deed from the actor
-      if (this.system.damageWeaponBonus) {
-        if (this.system.damage.includes('d') || this.system.damageWeaponBonus.includes('d')) {
-          this.system.damage = `${this.system.damage}${this.system.damageWeaponBonus}`
+        if (this.system.doubleIfMounted) {
+          this.system.damage = `(${this.system.damageWeapon})*2${this.system.damage}`
         } else {
-          this.system.damage = ensurePlus(Roll.safeEval(`${this.system.damage}${this.system.damageWeaponBonus}`))
+          this.system.damage = `${this.system.damageWeapon}${this.system.damage}`
         }
-      }
-      if (this.system.doubleIfMounted) {
-        this.system.damage = `(${this.system.damageWeapon})*2${this.system.damage}`
-      } else {
-        this.system.damage = `${this.system.damageWeapon}${this.system.damage}`
-      }
-      if (this.system.subdual) {
-        this.system.damage = `${this.system.damage}[subdual]`
+        if (this.system.subdual) {
+          this.system.damage = `${this.system.damage}[subdual]`
+        }
       }
       if (this.system.config.damageOverride) {
         this.system.damage = this.system?.config?.damageOverride

--- a/module/migrations.js
+++ b/module/migrations.js
@@ -1,6 +1,6 @@
 /* global foundry, game, ui */
 
-import { getSingleActionDie } from './utilities.js'
+import { getSingleActionDie, inferWeaponDie } from './utilities.js'
 
 /**
  * Core class keys used for migration lookups
@@ -76,8 +76,15 @@ async function buildClassNameLookup () {
  * scene tokens never received any actor migration (including 0.70's
  * action-die seed). All branches are data-driven/idempotent, so each
  * ceiling bump costs one extra pass.
+ *
+ * 0.72: re-sweep to persist the weapon-die split for legacy-shape weapons
+ * (`damage` stored with no `damageWeapon`). item.js no longer re-derives
+ * the split heuristically on every prepare (#907), so shapes it can
+ * attribute confidently — a bare die, or die + the owning actor's current
+ * damage bonus — are stamped into `damageWeapon` here; anything ambiguous
+ * is left untouched and rolls as stored.
  */
-export const NEEDS_MIGRATION_VERSION = 0.71
+export const NEEDS_MIGRATION_VERSION = 0.72
 
 /**
  * Floor below which a world must first pass through a pre-V14 DCC release.
@@ -503,12 +510,21 @@ export const migrateActorData = async function (actor) {
   }
 
   // Migrate Owned Items
+  // Player actors pass their current damage bonuses so the legacy weapon-die
+  // split can attribute a matching baked-in modifier (#907); NPC weapons use
+  // `damage` directly (no composition), so the split is skipped for them.
+  const weaponContext = actor.type === 'NPC'
+    ? { skipWeapons: true }
+    : {
+        damageBonusMelee: actor.system?.details?.attackDamageBonus?.melee?.value || '',
+        damageBonusMissile: actor.system?.details?.attackDamageBonus?.missile?.value || ''
+      }
   let hasItemUpdates = false
   let items = []
   if (actor.items) {
     items = actor.items.map(i => {
       // Migrate the Owned Item
-      const itemUpdate = migrateItemData(i)
+      const itemUpdate = migrateItemData(i, weaponContext)
 
       // Update the Owned Item
       if (!foundry.utils.isEmpty(itemUpdate)) {
@@ -533,13 +549,41 @@ export const migrateActorData = async function (actor) {
  * Migrate a single Item document to incorporate latest data model changes
  *
  * Exported for unit testing of its V14 AE numeric-mode → string-type
- * conversion branch. Not part of the Foundry-facing API — internal
- * migration helper only.
+ * conversion branch and the legacy weapon-die split (#907). Not part of
+ * the Foundry-facing API — internal migration helper only.
  *
- * @param item
+ * @param {Item} item
+ * @param {Object} [options]
+ * @param {boolean} [options.skipWeapons] - Skip the weapon-die split
+ *   (NPC-owned weapons use `damage` directly, no composition)
+ * @param {string} [options.damageBonusMelee] - Owning actor's current melee
+ *   damage bonus, for attributing a baked-in modifier
+ * @param {string} [options.damageBonusMissile] - Owning actor's current
+ *   missile damage bonus
  */
-export const migrateItemData = function (item) {
+export const migrateItemData = function (item, options = {}) {
   const updateData = {}
+
+  // Persist the weapon-die split for legacy-shape weapons: `damage` stored
+  // with no `damageWeapon` and no override (#907). Reads raw _source so the
+  // new prepare path (which no longer re-derives the split) can't mask the
+  // persisted state. Data-driven and idempotent: once `damageWeapon` is
+  // set, the branch never fires again. Only confident shapes are stamped —
+  // a bare die, or die + the owner's current damage bonus (world items have
+  // no owner context, so only the bare die qualifies); ambiguous formulas
+  // are left untouched and roll as stored.
+  if (item.type === 'weapon' && !options.skipWeapons) {
+    const source = item._source?.system ?? item.system
+    if (source?.damage && !source.damageWeapon && !source.config?.damageOverride) {
+      const bonus = (source.melee !== false)
+        ? options.damageBonusMelee
+        : options.damageBonusMissile
+      const damageWeapon = inferWeaponDie(source.damage, bonus || '')
+      if (damageWeapon) {
+        updateData['system.damageWeapon'] = damageWeapon
+      }
+    }
+  }
 
   // Convert ActiveEffect changes for v14 compatibility (data-driven check)
   // - Convert numeric mode to string type

--- a/module/migrations.js
+++ b/module/migrations.js
@@ -511,33 +511,31 @@ export const migrateActorData = async function (actor) {
 
   // Migrate Owned Items
   // Player actors pass their current damage bonuses so the legacy weapon-die
-  // split can attribute a matching baked-in modifier (#907); NPC weapons use
-  // `damage` directly (no composition), so the split is skipped for them.
-  const weaponContext = actor.type === 'NPC'
-    ? { skipWeapons: true }
-    : {
+  // split can attribute a matching baked-in modifier (#907); NPC (and Party)
+  // weapons use `damage` directly (no composition), so the split is skipped
+  // for them — matching DCCItem._preCreate's Player-only gate.
+  const weaponContext = actor.type === 'Player'
+    ? {
         damageBonusMelee: actor.system?.details?.attackDamageBonus?.melee?.value || '',
         damageBonusMissile: actor.system?.details?.attackDamageBonus?.missile?.value || ''
       }
-  let hasItemUpdates = false
-  let items = []
-  if (actor.items) {
-    items = actor.items.map(i => {
-      // Migrate the Owned Item
-      const itemUpdate = migrateItemData(i, weaponContext)
-
-      // Update the Owned Item
-      if (!foundry.utils.isEmpty(itemUpdate)) {
-        hasItemUpdates = true
-        return foundry.utils.mergeObject(i, itemUpdate, { enforceTypes: false, inplace: false })
-      } else {
-        return i
-      }
-    })
+    : { skipWeapons: true }
+  // Each changed item becomes a plain `{_id, ...changes}` delta — the
+  // differential embedded-update shape `Actor#update` persists to _source.
+  // The previous `mergeObject(itemDocument, update)` pattern wrote the
+  // changes onto the live document's *prepared* data (deepClone returns
+  // class instances by reference), which document serialization — reading
+  // _source — then dropped, so owned-item updates could silently fail to
+  // persist (#907 review).
+  const itemUpdates = []
+  for (const i of actor.items ?? []) {
+    const itemUpdate = migrateItemData(i, weaponContext)
+    if (!foundry.utils.isEmpty(itemUpdate)) {
+      itemUpdates.push({ _id: i._id ?? i.id, ...itemUpdate })
+    }
   }
-
-  if (hasItemUpdates) {
-    updateData.items = items
+  if (itemUpdates.length > 0) {
+    updateData.items = itemUpdates
   }
 
   return updateData

--- a/module/pc-parser.js
+++ b/module/pc-parser.js
@@ -1,7 +1,7 @@
 /* global game, ui, CONFIG */
 
 import EntityImages from './entity-images.js'
-import { getFirstDie, getFirstMod, getSingleActionDie } from './utilities.js'
+import { ensurePlus, getFirstDie, getFirstMod, getSingleActionDie, inferWeaponDie } from './utilities.js'
 import DCC from './config.js'
 
 /**
@@ -83,9 +83,12 @@ function _parseJSONPCs (pcObject) {
     }
 
     if (pcObject.weapon && !pcObject.weapons) {
-      // Split out the weapon die like the upper-level weapons branch above,
-      // so the composed damage tracks the actor's current Strength modifier
-      // instead of freezing the imported total (#907)
+      // Split out the weapon die so the composed damage tracks the actor's
+      // current Strength modifier instead of freezing the imported total
+      // (#907). Conservative: only a bare die or die + the imported Str mod
+      // is attributed — anything else (a damage-affecting birth augur, a
+      // die outside getFirstDie's range) records no die and rolls as stored.
+      const strMod = DCC.abilityModifiers[pcObject.strengthScore] ?? 0
       pc.items.push({
         name: pcObject.weapon,
         type: 'weapon',
@@ -93,7 +96,7 @@ function _parseJSONPCs (pcObject) {
         system: {
           toHit: pcObject.attackMod || '0',
           damage: pcObject.attackDamage || '1d3',
-          damageWeapon: pcObject.attackDamage ? getFirstDie(pcObject.attackDamage) : '1d3',
+          damageWeapon: pcObject.attackDamage ? inferWeaponDie(pcObject.attackDamage, ensurePlus(strMod)) : '1d3',
           melee: true // No way to know, but melee is most likely
         }
       })

--- a/module/pc-parser.js
+++ b/module/pc-parser.js
@@ -83,6 +83,9 @@ function _parseJSONPCs (pcObject) {
     }
 
     if (pcObject.weapon && !pcObject.weapons) {
+      // Split out the weapon die like the upper-level weapons branch above,
+      // so the composed damage tracks the actor's current Strength modifier
+      // instead of freezing the imported total (#907)
       pc.items.push({
         name: pcObject.weapon,
         type: 'weapon',
@@ -90,6 +93,7 @@ function _parseJSONPCs (pcObject) {
         system: {
           toHit: pcObject.attackMod || '0',
           damage: pcObject.attackDamage || '1d3',
+          damageWeapon: pcObject.attackDamage ? getFirstDie(pcObject.attackDamage) : '1d3',
           melee: true // No way to know, but melee is most likely
         }
       })

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -201,6 +201,40 @@ export function getSingleActionDie (value) {
 }
 
 /**
+ * Infer the weapon die from a legacy-shape damage formula (`system.damage`
+ * set with no `system.damageWeapon` recorded — older worlds and imports).
+ *
+ * Conservative by design: only recognizes a formula that is exactly the
+ * bare die (`1d4`) or exactly die + the owning actor's current damage
+ * bonus (`1d4-1` with bonus `-1`, tolerating a dropped `+0`). Anything
+ * else — baked-in bonuses that no longer match, `@ab` deed forms, custom
+ * expressions — returns '' so the caller leaves the stored formula alone
+ * rather than baking a wrong attribution (#907).
+ *
+ * @param {string} damage - the stored damage formula
+ * @param {string} [bonus] - the actor's current damage bonus for the
+ *   weapon's attack mode (e.g. `+2`, `-1`), if known
+ * @return {string} - the weapon die, or an empty string if not confidently inferable
+ */
+export function inferWeaponDie (damage, bonus = '') {
+  if (typeof damage !== 'string' || damage === '') {
+    return ''
+  }
+  const die = getFirstDie(damage)
+  if (!die) {
+    return ''
+  }
+  if (damage === die) {
+    return die
+  }
+  const total = `${die}${bonus || ''}`
+  if (damage === total || damage === total.replaceAll('+0', '')) {
+    return die
+  }
+  return ''
+}
+
+/**
  * Get the first modifier in a string expression
  * @param {string} value - value to extract first modifier from
  * @return {string} - first modifier expression or an empty string if none

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -211,6 +211,11 @@ export function getSingleActionDie (value) {
  * expressions — returns '' so the caller leaves the stored formula alone
  * rather than baking a wrong attribution (#907).
  *
+ * Dice outside `getFirstDie`'s 1-2-digit range (`d6` with no count,
+ * `1d100`, `100d6`) never produce an exact match, so those formulas are
+ * likewise declined and roll as stored — a conservative miss, never a
+ * truncated die.
+ *
  * @param {string} damage - the stored damage formula
  * @param {string} [bonus] - the actor's current damage bonus for the
  *   weapon's attack mode (e.g. `+2`, `-1`), if known


### PR DESCRIPTION
## Summary

Fixes a user report: with max Strength 9 temporarily lowered to 7, the -1 modifier was not subtracted from melee damage rolls. Root cause was the legacy-weapon runtime migration in `item.js`: a weapon storing only `damage` (`1d4`) with no `damageWeapon` stopped matching `weaponDie + currentBonus` once the bonus went nonzero, was misread as a custom formula, and got frozen via `config.damageOverride` on every prepare — silently dropping the Strength change. Per #907, the heuristic is retired entirely in favor of persisted normalization:

- **`item.js`**: damage composition now requires `damageWeapon`; weapons without one roll their stored formula verbatim (permanent safety net) instead of having a guessed override baked in each prepare. New `DCCItem._preCreate` splits out the weapon die when a legacy-shape weapon is embedded into a Player actor (compendium drags, module creations, importer remaps), using the owner's current damage bonus for attribution.
- **`migrations.js`**: one-time world sweep (`NEEDS_MIGRATION_VERSION` 0.72) persists the same split for existing Player-owned weapons and bare-die world items; NPC/Party weapons untouched; reads raw `_source`; idempotent. Ambiguous formulas are left alone — user-fixable once on the weapon sheet, instead of silently re-frozen every render. The owned-item sweep now emits plain `{_id, ...changes}` deltas instead of `mergeObject`-ing live Item documents (whose prepared-layer writes document serialization would drop — review finding).
- **`pc-parser.js`**: the 0-level single-weapon import branch now records `damageWeapon` via the conservative `inferWeaponDie` + imported Str mod, so a baked-in non-Str bonus (e.g. birth augur) or an out-of-range die rolls as stored rather than being replaced or truncated.
- **`utilities.js`**: shared conservative helper `inferWeaponDie()` — recognizes a bare die or die + current bonus (tolerating a dropped `+0`); declines `@ab` deed forms, stale baked-in bonuses, custom expressions, and dice outside `getFirstDie`'s 1-2-digit range.

No exports were removed; `migrateItemData`'s new options parameter is optional and backward compatible.

## Known limitation

Foundry does not run embedded documents' `_preCreate` when items ride inside an `Actor.create({items})` payload. A pre-#907 Player actor imported from a third-party compendium/adventure **after** the world is stamped 0.72 therefore keeps its legacy-shape weapons: they roll their stored formula verbatim (functional, but frozen — same as the old behavior when the heuristic mismatched) until the user fills the weapon-die field once on the sheet. An Actor-side `_preCreateDescendantDocuments` normalization would close this, but it touches lifecycle semantics best verified against live Foundry — left out of this PR deliberately.

## Test plan

- [x] Full unit suite green: 108 files, 2380 tests (27 new)
- [x] `inferWeaponDie`: bare die, die + bonus, `+0` tolerance, all rejection classes, out-of-range dice never truncate, input hygiene
- [x] `_preCreate`: temp-Strength scenario end-to-end (`1d4` → `1d4-1`), missile-bonus attribution, guards (non-weapon, unowned, NPC parent, already-normalized, override, empty)
- [x] Migration: `{_id, ...changes}` delta shape pinned, melee/missile attribution, `_source`-over-prepared read, NPC skip, missing-bonus bare-die split, ambiguous no-op, 0.71→0.72 gate boundaries
- [x] pc-parser: split asserted on both import paths + augur-shape decline, default, and die-less damage
- [x] New Playwright spec (`adapter-dispatch.spec.js`): legacy weapon on a Str 7/max 9 actor composes `1d4-1` with a `Strength: -1` breakdown entry
- [x] Audited every e2e spec creating damage-only weapons — all compose to the same final formula under the new flow
- [ ] Run the full `browser-tests/e2e` suite locally (implementation environment has no Foundry license)
- [ ] Verify the 0.72 migration persists `_source.system.damageWeapon` on a real pre-#907 world (seed a legacy weapon, boot, inspect) — the delta pattern is canonical but only live Foundry proves persistence
- [ ] Smoke-check dcc-qol / xcc / mcc-classes for Player-owned weapons created with only `damage` set (repos not available in the implementation environment)

Closes #907

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1NUnNkHLtupwME1fnR9cc