### PR TITLE
feat: show Success/Failure on Luck Check (Roll Under) chat cards

### DIFF
--- a/browser-tests/e2e/adapter-dispatch.spec.js
+++ b/browser-tests/e2e/adapter-dispatch.spec.js
@@ -246,7 +246,9 @@ test.describe('DCC Adapter Dispatch Validation', () => {
               ability: msg.getFlag('dcc', 'Ability'),
               isAbilityCheck: msg.getFlag('dcc', 'isAbilityCheck'),
               libResult: msg.getFlag('dcc', 'libResult') ?? null,
-              dcc: term?.options?.dcc ?? null
+              dcc: term?.options?.dcc ?? null,
+              flavor: msg.flavor,
+              total: msg.rolls?.[0]?.total ?? null
             }
           }
           await new Promise(resolve => setTimeout(resolve, 50))
@@ -265,6 +267,10 @@ test.describe('DCC Adapter Dispatch Validation', () => {
       expect(card.dcc.rollUnder).toBe(true)
       expect(card.dcc.lowerThreshold).toBe(14)
       expect(card.dcc.upperThreshold).toBe(15)
+      // The flavor announces the roll-under outcome: roll ≤ Luck (14) is a
+      // success, above it a failure.
+      expect(card.total).not.toBeNull()
+      expect(card.flavor).toContain(card.total <= 14 ? 'Success' : 'Failure')
     })
 
     // Legacy-decom step 2: the modifier dialog no longer routes ability

--- a/browser-tests/e2e/adapter-dispatch.spec.js
+++ b/browser-tests/e2e/adapter-dispatch.spec.js
@@ -267,10 +267,10 @@ test.describe('DCC Adapter Dispatch Validation', () => {
       expect(card.dcc.rollUnder).toBe(true)
       expect(card.dcc.lowerThreshold).toBe(14)
       expect(card.dcc.upperThreshold).toBe(15)
-      // The flavor announces the roll-under outcome: roll ≤ Luck (14) is a
-      // success, above it a failure.
+      // The flavor announces the roll-under outcome: roll ≤ Luck is a
+      // success, above it a failure (threshold asserted as 14 above).
       expect(card.total).not.toBeNull()
-      expect(card.flavor).toContain(card.total <= 14 ? 'Success' : 'Failure')
+      expect(card.flavor).toContain(card.total <= card.dcc.lowerThreshold ? 'Success' : 'Failure')
     })
 
     // Legacy-decom step 2: the modifier dialog no longer routes ability

--- a/browser-tests/e2e/death-clock.spec.js
+++ b/browser-tests/e2e/death-clock.spec.js
@@ -251,8 +251,11 @@ test.describe('Death clock', () => {
         const sumBefore = abilitySum(lucky)
         await mod.rollTheBody(lucky)
         // The attempt posts the system's native roll-under Luck check card.
-        observed.luckCheckCardPosted = !!(await pollFor(() =>
-          game.messages.contents.slice(-5).find(m => m.getFlag('dcc', 'RollType') === 'AbilityCheckRollUnder')))
+        const luckCheckCard = await pollFor(() =>
+          game.messages.contents.slice(-5).find(m => m.getFlag('dcc', 'RollType') === 'AbilityCheckRollUnder'))
+        observed.luckCheckCardPosted = !!luckCheckCard
+        // Luck 20 → d20 always ≤ 20: the flavor announces the outcome.
+        observed.luckCheckCardFlavor = luckCheckCard?.flavor ?? ''
         observed.recovered = await pollFor(() => !isDead(lucky))
         observed.hpAfter = await pollFor(() => lucky.system.attributes.hp.value)
         observed.groggy = !!(await pollFor(() =>
@@ -276,6 +279,11 @@ test.describe('Death clock', () => {
         await unlucky.update({ 'system.attributes.hp.value': 0 })
         await pollFor(() => isDead(unlucky))
         await mod.rollTheBody(unlucky)
+        // Luck 0 → d20 never ≤ 0: the roll-under card announces the failure.
+        const failedCheckCard = await pollFor(() =>
+          game.messages.contents.slice(-5).find(m =>
+            m.getFlag('dcc', 'RollType') === 'AbilityCheckRollUnder' && m.speaker?.alias === unlucky.name))
+        observed.failedCheckCardFlavor = failedCheckCard?.flavor ?? ''
         observed.trulyDeadCard = !!(await pollFor(() =>
           game.messages.contents.slice(-5).find(m => m.content.includes(unlucky.name) && m.content.includes('truly dead'))))
         observed.stillDead = isDead(unlucky)
@@ -289,6 +297,8 @@ test.describe('Death clock', () => {
 
     expect(result.buttonOnCard).toBe(true)
     expect(result.luckCheckCardPosted).toBe(true)
+    expect(result.luckCheckCardFlavor).toContain('Success')
+    expect(result.failedCheckCardFlavor).toContain('Failure')
     expect(result.recovered).toBe(true)
     expect(result.hpAfter).toBe(1)
     expect(result.groggy).toBe(true)

--- a/module/__tests__/actor.test.js
+++ b/module/__tests__/actor.test.js
@@ -122,7 +122,7 @@ test('roll ability check', async () => {
   // Adapter path — DCCRoll.createRoll is never invoked.
   expect(dccRollCreateRollMock).toHaveBeenCalledTimes(0)
   expect(rollToMessageMock).toHaveBeenLastCalledWith({
-    flavor: 'Luck CheckRollUnder',
+    flavor: 'Luck CheckRollUnder — Success',
     speaker: actor,
     flags: { 'dcc.Ability': 'lck', 'dcc.RollType': 'AbilityCheckRollUnder', 'dcc.isAbilityCheck': true },
     system: {

--- a/module/__tests__/adapter-ability-check.test.js
+++ b/module/__tests__/adapter-ability-check.test.js
@@ -100,11 +100,13 @@ test('rollUnder (Luck check) routes through the lib luck-check adapter path', as
   expect(rollToMessageMock).toHaveBeenCalledTimes(1)
   const [messageData, toMessageOpts] = rollToMessageMock.mock.calls[0]
 
-  // Roll-under flag + flavor contract (unchanged from the legacy path).
+  // Roll-under flag contract (unchanged from the legacy path); the flavor
+  // now carries an explicit success/failure suffix (mock natural 10 vs
+  // mock lck 18 → success).
   expect(messageData.flags['dcc.RollType']).toBe('AbilityCheckRollUnder')
   expect(messageData.flags['dcc.Ability']).toBe('lck')
   expect(messageData.flags['dcc.isAbilityCheck']).toBe(true)
-  expect(messageData.flavor).toBe('Luck CheckRollUnder')
+  expect(messageData.flavor).toBe('Luck CheckRollUnder — Success')
 
   // Roll-under is a naked d20 — no modifier breakdown, so (unlike the
   // standard ability check) it carries NO dcc.libResult flag and does
@@ -250,6 +252,24 @@ test('rollUnder thresholds follow the effective Luck score when otherMod shifts 
     lowerThreshold: 16,
     upperThreshold: 17
   })
+
+  chatMessageCreateSpy.mockRestore()
+})
+
+test('rollUnder flavor indicates failure when the roll exceeds the Luck score', async () => {
+  rollToMessageMock.mockClear()
+  const chatMessageCreateSpy = vi.spyOn(ChatMessage, 'create')
+
+  // Luck 5 vs the mock's natural 10 → roll > score → failure suffix.
+  // noinspection JSCheckFunctionSignatures
+  const unlucky = new DCCActor()
+  unlucky.system.abilities.lck.value = 5
+  unlucky.prepareBaseData()
+
+  await unlucky.rollAbilityCheck('lck', { rollUnder: true })
+
+  const [messageData] = rollToMessageMock.mock.calls[0]
+  expect(messageData.flavor).toBe('Luck CheckRollUnder — Failure')
 
   chatMessageCreateSpy.mockRestore()
 })

--- a/module/__tests__/adapter-ability-check.test.js
+++ b/module/__tests__/adapter-ability-check.test.js
@@ -258,7 +258,6 @@ test('rollUnder thresholds follow the effective Luck score when otherMod shifts 
 
 test('rollUnder flavor indicates failure when the roll exceeds the Luck score', async () => {
   rollToMessageMock.mockClear()
-  const chatMessageCreateSpy = vi.spyOn(ChatMessage, 'create')
 
   // Luck 5 vs the mock's natural 10 → roll > score → failure suffix.
   // noinspection JSCheckFunctionSignatures
@@ -270,8 +269,6 @@ test('rollUnder flavor indicates failure when the roll exceeds the Luck score', 
 
   const [messageData] = rollToMessageMock.mock.calls[0]
   expect(messageData.flavor).toBe('Luck CheckRollUnder — Failure')
-
-  chatMessageCreateSpy.mockRestore()
 })
 
 test('adapter path returns undefined when the ability-check dialog is cancelled', async () => {

--- a/module/adapter/chat-renderer.mjs
+++ b/module/adapter/chat-renderer.mjs
@@ -339,8 +339,11 @@ export async function renderAbilityCheck ({
  * `highlightCriticalSuccessFailure` (module/chat.js) swaps the
  * success/failure highlight classes (roll ≤ score = success).
  *
- * Reproduces the legacy `_rollAbilityCheckLegacy` roll-under branch's
- * flag + flavor contract exactly; only the producing code path changed.
+ * The flavor carries an explicit " — Success" / " — Failure" suffix from
+ * the lib's `result.success` (roll ≤ score), matching the DC suffix
+ * convention the ability/save/skill renderers use via `dcResultSuffix` —
+ * roll-under has no DC (the target IS the Luck score), so the outcome is
+ * always known and always shown.
  *
  * @param {Object} params
  * @param {Object} params.actor - The DCCActor that rolled.
@@ -364,7 +367,8 @@ export async function renderAbilityCheckRollUnder ({
   foundryRoll,
   actionDiceChatLine = ''
 }) {
-  const flavor = `${abilityLabel} ${game.i18n.localize('DCC.CheckRollUnder')}`
+  const resultLabel = game.i18n.localize(result.success ? 'DCC.SaveSuccess' : 'DCC.SaveFailure')
+  const flavor = `${abilityLabel} ${game.i18n.localize('DCC.CheckRollUnder')} — ${resultLabel}`
 
   // Tag the rolled die so the chat highlight hook treats it as
   // roll-under: ≤ target highlights as success (critical class),


### PR DESCRIPTION
## Summary

- The roll-under Luck check chat card previously only hinted at the outcome via the green/red highlight on the die total; the flavor line now carries an explicit ` — Success` / ` — Failure` suffix from the lib's roll-under classification (roll ≤ Luck score).
- Uses the existing localized `DCC.SaveSuccess` / `DCC.SaveFailure` strings and the same em-dash convention as the DC suffix on ability/save/skill cards (`dcResultSuffix`) — no new i18n keys.
- Covers every roll-under entry point automatically, since they all share `renderAbilityCheckRollUnder`: the sheet's Luck label, journal roll links, hotbar macros, roll requests, and the Death Clock's "Roll the Body" recovery check.
- Message flags, renderer signature, die tagging/highlight thresholds, and roll structure are unchanged — the only change to the emitted message is the flavor suffix.

## Test plan

- [x] Unit: updated roll-under flavor assertions in `adapter-ability-check.test.js` and `actor.test.js`
- [x] Unit: new failure-case test (Luck 5 vs natural 10 → `— Failure`)
- [x] E2E: `adapter-dispatch.spec.js` asserts the suffix matches the actual roll vs the Luck score
- [x] E2E: `death-clock.spec.js` asserts the deterministic outcomes (Luck 20 → Success, Luck 0 → Failure)
- [x] `pnpm run check` green (format, scss, 2352 unit tests, compare-lang)
- [ ] Full Playwright E2E run (needs a live Foundry server — not available in the remote container; specs updated by inspection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018271s6juNu1Z7uyE1zN9ep

---
_Generated by [Claude Code](https://claude.ai/code/session_018271s6juNu1Z7uyE1zN9ep)_