### PR TITLE
chore: supply-chain quarantine, auto-close hardening PR spam, pnpm 11.25.0

### DIFF
--- a/.github/workflows/audit-fix.yml
+++ b/.github/workflows/audit-fix.yml
@@ -58,8 +58,22 @@ jobs:
         run: |
           pnpm audit || true
           pnpm audit --fix || true
-          # Realize any new overrides into the lockfile
-          pnpm install --no-frozen-lockfile
+          # Realize any new overrides into the lockfile.
+          #
+          # --config.minimumReleaseAge=0 deliberately suspends the 7-day
+          # supply-chain quarantine from pnpm-workspace.yaml for this one
+          # install. The quarantine is unconditional — pnpm has no notion of
+          # "this is a security fix, let it through" — so without the bypass a
+          # freshly published fix would be refused with
+          # ERR_PNPM_NO_MATURE_MATCHING_VERSION and this job could never
+          # produce a PR for exactly the advisories that matter most.
+          #
+          # Suspending it here is safe because a human reviews the resulting
+          # PR. It is NOT safe to copy this flag into run-tests.yml or a local
+          # workflow: that is where the quarantine does its real work.
+          # (Env vars and --minimum-release-age do not work; only
+          # --config.<key> is honoured.)
+          pnpm install --no-frozen-lockfile --config.minimumReleaseAge=0
 
       - name: Check for changes
         id: changes
@@ -92,6 +106,15 @@ jobs:
             package.json, which pin the affected transitive versions
             permanently. When the upstream dependency ships a release that
             makes an override redundant, remove the override in a follow-up.
+
+            **Review note:** if the fix pulls in a version published less
+            than 7 days ago, CI on this PR will fail with
+            `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` — the lockfile is
+            re-verified against the quarantine on every install. That failure
+            is a prompt, not a bug: decide whether the fresh release is worth
+            taking, and if so add the exact `package@version` to
+            `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` in this PR,
+            then remove that entry once the version ages past a week.
 
             The unit test suite (`pnpm test`) passed against the updated
             dependencies before this PR was opened. See the workflow run for

--- a/.github/workflows/close-automated-hardening-prs.yml
+++ b/.github/workflows/close-automated-hardening-prs.yml
@@ -1,0 +1,92 @@
+# Auto-close unsolicited automated "security hardening" PRs.
+#
+# Background: PR #918 (2026-09-01) was filed by an automated semgrep-driven
+# campaign ("OrbisAI Security") proposing pnpm supply-chain settings. Beyond
+# being unsolicited, it overreached its own description — the cited finding
+# covered `minimumReleaseAge` only, but the diff also added
+# `blockExoticSubdeps` and `trustPolicy`, and the "regression test" quoted in
+# the PR body was not in the changeset at all. The account was blocked
+# org-wide, but these campaigns rotate accounts, so a per-account block does
+# not hold. This workflow catches the class by its boilerplate instead.
+#
+# Note on `minimumReleaseAge` specifically: we are not opposed to it in
+# principle, but a publish-age quarantine cannot be adopted without a
+# `minimumReleaseAgeExclude` entry for `@moonloch/dcc-core-lib` — we install
+# our own lib releases immediately after they ship, and a 7-day hold would
+# stall the vendor sync loop.
+#
+# Safety: this uses `pull_request_target` because the default GITHUB_TOKEN is
+# read-only for fork PRs and cannot close them. That event runs in the base
+# repo's context with a write token, so it MUST NOT check out or execute the
+# PR's code — and it does not. It reads PR metadata only, and every
+# attacker-controlled value (title, body) is passed through `env:` rather than
+# interpolated into the shell, so a crafted title cannot inject commands.
+#
+# Tuning: extend BODY_SIGNATURES / TITLE_SIGNATURES below when a new campaign
+# appears. Maintainers, members and collaborators are exempt via
+# author_association, so this can never fire on our own PRs. A false positive
+# is recoverable — any maintainer can reopen the PR.
+name: Close Automated Hardening PRs
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    # Never fire on PRs from anyone with a standing relationship to the repo.
+    if: >-
+      github.repository == 'foundryvtt-dcc/dcc' &&
+      !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) &&
+      github.event.pull_request.user.type != 'Bot'
+    steps:
+      - name: Match campaign signature and close
+        env:
+          # Case-insensitive extended regex alternations. Add new campaign
+          # markers here rather than adding steps.
+          BODY_SIGNATURES: 'orbisappsec\.com|automated security fix by|removes an exploit primitive|automated exploit-development tooling'
+          TITLE_SIGNATURES: '^harden:'
+          # Attacker-controlled values: read via env only, never interpolated
+          # into the script body.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLOSE_COMMENT: |
+            Thanks for the interest, but this repository does not accept
+            unsolicited automated security-hardening pull requests, so this has
+            been closed without review.
+
+            These submissions have consistently cost us more to triage than they
+            save: the proposed diff tends to exceed the scope of the finding it
+            cites, and the "regression test" shown in the description is often
+            not present in the changeset at all. We would rather receive a plain
+            issue describing the concern than a generated patch.
+
+            If you are a human who has hit this by mistake, please open an issue
+            and a maintainer will reopen the PR.
+
+            _Closed automatically by the Close Automated Hardening PRs workflow._
+        run: |
+          set -euo pipefail
+
+          matched=''
+          if printf '%s' "$PR_BODY" | grep -qiE "$BODY_SIGNATURES"; then
+            matched='body'
+          fi
+          if printf '%s' "$PR_TITLE" | grep -qiE "$TITLE_SIGNATURES"; then
+            matched="${matched:+$matched and }title"
+          fi
+
+          if [ -z "$matched" ]; then
+            echo "::notice::No automated-hardening signature found; leaving PR alone"
+            exit 0
+          fi
+
+          echo "::warning::Matched automated-hardening signature in $matched; closing $PR_URL"
+          gh pr close "$PR_URL" --comment "$CLOSE_COMMENT"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=24.0.0",
     "pnpm": ">=11.0.0"
   },
-  "packageManager": "pnpm@11.9.0",
+  "packageManager": "pnpm@11.25.0",
   "homepage": "https://github.com/foundryvtt-dcc/dcc#readme",
   "keywords": [
     "FoundryVTT",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,42 @@
 # via the shared content-addressable store).
 packages:
   - 'browser-tests/e2e'
+# Supply-chain quarantine: refuse to resolve a dependency version until it has
+# been public for seven days (10080 minutes). The threat this addresses is a
+# maintainer's npm account being compromised and a malicious release being
+# published — those are typically caught and yanked within hours to days, so
+# simply waiting is a cheap and effective defence.
+#
+# What this actually protects: a blind `pnpm update` or `pnpm add`. Without it,
+# either command will happily pull in a release published minutes ago. With it,
+# resolution fails loudly:
+#
+#   ERR_PNPM_NO_MATURE_MATCHING_VERSION
+#   eslint@10.9.1 was published at <date>, within the minimumReleaseAge cutoff
+#
+# Note this is checked two ways: new resolutions are refused as above, AND the
+# whole committed lockfile is re-verified on every install. Setting
+# minimumReleaseAge auto-enables minimumReleaseAgeStrict; setting it to false
+# does not disable the lockfile check.
+#
+# When a security fix is genuinely urgent: a fix published less than a week ago
+# will be refused, and a Dependabot security PR carrying one will fail CI with
+# ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION. That is a prompt to make a conscious
+# call, not a bug. To accept it, add the exact package@version to
+# minimumReleaseAgeExclude below, then drop the entry once the version ages
+# past a week. (audit-fix.yml suspends the quarantine for its own install via
+# --config.minimumReleaseAge=0 so it can still open the PR; do not copy that
+# flag into run-tests.yml or local workflows.)
+#
+# The @moonloch/dcc-core-lib exclusion is permanent and load-bearing: we
+# publish that package ourselves and vendor each fresh release into
+# module/vendor/dcc-core-lib immediately after a lib PR merges (see the
+# sync-core-lib skill). Quarantining our own releases would stall that sync for
+# a week every time while buying nothing — the risk here is a third party's
+# account being compromised, not ours.
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - '@moonloch/dcc-core-lib'
 # Native build scripts pnpm may run (everything else stays sandboxed):
 # classic-level backs e2e-env's world-settings edits, @parcel/watcher backs
 # file watching.


### PR DESCRIPTION
Prompted by #918, an unsolicited automated "hardening" PR (semgrep-driven, "OrbisAI Security"). That PR was closed and the account blocked org-wide, but the underlying question was worth answering properly.

## What #918 got wrong

- **Redundant.** `.github/dependabot.yml` already enforces the 7-day policy via `cooldown.default-days: 7` on all three ecosystems. semgrep only reads `pnpm-workspace.yaml`, so it couldn't see it.
- **Overreaching.** The cited finding covered `minimumReleaseAge` only, but the diff also added `blockExoticSubdeps` and `trustPolicy` without mentioning them. Neither is carried over here.
- **Untested.** The "regression test" quoted in its body was not in the changeset at all.

## What's actually worth having

Dependabot's cooldown gates *proposed updates*. It does nothing about a maintainer running `pnpm update` locally and pulling a release published minutes ago — the realistic supply-chain vector. `minimumReleaseAge` closes that at resolution time:

```
ERR_PNPM_NO_MATURE_MATCHING_VERSION
  eslint@10.9.1 was published at 2026-08-24T18:21:58Z, within the
  minimumReleaseAge cutoff (2026-08-02T13:36:48Z)
```

`@moonloch/dcc-core-lib` is excluded permanently — we publish it ourselves and vendor each release immediately after a lib PR merges, so quarantining our own releases would stall the sync for a week while buying nothing.

## The awkward part, and how it's handled

The quarantine is **unconditional**: pnpm has no security-update exemption, and the committed lockfile is re-verified on every install (setting `minimumReleaseAge` auto-enables `minimumReleaseAgeStrict`; `strict: false` does *not* disable it). Cooldown deliberately lets security updates through immediately — pnpm can't make that distinction.

So `audit-fix.yml`'s override-realizing install now passes `--config.minimumReleaseAge=0`, or the nightly job could never open a PR for exactly the advisories that matter most. That's safe there because a human reviews the result; the comment warns against copying the flag into `run-tests.yml` or local workflows.

When a Dependabot security PR carries a <7-day-old version, CI will fail with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`. That's a prompt, not a bug: add the exact `package@version` to `minimumReleaseAgeExclude`, then drop it once the version ages out. Documented in both the workspace file and the audit-fix PR template.

## Auto-close workflow

The blocked account is one identity in a campaign that rotates accounts, so `close-automated-hardening-prs.yml` matches the boilerplate instead. Tested against real PR data:

| PR | Association | Match | Result |
|----|-------------|-------|--------|
| #918 | NONE | body + title | closed |
| #915, #912, #910, #908 | MEMBER | none | untouched |
| #913 | Bot (dependabot) | none | untouched |

It uses `pull_request_target` because `GITHUB_TOKEN` is read-only on fork PRs and can't close them. It never checks out PR code, and title/body reach the script through `env:` rather than shell interpolation. Members, collaborators and bots are exempt via `author_association`, and a false positive is recoverable by reopening.

Note it stays inert until merged — `pull_request_target` always runs the definition from the default branch.

## pnpm 11.25.0

These supply-chain settings are new and actively developed, so this runs them on a current release rather than one many minors behind. `pnpm/action-setup@v6` reads `packageManager`, so CI follows with no workflow change.

## Verification

Behaviour was established empirically on the pinned 11.25.0, not assumed:

- Resolution of a too-fresh version is refused; a 39-day-old version installs normally.
- `--config.minimumReleaseAge=0` is the **only** working override — env vars don't work, and `--minimum-release-age` is "Unknown option" for `install`.
- `minimumReleaseAgeExclude` accepts both bare `pkg` and exact `pkg@1.2.3`.
- All 502 lockfile entries pass the new policy; no lockfile churn, still `lockfileVersion 9.0`.
- 2532 unit tests pass.

One caveat for reviewers: pnpm caches the policy verdict and reports "verified Nm ago". A bypass test that hits the cache proves nothing — it silently faked a passing result twice during this work. Force a real check by changing the threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pD8r2Y9c4ead3JkNunhhn