### PR TITLE
docs: document the per-weapon Action Die Override

### DIFF
--- a/docs/user-guide/Action-Dice.md
+++ b/docs/user-guide/Action-Dice.md
@@ -9,6 +9,16 @@ To roll with a different Action Die (e.g. 1d16), Command or Ctrl Click the die i
 
 ![Action Dice Roll Dialog](images/action_dice_roll_dialog.png)
 
+## Per-weapon action die
+
+A single weapon can roll a different die than the rest of the sheet. Click the
+pencil next to the weapon and fill in the **Action Die Override** field (for
+example `1d16`). The override replaces the action die for that weapon only, and
+takes precedence over the untrained and two-weapon fighting adjustments. Leave
+it blank to use the sheet's action die. NPC attacks have the same field in
+their **To Hit** box — see
+[NPC Weapon Action Dice](Creating-Importing-an-NPC.md#npc-weapon-action-dice).
+
 To have the system *track* your action dice during combat — spending one per
 roll, showing spent/ready pips, and resetting each round — see
 [Multiple Action Dice (Tracking)](Multiple-Action-Dice.md).

--- a/docs/user-guide/Creating-Importing-an-NPC.md
+++ b/docs/user-guide/Creating-Importing-an-NPC.md
@@ -33,3 +33,27 @@ To increase the crit range for an NPC, you can change their crit range on each a
 ![NPC Crit Range Edit](images/npc_crit_range_edit.png)
 
 Click on the pencil next to the attack, and then adjust the crit range.
+
+## NPC Weapon Action Dice
+
+By default every attack on an NPC rolls the NPC's action die (the **Action
+Dice** box on the sheet, or the first die of a list like `2d20` or
+`1d20,1d14`). If one attack should use a different die — say a creature with a
+`1d20` main attack and a `1d14` off-hand attack — set it on that attack:
+
+1. Click the pencil next to the attack to open its weapon sheet.
+2. In the **To Hit** box, enter the die in the **Action Die Override** field
+   (for example `1d14`).
+3. Leave the field blank on any attack that should keep using the NPC's
+   default action die.
+
+The override replaces the action die for that attack only. It also wins over
+any Dice Chain Active Effect on the NPC's action die, so use it for a fixed
+die rather than a temporary penalty.
+
+If you use the [Multiple Action Dice](Multiple-Action-Dice.md) tracking
+setting, there is another option: set the NPC's action dice to `1d20,1d14` in
+the `</>` Config menu, and the first attack of the round spends the `1d20`
+while the second automatically rolls the `1d14`. The two approaches work
+together — an attack that rolls an overridden `1d14` is matched to the ready
+`1d14` slot.


### PR DESCRIPTION
## Summary

- The weapon sheet's **Action Die Override** field was not documented anywhere in the user guide, so a Discord question ("how do I give an NPC a d20 main attack and a d14 off-hand?") had no page to point at.
- Adds an **NPC Weapon Action Dice** section to *Creating/Importing an NPC*, after the crit range section: pencil icon → To Hit box → Action Die Override, using the d20 / d14 example. Notes that the override wins over Dice Chain Active Effects on the NPC's action die, and describes the Multiple Action Dice tracking alternative (`1d20,1d14`).
- Adds a **Per-weapon action die** section to *Action Dice* for PCs, noting the override takes precedence over the untrained and two-weapon adjustments, cross-linked to the NPC section.
- Docs only; no code, lang, or `version.txt` changes. No new pages, so no mkdocs nav change.

## Test plan

- [x] `pnpm run check` passes (format, scss, unit tests, compare-lang)
- [x] Precedence claims verified against `DCCItem.prepareBaseData` (override applied after the actor-derived die, untrained bump, and two-weapon penalty)
- [ ] Read the Docs build of `latest` renders both new sections and the cross-link anchor resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpYf3EgCUizATwiE5WCxQw

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpYf3EgCUizATwiE5WCxQw)_